### PR TITLE
Build gym tracker: extraction pipeline, web app, and weekly report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,53 @@
+# Copy to .env and fill in. NEVER commit the real .env — it is gitignored.
+
+# --- Groq (LLM) -----------------------------------------------------------
+# Free tier. https://console.groq.com/keys
+GROQ_API_KEY=gsk_your_key_here
+# Groq deprecated llama-3.3-70b-versatile / llama-3.1-8b-instant for free and
+# developer tiers on 2026-06-17. openai/gpt-oss-120b is the recommended
+# general-purpose replacement. Re-check console.groq.com/docs/models before
+# assuming this is still current.
+GROQ_MODEL=openai/gpt-oss-120b
+
+# --- Database -------------------------------------------------------------
+# Supabase free tier connection string (use the pooled connection URI).
+DATABASE_URL=postgresql://postgres:your_password@db.your-project.supabase.co:5432/postgres
+
+# --- Web app auth ---------------------------------------------------------
+# HTTP Basic Auth. Only safe over HTTPS — Render terminates TLS by default,
+# but confirm your deployed URL is https:// before relying on this.
+APP_USERNAME=change_me
+APP_PASSWORD=use_a_long_random_string
+
+# --- Pipeline tuning ------------------------------------------------------
+# Entries scoring below this are surfaced for review instead of inserted.
+CONFIDENCE_THRESHOLD=0.7
+# rapidfuzz score at/above which a proposed exercise name reuses an existing row.
+FUZZY_MATCH_THRESHOLD=85
+# Single fixed timezone for this single-user tool. IANA name.
+LOCAL_TIMEZONE=UTC
+# Assumed wall-clock hour when the journal text carries no time marker.
+DEFAULT_SESSION_HOUR=18
+# Window for the /log duplicate-submission guard, in minutes.
+DUPLICATE_WINDOW_MINUTES=5
+
+# --- Weekly report tuning -------------------------------------------------
+# Pain safeguard. MUST stay true unless you are deliberately turning it off.
+PAIN_SAFEGUARD_ENABLED=true
+# Minimum regularly-trained exercises before program-level stagnation is judged.
+PROGRAM_STAGNATION_MIN_EXERCISES=4
+# Fraction of them that must be simultaneously plateaued to flag the program.
+PROGRAM_STAGNATION_FRACTION=0.6
+# Working rep range driving the overload rules.
+WORKING_REP_RANGE_LOW=6
+WORKING_REP_RANGE_HIGH=12
+# Smallest real load change available in your gym, in kg.
+PLATE_INCREMENT_KG=2.5
+# Weeks of history each report considers.
+ANALYSIS_WEEKS=6
+# Sessions of flat/declining e1RM that count as a plateau.
+PLATEAU_MIN_SESSIONS=3
+PLATEAU_TOLERANCE=0.01
+
+# --- Logging --------------------------------------------------------------
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.env
+.env.*
+!.env.example
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+htmlcov/
+*.egg-info/
+.DS_Store
+.idea/
+.vscode/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app:app --host 0.0.0.0 --port $PORT

--- a/README.md
+++ b/README.md
@@ -1,0 +1,241 @@
+# Gym Tracker
+
+Turns messy free-text gym journal entries into structured Postgres rows, and
+generates a weekly progress report on top of them.
+
+You keep logging in your phone's Notes app exactly as you do now — typos,
+voice-to-text run-ons, times like "6:20ish", commentary like "almost died" —
+then paste the text into a small web form. The pipeline extracts the sets,
+validates them, scores how much it trusts each one, and inserts only what clears
+the bar. Everything else is listed for you to look at rather than quietly saved.
+
+Power BI connects straight to the Postgres tables. That side is out of scope
+here; the schema is just shaped for it.
+
+## How it works
+
+```
+Notes app (unchanged)
+  -> paste into the mobile web form            app.py
+  -> Groq extraction, JSON mode, 1 retry       pipeline.extract_entities
+  -> Pydantic validation                       pipeline.validate_extraction
+  -> computed confidence heuristic             pipeline.compute_confidence
+  -> fuzzy match against existing exercises    pipeline.find_matching_exercise
+  -> below threshold? -> review list, not inserted
+  -> above threshold? -> parameterized INSERT into Postgres
+  -> Power BI reads Postgres directly (later, not part of this build)
+```
+
+## Files
+
+| File | What it is |
+|---|---|
+| `schema.sql` | Postgres schema: `exercises`, `workout_logs`, `bodyweight_logs`, `weekly_reports` |
+| `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
+| `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
+| `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
+| `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
+| `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
+| `tests/` | Unit tests for the Stage A rules and the confidence / fuzzy-match logic |
+| `sample_entry.txt` | A messy journal entry in the real style, for trying the CLI |
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env      # then fill it in
+psql "$DATABASE_URL" -f schema.sql
+```
+
+`schema.sql` is safe to re-run — every object is `IF NOT EXISTS`.
+
+### Try it
+
+```bash
+python parse_workout_log.py sample_entry.txt 2026-08-14 --dry-run   # no writes
+python parse_workout_log.py sample_entry.txt 2026-08-14
+
+python seed_sample_data.py --reset      # three weeks of sample data
+uvicorn app:app --reload                # then open http://127.0.0.1:8000
+```
+
+## The decisions worth knowing about
+
+### The LLM does not produce any number in the report
+
+`insights.py` is split in two, and the split is the point.
+
+**Stage A** is plain Python and SQL. Estimated 1RM (Epley: `weight × (1 + reps/30)`),
+volume, this week's e1RM versus the trailing 4-week average, rep-range
+distribution, plateau detection, the program-stagnation rollup, and every
+load recommendation are computed in code.
+
+**Stage B** hands Stage A's finished numbers to Groq and asks for prose. Its
+prompt states that it may not alter, invent, or re-round any figure, and may not
+create or second-guess a recommendation. If the Groq call fails, you get
+`fallback_summary()` — the same numbers, less polish. A failed narration never
+costs you the report and never tempts anyone into letting the model fill a gap.
+
+### Confidence is computed, not asked for
+
+LLMs are badly calibrated at rating their own certainty, so the model is
+explicitly told not to report a confidence score. `compute_confidence()` derives
+one from things that can actually be checked:
+
+- did Pydantic validation pass;
+- did the required fields (exercise name, weight, reps) come back non-null;
+- does the exercise name actually match the text span it was supposedly read
+  from — the check that catches a name the model invented rather than read.
+
+Below `CONFIDENCE_THRESHOLD` (0.7) an entry goes to the review list and is not
+inserted. A set missing its weight or reps lands at 0.65 and so is always
+surfaced. That is deliberate: a set with no load recorded is not much use for
+progression, and a bodyweight exercise logged this way is worth a glance.
+
+### Exercise names are fuzzy-matched before a new row is created
+
+The model normalizes names, but not identically on every call. Left alone, "Chest
+Bench Press", "Bench Press (Chest)" and "Barbell Chest Bench Press" become three
+rows and your progress history splits three ways — which defeats the point of
+tracking.
+
+No single rapidfuzz scorer gets this right. `token_set_ratio` merges "Bench
+Press" with "Incline Bench Press" (score 100), and `token_sort_ratio` refuses to
+merge "Barbell Chest Bench Press" with "Chest Bench Press" (score 81). So
+`name_match_score()` uses `token_sort_ratio` as the base, and only lifts it to
+`token_set_ratio` when one name's tokens are a strict subset of the other's *and*
+every extra token is a known equipment/muscle qualifier (`barbell`, `dumbbell`,
+`chest`, `lat`…). Words outside that allowlist — `incline`, `front`, `close
+grip`, `romanian` — mark a genuinely different movement and block the merge.
+Unknown words fail closed, into a separate row.
+
+Both names must have at least two tokens for the subset bonus, so "Curl" never
+absorbs "Leg Curl". Threshold is 85, tunable via `FUZZY_MATCH_THRESHOLD`.
+
+### Recommendation precedence
+
+In order — the first one that applies wins:
+
+1. **Pain safeguard.** Any `pain_flag` on this exercise in the last 2 sessions
+   holds the load regardless of performance, and adds one light warm-up set at
+   ~45% of the working weight. Pain flagged 3+ consecutive sessions escalates the
+   note to suggest seeing a professional. Controlled by `PAIN_SAFEGUARD_ENABLED`,
+   default `true`; nothing else in the code path can turn it off.
+2. **Increase** when every working set in the last session hit the top of the rep
+   range — next practical increment up (~2.5–5%, rounded to a real plate change).
+3. **Deload or swap** when e1RM has been flat or declining for 3+ sessions.
+4. **Hold** otherwise.
+
+Increase deliberately outranks the plateau branch. Topping out the rep range at
+the same load for three sessions *does* read as a flat e1RM, but the right answer
+there is more weight, not a deload — ranking them the other way would recommend
+deloading someone who is progressing.
+
+On light lifts a single 2.5 kg change is more than 5%; that is simply the
+smallest change the plates allow. Set `PLATE_INCREMENT_KG` lower if your gym has
+finer dumbbells.
+
+### Program-level stagnation is a rollup, not a second metric
+
+Whole-program staleness is derived from the per-exercise plateau flags: it fires
+when at least `PROGRAM_STAGNATION_FRACTION` (0.6) of *regularly-trained*
+exercises — those appearing in 2 of the last 3 weeks — are simultaneously
+plateaued, and only once there are at least `PROGRAM_STAGNATION_MIN_EXERCISES`
+(4) of them. With two or three exercises logged, "60% plateaued" is noise.
+
+It deliberately does **not** key off total-volume trend. A volume drop is just as
+likely to be an intentional deload or a dropped accessory lift, and reading that
+as staleness would flag a deliberate program change as a problem.
+
+When it fires you get the *category* of action — rotate the split, deload week,
+new mesocycle. It never names a specific replacement program, because picking one
+is a coaching judgement call a text-log parser has no business making.
+
+### What the pain handling deliberately does not do
+
+It does not guess why something hurts, and it does not prescribe corrective or
+rehab work. A text note cannot separate a strain from a tendon issue from
+ordinary fatigue, and those want different responses. The tool holds the load,
+adds a light warm-up set, and after three consecutive flagged sessions says it is
+worth getting looked at. That is the whole of it — the Stage B prompt forbids the
+model from going further, and a unit test asserts the note never mentions a
+diagnosis or a corrective exercise.
+
+### Duplicate submissions
+
+Render's free tier cold-starts in 30–50s after idle, which is exactly when you
+double-tap submit. Before extracting anything, `/log` checks whether the same raw
+text was inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns the
+earlier result instead of re-running the model and re-inserting.
+
+## Security
+
+- **Parameterized SQL everywhere.** Every statement is `sqlalchemy.text()` with
+  bound `:param` placeholders. No value — user-typed or model-generated — is ever
+  formatted into a query string.
+- **Secrets are env vars only.** `GROQ_API_KEY`, `DATABASE_URL`, `APP_USERNAME`,
+  `APP_PASSWORD` are never hardcoded, never rendered to the page, never logged.
+  `.env` is gitignored; `.env.example` holds placeholders only.
+- **HTTP Basic Auth** on every route except `/healthz`, compared with
+  `secrets.compare_digest`. Basic Auth credentials are base64, not encrypted, so
+  this is **only safe over HTTPS** — Render terminates TLS by default, but confirm
+  your deployed URL is `https://` before relying on it. The app logs a warning on
+  any non-local request that arrives over plain HTTP.
+- **Model output is escaped before it reaches the page.** Extracted exercise
+  names are rendered through `html.escape`, so a name containing markup cannot
+  inject anything.
+
+## Deployment
+
+**Database — Supabase free tier.** Create a project, run `schema.sql`, and take
+the pooled connection URI as `DATABASE_URL`. Free projects pause after 7 days of
+inactivity; at normal logging frequency you will not notice, but that is why the
+first request after a long gap can be slow.
+
+**Web app — Render free tier.**
+
+- Build: `pip install -r requirements.txt`
+- Start: `uvicorn app:app --host 0.0.0.0 --port $PORT`
+- Set `GROQ_API_KEY`, `DATABASE_URL`, `APP_USERNAME`, `APP_PASSWORD` in the
+  dashboard, plus any tuning vars from `.env.example`.
+
+Free instances spin down after 15 minutes idle and take 30–50s to wake. That is
+fine for personal use and is exactly why the duplicate-submission guard exists.
+
+**LLM — Groq free tier.** No billing account is needed anywhere in this stack.
+
+### A note on the model ID
+
+Groq deprecated `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` for free and
+developer tiers on **2026-06-17**. This project defaults to
+**`openai/gpt-oss-120b`**, Groq's recommended general-purpose replacement,
+verified against their deprecation notice at build time. Override with
+`GROQ_MODEL`, and re-check <https://console.groq.com/docs/models> before assuming
+the default is still current.
+
+## Tests
+
+```bash
+pip install -r requirements-dev.txt
+pytest -q
+```
+
+147 tests, no network and no database required — they cover the Stage A rule
+branches (e1RM, plateau detection, the program-stagnation rollup, every
+increase/hold/deload branch, pain safeguard on and off, the escalation
+threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
+resolution, and JSON-mode retry behaviour. These are pure functions, so they are
+cheap to cover, and they are exactly the code where a silent bug produces a wrong
+training recommendation that nobody notices.
+
+## Not built (by design)
+
+- **iOS Shortcut** posting from the Notes Share Sheet straight to `/log`. Listed
+  as a stretch goal in the spec; ask for it when you want it.
+- **Scheduled report generation.** The weekly report runs from a button, which
+  keeps the stack free of scheduling infrastructure. A cron version is a fine
+  later upgrade.
+- **Power BI dashboards.** The schema is shaped for them; building them is not
+  part of this.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,398 @@
+"""FastAPI web app — the phone-facing front end for the gym tracker.
+
+Routes:
+    GET  /               mobile-friendly entry form
+    POST /log            run the pipeline on a pasted journal entry
+    GET  /weekly-report  report page with a "Generate weekly report" button
+    POST /weekly-report  run Stage A + Stage B and upsert the report
+    GET  /healthz        unauthenticated liveness probe
+
+All extraction/validation/insert logic is imported from pipeline.py; all report
+logic from insights.py. Nothing is reimplemented here.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+import secrets
+import time
+from datetime import date, datetime
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+import insights
+import pipeline
+
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    format='%(asctime)s level=%(levelname)s logger=%(name)s %(message)s',
+)
+logger = logging.getLogger("gym_tracker.app")
+
+app = FastAPI(title="Gym Tracker", docs_url=None, redoc_url=None)
+security = HTTPBasic()
+
+_engine = None
+
+
+def get_engine():
+    """Lazily build the SQLAlchemy engine so import never needs a database."""
+    global _engine
+    if _engine is None:
+        _engine = pipeline.get_engine()
+    return _engine
+
+
+# --------------------------------------------------------------------------
+# Auth
+# --------------------------------------------------------------------------
+
+
+def require_auth(request: Request, credentials: HTTPBasicCredentials = Depends(security)) -> str:
+    """HTTP Basic Auth against env vars, compared in constant time.
+
+    Basic Auth credentials are base64, not encrypted, so this is only safe over
+    HTTPS. Render terminates TLS by default; the check below logs loudly if a
+    request ever arrives over plain HTTP so a misconfigured deployment is not
+    silently insecure.
+    """
+    expected_user = os.getenv("APP_USERNAME")
+    expected_password = os.getenv("APP_PASSWORD")
+    if not expected_user or not expected_password:
+        logger.error("event=auth_misconfigured msg='APP_USERNAME/APP_PASSWORD not set'")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Server auth is not configured.",
+        )
+
+    forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    if forwarded_proto != "https" and request.client and request.client.host not in {"127.0.0.1", "::1"}:
+        logger.warning(
+            "event=insecure_transport proto=%s msg='Basic Auth credentials sent without TLS'",
+            forwarded_proto,
+        )
+
+    user_ok = secrets.compare_digest(credentials.username, expected_user)
+    password_ok = secrets.compare_digest(credentials.password, expected_password)
+    if not (user_ok and password_ok):
+        logger.warning("event=auth_failed path=%s", request.url.path)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username
+
+
+# --------------------------------------------------------------------------
+# Structured request logging
+# --------------------------------------------------------------------------
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    started = time.perf_counter()
+    try:
+        response = await call_next(request)
+    except Exception:
+        duration_ms = (time.perf_counter() - started) * 1000
+        logger.exception(
+            "event=request method=%s path=%s status=500 duration_ms=%.1f",
+            request.method,
+            request.url.path,
+            duration_ms,
+        )
+        raise
+    duration_ms = (time.perf_counter() - started) * 1000
+    logger.info(
+        "event=request method=%s path=%s status=%d duration_ms=%.1f",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
+
+
+# --------------------------------------------------------------------------
+# Rendering helpers (everything dynamic is escaped before it reaches the page)
+# --------------------------------------------------------------------------
+
+_STYLE = """
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       margin: 0; padding: 1rem; max-width: 40rem; margin-inline: auto; line-height: 1.5; }
+h1 { font-size: 1.35rem; margin: 0 0 1rem; }
+h2 { font-size: 1.1rem; margin: 1.4rem 0 .5rem; }
+label { display: block; font-weight: 600; margin: .9rem 0 .3rem; }
+input[type=date], textarea, button { width: 100%; font-size: 1rem; padding: .7rem;
+       border-radius: .5rem; border: 1px solid #8884; font-family: inherit; }
+textarea { min-height: 11rem; resize: vertical; }
+button { margin-top: 1rem; font-weight: 600; border: 0; background: #2563eb; color: #fff; }
+button:active { background: #1d4ed8; }
+.card { border: 1px solid #8884; border-radius: .6rem; padding: .8rem 1rem; margin: .8rem 0; }
+.ok { border-left: 4px solid #16a34a; }
+.warn { border-left: 4px solid #d97706; }
+.err { border-left: 4px solid #dc2626; }
+.muted { opacity: .75; font-size: .9rem; }
+ul { padding-left: 1.2rem; }
+nav a { display: inline-block; margin-right: 1rem; }
+pre { white-space: pre-wrap; word-wrap: break-word; }
+"""
+
+
+def _page(title: str, body: str) -> HTMLResponse:
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{html.escape(title)}</title>
+<style>{_STYLE}</style>
+</head><body>
+<nav><a href="/">Log entry</a><a href="/weekly-report">Weekly report</a></nav>
+{body}
+</body></html>"""
+    )
+
+
+def _render_markdown(markdown_text: str) -> str:
+    """Minimal markdown -> HTML. Escapes FIRST, so no user text can inject tags."""
+    escaped = html.escape(markdown_text)
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    lines_out: list[str] = []
+    in_list = False
+    for line in escaped.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            if in_list:
+                lines_out.append("</ul>")
+                in_list = False
+            lines_out.append(f"<h2>{stripped[3:]}</h2>")
+        elif stripped.startswith("# "):
+            if in_list:
+                lines_out.append("</ul>")
+                in_list = False
+            lines_out.append(f"<h2>{stripped[2:]}</h2>")
+        elif stripped.startswith("- "):
+            if not in_list:
+                lines_out.append("<ul>")
+                in_list = True
+            lines_out.append(f"<li>{stripped[2:]}</li>")
+        elif not stripped:
+            if in_list:
+                lines_out.append("</ul>")
+                in_list = False
+        else:
+            if in_list:
+                lines_out.append("</ul>")
+                in_list = False
+            lines_out.append(f"<p>{stripped}</p>")
+    if in_list:
+        lines_out.append("</ul>")
+    return "\n".join(lines_out)
+
+
+def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
+    parts: list[str] = []
+
+    if result.error:
+        parts.append(f'<div class="card err"><strong>Error.</strong> {html.escape(result.error)}</div>')
+
+    if result.duplicate_of_recent:
+        parts.append(
+            '<div class="card warn"><strong>Duplicate submission.</strong> '
+            "This exact text was already processed within the last "
+            f"{pipeline.DUPLICATE_WINDOW_MINUTES} minutes, so nothing was re-inserted. "
+            f"The earlier run saved {result.inserted_sets} set(s) and "
+            f"{result.inserted_bodyweight} bodyweight entry/entries.</div>"
+        )
+    else:
+        parts.append(
+            f'<div class="card ok"><strong>Inserted {result.inserted_sets} set(s)</strong> and '
+            f"{result.inserted_bodyweight} bodyweight entry/entries for "
+            f"{html.escape(session_date.isoformat())}.</div>"
+        )
+
+    if result.exercises_created:
+        names = ", ".join(html.escape(name) for name in result.exercises_created)
+        parts.append(f'<div class="card muted">New exercises created: {names}</div>')
+
+    if result.exercises_matched:
+        rows = "".join(
+            f"<li>{html.escape(proposed)} &rarr; matched existing <strong>{html.escape(matched)}</strong></li>"
+            for proposed, matched in result.exercises_matched
+        )
+        parts.append(f'<div class="card muted"><strong>Fuzzy-matched names</strong><ul>{rows}</ul></div>')
+
+    if result.review_items:
+        rows = []
+        for item in result.review_items:
+            confidence = f"{item.confidence:.2f}" if item.confidence is not None else "n/a"
+            label = html.escape(str(item.payload.get("exercise_name") or item.kind))
+            weight = item.payload.get("weight_kg")
+            reps = item.payload.get("reps")
+            detail = ""
+            if weight is not None or reps is not None:
+                detail = f" ({html.escape(str(weight))}kg &times; {html.escape(str(reps))})"
+            rows.append(
+                f"<li><strong>{label}</strong>{detail} &mdash; confidence {confidence}. "
+                f"{html.escape(item.reason)}</li>"
+            )
+        parts.append(
+            '<div class="card warn"><strong>Needs manual review '
+            f"({len(result.review_items)}) &mdash; not inserted</strong><ul>{''.join(rows)}</ul></div>"
+        )
+    elif not result.error and not result.duplicate_of_recent:
+        parts.append('<div class="card muted">Nothing needed review.</div>')
+
+    return "".join(parts)
+
+
+# --------------------------------------------------------------------------
+# Routes
+# --------------------------------------------------------------------------
+
+
+@app.get("/healthz")
+async def healthz() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
+    today = date.today().isoformat()
+    return _page(
+        "Log a workout",
+        f"""
+<h1>Log a workout</h1>
+<form method="post" action="/log">
+  <label for="session_date">Session date</label>
+  <input type="date" id="session_date" name="session_date" value="{today}" required>
+  <label for="raw_text">Journal entry</label>
+  <textarea id="raw_text" name="raw_text" required
+    placeholder="Paste straight from Notes. Messy is fine."></textarea>
+  <button type="submit">Parse &amp; save</button>
+</form>
+<p class="muted">Sets below the confidence threshold
+({pipeline.CONFIDENCE_THRESHOLD:.0%}) are listed for review instead of being saved.
+Bodyweight mentions in the same entry are picked up automatically.</p>
+""",
+    )
+
+
+@app.post("/log", response_class=HTMLResponse)
+async def log_entry(
+    session_date: str = Form(...),
+    raw_text: str = Form(...),
+    _user: str = Depends(require_auth),
+) -> HTMLResponse:
+    try:
+        parsed_date = datetime.strptime(session_date.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return _page(
+            "Invalid date",
+            '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
+            '<p><a href="/">Back</a></p>',
+        )
+
+    result = pipeline.process_entry(
+        raw_text,
+        parsed_date,
+        engine=get_engine(),
+        check_duplicates=True,
+    )
+    logger.info(
+        "event=log_processed date=%s inserted_sets=%d inserted_bodyweight=%d "
+        "review=%d duplicate=%s",
+        parsed_date,
+        result.inserted_sets,
+        result.inserted_bodyweight,
+        len(result.review_items),
+        result.duplicate_of_recent,
+    )
+    return _page(
+        "Result",
+        f'<h1>Result</h1>{_render_result(result, parsed_date)}<p><a href="/">Log another</a></p>',
+    )
+
+
+@app.get("/weekly-report", response_class=HTMLResponse)
+async def weekly_report_form(_user: str = Depends(require_auth)) -> HTMLResponse:
+    current_week = insights.week_start_for(date.today())
+    return _page(
+        "Weekly report",
+        f"""
+<h1>Weekly report</h1>
+<p class="muted">All figures are computed in code. The language model only writes
+the prose around them.</p>
+<form method="post" action="/weekly-report">
+  <label for="week_start">Week starting (Monday)</label>
+  <input type="date" id="week_start" name="week_start" value="{current_week.isoformat()}">
+  <button type="submit">Generate weekly report</button>
+</form>
+<p class="muted">Regenerating a week overwrites that week's stored report.
+Pain safeguard is currently <strong>{'on' if insights.PAIN_SAFEGUARD_ENABLED else 'OFF'}</strong>.</p>
+""",
+    )
+
+
+@app.post("/weekly-report", response_class=HTMLResponse)
+async def weekly_report_generate(
+    week_start: Optional[str] = Form(None),
+    _user: str = Depends(require_auth),
+) -> HTMLResponse:
+    parsed_week: Optional[date] = None
+    if week_start and week_start.strip():
+        try:
+            parsed_week = datetime.strptime(week_start.strip(), "%Y-%m-%d").date()
+        except ValueError:
+            return _page(
+                "Invalid date",
+                '<h1>Weekly report</h1><div class="card err">Week start must be YYYY-MM-DD.</div>'
+                '<p><a href="/weekly-report">Back</a></p>',
+            )
+
+    report = insights.generate_weekly_report(get_engine(), week_start=parsed_week)
+    logger.info(
+        "event=report_generated week_start=%s records=%d narration_error=%s",
+        report["week_start_date"],
+        report["record_count"],
+        bool(report["narration_error"]),
+    )
+
+    banner = ""
+    if report["record_count"] == 0:
+        banner = (
+            '<div class="card warn">No sets logged in the analysis window, so the '
+            "report has nothing to work from.</div>"
+        )
+    elif report["narration_error"]:
+        banner = (
+            '<div class="card warn">The narration step failed, so this is the '
+            "deterministic summary. Every number is unaffected &mdash; they are all "
+            "computed in code.</div>"
+        )
+
+    program_note = report["recommendations"]["program_note"]
+    if program_note["stagnation_flagged"]:
+        banner += (
+            '<div class="card warn"><strong>Program-level stagnation flagged.</strong> '
+            f"{html.escape(program_note['detail']['reason'])}</div>"
+        )
+
+    return _page(
+        "Weekly report",
+        f"""<h1>Week of {html.escape(str(report['week_start_date']))}</h1>
+{banner}
+<div class="card">{_render_markdown(report['summary_text'])}</div>
+<p class="muted">Saved to <code>weekly_reports</code> ({report['record_count']} sets analysed).</p>
+<p><a href="/weekly-report">Generate another</a></p>""",
+    )

--- a/insights.py
+++ b/insights.py
@@ -1,0 +1,830 @@
+"""Weekly report generation, split strictly into two stages.
+
+Stage A (this module's pure functions + SQL): every number in the report —
+e1RM, volume, percentages, recommended weights, plateau and stagnation flags —
+is computed here, in code.
+
+Stage B (`narrate`): Groq is handed Stage A's finished numbers and writes prose
+around them. It may not alter, invent, or re-round any of them, and it never
+decides a recommendation.
+
+The Stage A functions take plain dataclasses, not database rows, so they are
+directly unit-testable with no database and no network.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Any, Iterable, Optional
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+import pipeline
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------
+# Tunables (env vars so they can be adjusted without a code change)
+# --------------------------------------------------------------------------
+
+# Program-level stagnation is meaningless on a handful of exercises: with 2-3
+# logged, "60% plateaued" is noise. Require at least this many regularly-trained
+# exercises before the check runs at all.
+PROGRAM_STAGNATION_MIN_EXERCISES = int(os.getenv("PROGRAM_STAGNATION_MIN_EXERCISES", "4"))
+
+# Fraction of regularly-trained exercises that must be simultaneously plateaued.
+PROGRAM_STAGNATION_FRACTION = float(os.getenv("PROGRAM_STAGNATION_FRACTION", "0.6"))
+
+# Pain safeguard defaults to ON. Only an explicit env var turns it off; no code
+# path may skip the check on its own.
+PAIN_SAFEGUARD_ENABLED = os.getenv("PAIN_SAFEGUARD_ENABLED", "true").strip().lower() not in {
+    "false", "0", "no", "off",
+}
+
+# Working rep range used by the progressive-overload rules.
+WORKING_REP_RANGE_LOW = int(os.getenv("WORKING_REP_RANGE_LOW", "6"))
+WORKING_REP_RANGE_HIGH = int(os.getenv("WORKING_REP_RANGE_HIGH", "12"))
+
+# Smallest real load change available in the gym, in kg.
+PLATE_INCREMENT_KG = float(os.getenv("PLATE_INCREMENT_KG", "2.5"))
+
+# How much history each report considers.
+ANALYSIS_WEEKS = int(os.getenv("ANALYSIS_WEEKS", "6"))
+
+# Sessions of flat-or-declining e1RM that count as a per-exercise plateau.
+PLATEAU_MIN_SESSIONS = int(os.getenv("PLATEAU_MIN_SESSIONS", "3"))
+
+# Growth below this fraction over the window still counts as flat.
+PLATEAU_TOLERANCE = float(os.getenv("PLATEAU_TOLERANCE", "0.01"))
+
+GROQ_MODEL = pipeline.GROQ_MODEL
+
+
+# --------------------------------------------------------------------------
+# Stage A data types
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SetRecord:
+    """One logged set, already resolved to a local calendar date."""
+
+    exercise_name: str
+    session_date: date
+    weight_kg: Optional[float] = None
+    reps: Optional[int] = None
+    is_warmup: bool = False
+    pain_flag: bool = False
+    muscle_group: Optional[str] = None
+
+
+@dataclass
+class Recommendation:
+    exercise: str
+    action: str  # increase | hold | hold_pain | deload_or_swap | insufficient_data
+    current_weight_kg: Optional[float] = None
+    recommended_weight_kg: Optional[float] = None
+    target_reps: Optional[str] = None
+    reason: str = ""
+    plateaued: bool = False
+    pain_safeguard_applied: bool = False
+    warmup_set_kg: Optional[float] = None
+    pain_note: Optional[str] = None
+    escalate_pain_to_professional: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# --------------------------------------------------------------------------
+# Stage A: pure computation
+# --------------------------------------------------------------------------
+
+
+def epley_1rm(weight_kg: Optional[float], reps: Optional[int]) -> Optional[float]:
+    """Estimated 1RM: weight * (1 + reps / 30)."""
+    if weight_kg is None or reps is None:
+        return None
+    if weight_kg <= 0 or reps <= 0:
+        return None
+    return float(weight_kg) * (1.0 + reps / 30.0)
+
+
+def is_working_set(record: SetRecord) -> bool:
+    """A set that counts toward progression: not a warm-up, and fully logged."""
+    return (
+        not record.is_warmup
+        and record.weight_kg is not None
+        and record.reps is not None
+        and record.weight_kg > 0
+        and record.reps > 0
+    )
+
+
+def working_sets(records: Iterable[SetRecord]) -> list[SetRecord]:
+    return [r for r in records if is_working_set(r)]
+
+
+def group_by_exercise_session(
+    records: Iterable[SetRecord],
+) -> dict[str, dict[date, list[SetRecord]]]:
+    """{exercise: {session_date: [sets]}} — the shape most Stage A rules need."""
+    grouped: dict[str, dict[date, list[SetRecord]]] = defaultdict(lambda: defaultdict(list))
+    for record in records:
+        grouped[record.exercise_name][record.session_date].append(record)
+    return {name: dict(sessions) for name, sessions in grouped.items()}
+
+
+def e1rm_series(sessions: dict[date, list[SetRecord]]) -> list[tuple[date, float]]:
+    """Best e1RM per session, oldest first. Sessions with no working set are skipped."""
+    series: list[tuple[date, float]] = []
+    for session_date in sorted(sessions):
+        estimates = [
+            value
+            for value in (epley_1rm(r.weight_kg, r.reps) for r in working_sets(sessions[session_date]))
+            if value is not None
+        ]
+        if estimates:
+            series.append((session_date, max(estimates)))
+    return series
+
+
+def detect_plateau(
+    series: list[tuple[date, float]],
+    min_sessions: int = PLATEAU_MIN_SESSIONS,
+    tolerance: float = PLATEAU_TOLERANCE,
+) -> bool:
+    """True when e1RM is flat or declining across the trailing `min_sessions`.
+
+    "Flat" allows `tolerance` of drift so a 0.5% wobble is not read as progress.
+    """
+    if min_sessions < 2 or len(series) < min_sessions:
+        return False
+    recent = series[-min_sessions:]
+    baseline = recent[0][1]
+    ceiling = baseline * (1.0 + tolerance)
+    return all(value <= ceiling for _, value in recent[1:])
+
+
+def rep_range_distribution(records: Iterable[SetRecord]) -> dict[str, int]:
+    """Set counts by rep band. Raw input for the training-goal inference only.
+
+    Bands: <=5 strength-biased, 6-12 hypertrophy-biased, >12 endurance-biased.
+    (The spec's "12+" overlaps "6-12"; 12 is counted as hypertrophy.)
+    """
+    counts = {"strength": 0, "hypertrophy": 0, "endurance": 0}
+    for record in working_sets(records):
+        reps = record.reps or 0
+        if reps <= 5:
+            counts["strength"] += 1
+        elif reps <= 12:
+            counts["hypertrophy"] += 1
+        else:
+            counts["endurance"] += 1
+    return counts
+
+
+def set_volume(record: SetRecord) -> float:
+    if not is_working_set(record):
+        return 0.0
+    return float(record.weight_kg) * float(record.reps)  # type: ignore[arg-type]
+
+
+def total_volume(records: Iterable[SetRecord]) -> float:
+    return round(sum(set_volume(r) for r in records), 1)
+
+
+def volume_by_exercise(records: Iterable[SetRecord]) -> dict[str, float]:
+    totals: dict[str, float] = defaultdict(float)
+    for record in records:
+        totals[record.exercise_name] += set_volume(record)
+    return {name: round(value, 1) for name, value in sorted(totals.items())}
+
+
+def volume_by_muscle_group(records: Iterable[SetRecord]) -> dict[str, float]:
+    totals: dict[str, float] = defaultdict(float)
+    for record in records:
+        totals[record.muscle_group or "Unassigned"] += set_volume(record)
+    return {name: round(value, 1) for name, value in sorted(totals.items())}
+
+
+def week_start_for(day: date) -> date:
+    """Monday of the week containing `day`."""
+    return day - timedelta(days=day.weekday())
+
+
+def find_regularly_trained(
+    records: Iterable[SetRecord],
+    reference_week_start: date,
+    lookback_weeks: int = 3,
+    min_weeks: int = 2,
+) -> set[str]:
+    """Exercises appearing in at least `min_weeks` of the last `lookback_weeks` weeks.
+
+    Excludes one-off exercises, which would otherwise skew the program-level
+    stagnation fraction.
+    """
+    windows = {reference_week_start - timedelta(weeks=offset) for offset in range(lookback_weeks)}
+    weeks_seen: dict[str, set[date]] = defaultdict(set)
+    for record in records:
+        bucket = week_start_for(record.session_date)
+        if bucket in windows:
+            weeks_seen[record.exercise_name].add(bucket)
+    return {name for name, weeks in weeks_seen.items() if len(weeks) >= min_weeks}
+
+
+def detect_program_stagnation(
+    regularly_trained: Iterable[str],
+    plateaued: Iterable[str],
+    min_exercises: int = PROGRAM_STAGNATION_MIN_EXERCISES,
+    fraction_threshold: float = PROGRAM_STAGNATION_FRACTION,
+) -> dict[str, Any]:
+    """Roll per-exercise plateau flags up into a whole-program verdict.
+
+    Deliberately built from the plateau flags rather than a total-volume trend:
+    a volume drop can be an intentional deload or a dropped accessory lift, and
+    reading that as staleness would flag a deliberate program change.
+    """
+    regular = sorted(set(regularly_trained))
+    plateaued_regular = sorted(set(plateaued) & set(regular))
+    count = len(regular)
+
+    if count < min_exercises:
+        return {
+            "checked": False,
+            "flagged": False,
+            "regularly_trained_count": count,
+            "regularly_trained": regular,
+            "plateaued_count": len(plateaued_regular),
+            "plateaued_exercises": plateaued_regular,
+            "fraction": None,
+            "fraction_threshold": fraction_threshold,
+            "min_exercises": min_exercises,
+            "reason": (
+                f"Only {count} regularly-trained exercise(s); at least {min_exercises} "
+                "are needed before a program-level judgement is meaningful."
+            ),
+        }
+
+    fraction = len(plateaued_regular) / count
+    flagged = fraction >= fraction_threshold
+    return {
+        "checked": True,
+        "flagged": flagged,
+        "regularly_trained_count": count,
+        "regularly_trained": regular,
+        "plateaued_count": len(plateaued_regular),
+        "plateaued_exercises": plateaued_regular,
+        "fraction": round(fraction, 3),
+        "fraction_threshold": fraction_threshold,
+        "min_exercises": min_exercises,
+        "reason": (
+            f"{len(plateaued_regular)} of {count} regularly-trained exercises are "
+            f"individually plateaued ({fraction:.0%}), "
+            + (
+                f"at or above the {fraction_threshold:.0%} threshold."
+                if flagged
+                else f"below the {fraction_threshold:.0%} threshold."
+            )
+        ),
+    }
+
+
+def round_to_increment(weight: float, increment: float = PLATE_INCREMENT_KG) -> float:
+    """Round to the nearest real plate change."""
+    if increment <= 0:
+        return round(weight, 2)
+    return round(round(weight / increment) * increment, 2)
+
+
+def next_load(current: float, increment: float = PLATE_INCREMENT_KG, pct: float = 0.05) -> float:
+    """The next practical load up (~2.5-5%), never less than one increment.
+
+    On light lifts a single increment is more than 5% — that is simply the
+    smallest change the plates allow.
+    """
+    proposed = round_to_increment(current * (1.0 + pct), increment)
+    if proposed <= current:
+        proposed = round(current + increment, 2)
+    return proposed
+
+
+def deload_load(current: float, increment: float = PLATE_INCREMENT_KG, pct: float = 0.10) -> float:
+    """~10% down for one session, rounded to a real increment and always lower."""
+    proposed = round_to_increment(current * (1.0 - pct), increment)
+    if proposed >= current:
+        proposed = round(current - increment, 2)
+    return proposed if proposed > 0 else round(current, 2)
+
+
+def warmup_load(current: float, increment: float = PLATE_INCREMENT_KG, pct: float = 0.45) -> float:
+    """One extra light warm-up set at ~40-50% of the working weight."""
+    proposed = round_to_increment(current * pct, increment)
+    return proposed if proposed > 0 else round(increment, 2)
+
+
+def pain_sessions(sessions: dict[date, list[SetRecord]]) -> list[date]:
+    """Session dates (oldest first) that carry at least one pain flag."""
+    return sorted(d for d, sets in sessions.items() if any(s.pain_flag for s in sets))
+
+
+def trailing_pain_streak(sessions: dict[date, list[SetRecord]]) -> int:
+    """Consecutive most-recent sessions carrying a pain flag."""
+    flagged = set(pain_sessions(sessions))
+    streak = 0
+    for session_date in sorted(sessions, reverse=True):
+        if session_date in flagged:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def recommend_for_exercise(
+    exercise: str,
+    sessions: dict[date, list[SetRecord]],
+    rep_low: int = WORKING_REP_RANGE_LOW,
+    rep_high: int = WORKING_REP_RANGE_HIGH,
+    increment: float = PLATE_INCREMENT_KG,
+    pain_safeguard_enabled: bool = PAIN_SAFEGUARD_ENABLED,
+    plateau_min_sessions: int = PLATEAU_MIN_SESSIONS,
+) -> Recommendation:
+    """Rule-based progressive-overload recommendation for one exercise.
+
+    Precedence (deliberate):
+      1. Pain safeguard — holds the load regardless of performance.
+      2. Hit the top of the rep range on every working set -> increase.
+      3. Plateaued 3+ sessions -> deload or swap.
+      4. Otherwise hold.
+
+    Increase outranks the plateau branch on purpose: topping out the rep range
+    at the same load for three sessions reads as a plateau by e1RM, but the
+    right answer there is more weight, not a deload.
+    """
+    ordered_dates = sorted(sessions)
+    if not ordered_dates:
+        return Recommendation(exercise=exercise, action="insufficient_data",
+                              reason="No sessions logged for this exercise.")
+
+    last_date = ordered_dates[-1]
+    last_working = working_sets(sessions[last_date])
+    series = e1rm_series(sessions)
+    plateaued = detect_plateau(series, min_sessions=plateau_min_sessions)
+
+    if not last_working:
+        return Recommendation(
+            exercise=exercise,
+            action="insufficient_data",
+            plateaued=plateaued,
+            reason=f"Last session on {last_date.isoformat()} had no fully-logged working sets.",
+        )
+
+    current_weight = max(float(s.weight_kg) for s in last_working)  # type: ignore[arg-type]
+    top_set_reps = [s.reps for s in last_working if float(s.weight_kg) == current_weight]  # type: ignore[arg-type]
+    target_reps = f"{rep_low}-{rep_high}"
+
+    recent_two = ordered_dates[-2:]
+    pain_recent = any(s.pain_flag for d in recent_two for s in sessions[d])
+    pain_streak = trailing_pain_streak(sessions)
+
+    # 1. Pain safeguard. Default on; only an explicit env var disables it.
+    if pain_safeguard_enabled and pain_recent:
+        note = (
+            f"A pain flag was logged on this exercise within the last "
+            f"{len(recent_two)} session(s), so the load is held rather than increased."
+        )
+        escalate = pain_streak >= 3
+        if escalate:
+            note += (
+                f" Pain has now been flagged {pain_streak} sessions in a row — worth having "
+                "it looked at by a qualified professional rather than continuing to "
+                "self-adjust warm-ups."
+            )
+        reason = "Load held under the pain safeguard."
+        if plateaued:
+            reason += " (e1RM is also flat across recent sessions, but pain takes precedence.)"
+        return Recommendation(
+            exercise=exercise,
+            action="hold_pain",
+            current_weight_kg=current_weight,
+            recommended_weight_kg=current_weight,
+            target_reps=target_reps,
+            reason=reason,
+            plateaued=plateaued,
+            pain_safeguard_applied=True,
+            warmup_set_kg=warmup_load(current_weight, increment),
+            pain_note=note,
+            escalate_pain_to_professional=escalate,
+        )
+
+    # 2. Top of the rep range on every working set -> add load.
+    if all((s.reps or 0) >= rep_high for s in last_working):
+        return Recommendation(
+            exercise=exercise,
+            action="increase",
+            current_weight_kg=current_weight,
+            recommended_weight_kg=next_load(current_weight, increment),
+            target_reps=target_reps,
+            reason=(
+                f"Every working set last session hit the top of the {target_reps} range "
+                f"at {current_weight:g}kg."
+            ),
+            plateaued=plateaued,
+        )
+
+    # 3. Plateaued for 3+ sessions -> deload or swap (a suggestion, not an instruction).
+    if plateaued:
+        return Recommendation(
+            exercise=exercise,
+            action="deload_or_swap",
+            current_weight_kg=current_weight,
+            recommended_weight_kg=deload_load(current_weight, increment),
+            target_reps=target_reps,
+            reason=(
+                f"Estimated 1RM has been flat or declining across the last "
+                f"{plateau_min_sessions} sessions. Consider one session at roughly 10% "
+                "lighter, or swapping this movement for a variation."
+            ),
+            plateaued=True,
+        )
+
+    # 4. Otherwise hold and repeat.
+    missed_bottom = any((s.reps or 0) < rep_low for s in last_working)
+    reason = (
+        f"A working set fell below {rep_low} reps last session — repeat {current_weight:g}kg "
+        "and build reps first."
+        if missed_bottom
+        else f"Still working through the {target_reps} range at {current_weight:g}kg."
+    )
+    return Recommendation(
+        exercise=exercise,
+        action="hold",
+        current_weight_kg=current_weight,
+        recommended_weight_kg=current_weight,
+        target_reps=target_reps,
+        reason=reason,
+        plateaued=False,
+    )
+
+
+PROGRAM_STAGNATION_NOTE = (
+    "Most of what you train regularly has stalled at the same time. That usually "
+    "points at the program rather than any one lift — the categories of change "
+    "worth considering are rotating your split, taking a full deload week, or "
+    "starting a new mesocycle. Which one fits is your call; this tool doesn't "
+    "prescribe a specific replacement program."
+)
+
+
+def build_stage_a(
+    records: list[SetRecord],
+    week_start: date,
+    pain_safeguard_enabled: bool = PAIN_SAFEGUARD_ENABLED,
+    min_exercises: int = PROGRAM_STAGNATION_MIN_EXERCISES,
+    fraction_threshold: float = PROGRAM_STAGNATION_FRACTION,
+    rep_low: int = WORKING_REP_RANGE_LOW,
+    rep_high: int = WORKING_REP_RANGE_HIGH,
+    increment: float = PLATE_INCREMENT_KG,
+) -> dict[str, Any]:
+    """Every number in the weekly report. No LLM involved anywhere in here."""
+    week_end = week_start + timedelta(days=7)
+    this_week = [r for r in records if week_start <= r.session_date < week_end]
+    prior_4_weeks = [
+        r for r in records if week_start - timedelta(weeks=4) <= r.session_date < week_start
+    ]
+
+    by_exercise = group_by_exercise_session(records)
+    this_week_by_exercise = group_by_exercise_session(this_week)
+    prior_by_exercise = group_by_exercise_session(prior_4_weeks)
+
+    exercises: dict[str, Any] = {}
+    plateaued: set[str] = set()
+    recommendations: dict[str, Any] = {}
+
+    for name, sessions in sorted(by_exercise.items()):
+        series = e1rm_series(sessions)
+        is_plateaued = detect_plateau(series)
+        if is_plateaued:
+            plateaued.add(name)
+
+        week_series = e1rm_series(this_week_by_exercise.get(name, {}))
+        best_this_week = round(max((v for _, v in week_series), default=0.0), 2) or None
+
+        prior_series = e1rm_series(prior_by_exercise.get(name, {}))
+        prior_average = (
+            round(sum(v for _, v in prior_series) / len(prior_series), 2) if prior_series else None
+        )
+        delta_pct = (
+            round((best_this_week - prior_average) / prior_average * 100, 1)
+            if best_this_week and prior_average
+            else None
+        )
+
+        recommendation = recommend_for_exercise(
+            name,
+            sessions,
+            rep_low=rep_low,
+            rep_high=rep_high,
+            increment=increment,
+            pain_safeguard_enabled=pain_safeguard_enabled,
+        )
+        recommendations[name] = recommendation.to_dict()
+
+        exercises[name] = {
+            "sessions_logged": len(sessions),
+            "best_e1rm_this_week_kg": best_this_week,
+            "trailing_4wk_avg_e1rm_kg": prior_average,
+            "e1rm_delta_pct_vs_4wk_avg": delta_pct,
+            "volume_this_week_kg": round(
+                sum(set_volume(r) for r in this_week if r.exercise_name == name), 1
+            ),
+            "plateaued": is_plateaued,
+            "pain_flag_streak_sessions": trailing_pain_streak(sessions),
+            "e1rm_series": [[d.isoformat(), round(v, 2)] for d, v in series],
+        }
+
+    regularly_trained = find_regularly_trained(records, week_start)
+    program_stagnation = detect_program_stagnation(
+        regularly_trained, plateaued, min_exercises, fraction_threshold
+    )
+
+    program_note = {
+        "stagnation_flagged": program_stagnation["flagged"],
+        "detail": program_stagnation,
+        "suggestion": PROGRAM_STAGNATION_NOTE if program_stagnation["flagged"] else None,
+    }
+
+    return {
+        "week_start_date": week_start.isoformat(),
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "config": {
+            "pain_safeguard_enabled": pain_safeguard_enabled,
+            "working_rep_range": [rep_low, rep_high],
+            "plate_increment_kg": increment,
+            "program_stagnation_min_exercises": min_exercises,
+            "program_stagnation_fraction": fraction_threshold,
+        },
+        "totals": {
+            "sets_logged_this_week": len(working_sets(this_week)),
+            "volume_this_week_kg": total_volume(this_week),
+            "volume_prior_4wk_avg_kg": (
+                round(total_volume(prior_4_weeks) / 4, 1) if prior_4_weeks else None
+            ),
+            "exercises_trained_this_week": len(this_week_by_exercise),
+        },
+        "volume_by_exercise_kg": volume_by_exercise(this_week),
+        "volume_by_muscle_group_kg": volume_by_muscle_group(this_week),
+        "rep_range_distribution": rep_range_distribution(records),
+        "rep_range_distribution_this_week": rep_range_distribution(this_week),
+        "exercises": exercises,
+        "recommendations": recommendations,
+        "program_note": program_note,
+    }
+
+
+# --------------------------------------------------------------------------
+# Stage B: narrative only
+# --------------------------------------------------------------------------
+
+_NARRATIVE_SYSTEM_PROMPT = """\
+You write a short weekly training report for one person, from a JSON object of
+numbers that have ALREADY been computed.
+
+Absolute rules:
+- You may NOT alter, invent, recompute, or "round differently" ANY number in the
+  input. Quote weights, percentages, volumes and e1RM values exactly as given.
+- You may NOT create, change, or second-guess a recommendation. Each exercise
+  already has an `action` and a `recommended_weight_kg`. Your job is to explain
+  the decision that was made, not to make one.
+- If a number you would like to cite is not in the input, leave it out.
+
+Write these sections in plain markdown, no preamble:
+
+## What improved
+Two to four sentences on the exercises whose `e1rm_delta_pct_vs_4wk_avg` is
+positive, and on this week's volume. Name real numbers from the input.
+
+## Next week
+One short line per exercise in `recommendations`, in this shape:
+**<exercise>** — <what to do> (<recommended_weight_kg>kg, target <target_reps> reps). <one sentence of why, from `reason`>.
+If `pain_safeguard_applied` is true, say the load is being held because pain was
+logged, and mention the extra light warm-up set at `warmup_set_kg`kg. If
+`escalate_pain_to_professional` is true, add that it is worth getting looked at
+by a professional. Never suggest a cause for the pain and never prescribe
+corrective, rehab or prehab exercises — a text log cannot tell a strain from a
+tendon issue, and guessing is out of scope.
+
+## Program note
+Include this section ONLY if `program_note.stagnation_flagged` is true. Relay
+`program_note.suggestion` in your own words. Name only the CATEGORY of change
+(rotate the split, deload week, new mesocycle). Never invent a specific
+replacement program, split, or exercise list.
+
+## What you look like you're training for
+Two or three sentences inferring the likely goal from
+`volume_by_muscle_group_kg` and `rep_range_distribution` only. Describe the
+pattern in the numbers ("your sets sit mostly in the 6-12 range and volume is
+weighted toward X, which reads as hypertrophy-focused"). Frame it as a reading
+of the data, not a fact about the person, and do not tell them to change it.
+
+Keep the whole thing under 350 words. Be direct, no cheerleading.
+"""
+
+
+def narrate(stage_a: dict[str, Any], client: Any = None, model: str = GROQ_MODEL) -> str:
+    """Stage B. Turns Stage A's numbers into prose. Computes nothing."""
+    if client is None:
+        client = pipeline.get_groq_client()
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _NARRATIVE_SYSTEM_PROMPT},
+            {"role": "user", "content": json.dumps(stage_a, default=str, indent=2)},
+        ],
+        temperature=0,
+    )
+    return (response.choices[0].message.content or "").strip()
+
+
+def fallback_summary(stage_a: dict[str, Any]) -> str:
+    """Deterministic summary used when Groq is unavailable.
+
+    Same numbers, no prose polish — so a failed narration never blocks the
+    report or tempts anyone into letting the LLM supply figures.
+    """
+    lines = [f"# Week of {stage_a['week_start_date']}", "", "## What improved", ""]
+    improved = [
+        (name, data["e1rm_delta_pct_vs_4wk_avg"])
+        for name, data in stage_a["exercises"].items()
+        if data["e1rm_delta_pct_vs_4wk_avg"] is not None and data["e1rm_delta_pct_vs_4wk_avg"] > 0
+    ]
+    if improved:
+        for name, delta in sorted(improved, key=lambda pair: -pair[1]):
+            lines.append(f"- {name}: estimated 1RM {delta:+.1f}% vs the trailing 4-week average.")
+    else:
+        lines.append("- No exercise beat its trailing 4-week average estimated 1RM this week.")
+    totals = stage_a["totals"]
+    lines += [
+        "",
+        f"Volume this week: {totals['volume_this_week_kg']:g} kg across "
+        f"{totals['sets_logged_this_week']} working sets in "
+        f"{totals['exercises_trained_this_week']} exercise(s).",
+        "",
+        "## Next week",
+        "",
+    ]
+    for name, rec in stage_a["recommendations"].items():
+        weight = rec["recommended_weight_kg"]
+        weight_text = f"{weight:g}kg" if weight is not None else "n/a"
+        lines.append(
+            f"- **{name}** — {rec['action'].replace('_', ' ')} at {weight_text} "
+            f"(target {rec['target_reps']} reps). {rec['reason']}"
+        )
+        if rec["pain_safeguard_applied"]:
+            lines.append(
+                f"  - Pain safeguard: hold the load and add one light warm-up set at "
+                f"~{rec['warmup_set_kg']:g}kg. {rec['pain_note']}"
+            )
+    if stage_a["program_note"]["stagnation_flagged"]:
+        lines += ["", "## Program note", "", stage_a["program_note"]["suggestion"]]
+    distribution = stage_a["rep_range_distribution"]
+    lines += [
+        "",
+        "## What you look like you're training for",
+        "",
+        f"Rep-range split across all logged working sets — strength (<=5): "
+        f"{distribution['strength']}, hypertrophy (6-12): {distribution['hypertrophy']}, "
+        f"endurance (>12): {distribution['endurance']}.",
+        f"Volume by muscle group this week: {stage_a['volume_by_muscle_group_kg']}.",
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Database access + orchestration
+# --------------------------------------------------------------------------
+
+
+def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord]:
+    """Load logged sets in [since, until), converting UTC timestamps to local dates."""
+    query = text(
+        """
+        SELECT e.name, e.muscle_group, w.logged_at, w.weight_kg, w.reps,
+               w.is_warmup, w.pain_flag
+        FROM workout_logs w
+        JOIN exercises e ON e.exercise_id = w.exercise_id
+        WHERE w.logged_at >= :since AND w.logged_at < :until
+        ORDER BY w.logged_at
+        """
+    )
+    since_utc = pipeline.local_to_utc(datetime.combine(since, datetime.min.time()))
+    until_utc = pipeline.local_to_utc(datetime.combine(until, datetime.min.time()))
+
+    from zoneinfo import ZoneInfo
+
+    local_zone = ZoneInfo(pipeline.LOCAL_TIMEZONE)
+    with engine.connect() as conn:
+        rows = conn.execute(query, {"since": since_utc, "until": until_utc}).fetchall()
+
+    records = []
+    for name, muscle_group, logged_at, weight_kg, reps, is_warmup, pain_flag in rows:
+        records.append(
+            SetRecord(
+                exercise_name=name,
+                muscle_group=muscle_group,
+                session_date=logged_at.astimezone(local_zone).date(),
+                weight_kg=float(weight_kg) if weight_kg is not None else None,
+                reps=int(reps) if reps is not None else None,
+                is_warmup=bool(is_warmup),
+                pain_flag=bool(pain_flag),
+            )
+        )
+    return records
+
+
+def save_report(
+    engine: Engine,
+    week_start: date,
+    summary_text: str,
+    recommendations: dict[str, Any],
+) -> None:
+    """Upsert on week_start_date so regenerating a week overwrites it."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO weekly_reports (week_start_date, summary_text, recommendations)
+                VALUES (:week_start_date, :summary_text, CAST(:recommendations AS jsonb))
+                ON CONFLICT (week_start_date) DO UPDATE
+                    SET summary_text    = EXCLUDED.summary_text,
+                        recommendations = EXCLUDED.recommendations,
+                        created_at      = now()
+                """
+            ),
+            {
+                "week_start_date": week_start,
+                "summary_text": summary_text,
+                "recommendations": json.dumps(recommendations, default=str),
+            },
+        )
+
+
+def generate_weekly_report(
+    engine: Engine,
+    week_start: Optional[date] = None,
+    client: Any = None,
+    use_llm: bool = True,
+    persist: bool = True,
+) -> dict[str, Any]:
+    """Stage A, then Stage B, then upsert into weekly_reports."""
+    if week_start is None:
+        week_start = week_start_for(date.today())
+    week_start = week_start_for(week_start)
+
+    since = week_start - timedelta(weeks=ANALYSIS_WEEKS)
+    until = week_start + timedelta(days=7)
+    records = load_set_records(engine, since, until)
+
+    stage_a = build_stage_a(records, week_start)
+
+    summary_text = ""
+    narration_error: Optional[str] = None
+    if use_llm:
+        try:
+            summary_text = narrate(stage_a, client=client)
+        except Exception as exc:  # noqa: BLE001 - never lose the report over narration
+            narration_error = str(exc)
+            logger.error("Stage B narration failed, using deterministic summary: %s", exc)
+    if not summary_text:
+        summary_text = fallback_summary(stage_a)
+
+    payload = {
+        "program_note": stage_a["program_note"],
+        "exercises": stage_a["recommendations"],
+        "stage_a": {
+            key: stage_a[key]
+            for key in (
+                "config", "totals", "volume_by_exercise_kg", "volume_by_muscle_group_kg",
+                "rep_range_distribution", "rep_range_distribution_this_week", "exercises",
+            )
+        },
+    }
+
+    if persist:
+        save_report(engine, week_start, summary_text, payload)
+
+    return {
+        "week_start_date": week_start,
+        "summary_text": summary_text,
+        "recommendations": payload,
+        "stage_a": stage_a,
+        "narration_error": narration_error,
+        "record_count": len(records),
+    }

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""CLI entry point: parse a journal text file into Postgres.
+
+    python parse_workout_log.py <file> <date>
+
+`<date>` is the session date in YYYY-MM-DD. All extraction, validation and
+insert logic lives in pipeline.py — this script only handles argument parsing
+and printing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import pipeline
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Parse a free-text gym journal entry into Postgres.",
+    )
+    parser.add_argument("file", type=Path, help="Text file containing the journal entry")
+    parser.add_argument("date", help="Session date, YYYY-MM-DD")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Extract and score without inserting anything",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Debug logging")
+    return parser.parse_args(argv)
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        print(f"Invalid date {value!r} — expected YYYY-MM-DD", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if not args.file.is_file():
+        print(f"No such file: {args.file}", file=sys.stderr)
+        return 2
+
+    session_date = _parse_date(args.date)
+    raw_text = args.file.read_text(encoding="utf-8").strip()
+    if not raw_text:
+        print(f"{args.file} is empty — nothing to parse.", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        payload = pipeline.extract_entities(raw_text, session_date)
+        scored_sets, scored_bodyweight, review = pipeline.validate_extraction(payload, raw_text)
+        print(f"Dry run — nothing inserted. Session date: {session_date}\n")
+        for workout_set, confidence in scored_sets:
+            verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
+            print(
+                f"  [{verdict}] {confidence:.2f}  {workout_set.exercise_name} "
+                f"{workout_set.weight_kg}kg x {workout_set.reps}"
+                + ("  (warmup)" if workout_set.is_warmup else "")
+                + ("  (PAIN)" if workout_set.pain_flag else "")
+            )
+        if scored_bodyweight:
+            entry, confidence = scored_bodyweight
+            verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
+            print(f"  [{verdict}] {confidence:.2f}  bodyweight {entry.weight_kg}kg")
+        for item in review:
+            print(f"  [REVIEW] {item.kind}: {item.reason}")
+        return 0
+
+    result = pipeline.process_entry(raw_text, session_date)
+
+    if result.error:
+        print(f"Error: {result.error}", file=sys.stderr)
+
+    print(f"Session date : {session_date}")
+    print(f"Inserted     : {result.inserted_sets} set(s), "
+          f"{result.inserted_bodyweight} bodyweight entry/entries")
+
+    if result.exercises_created:
+        print(f"New exercises: {', '.join(result.exercises_created)}")
+    for proposed, matched in result.exercises_matched:
+        print(f"Fuzzy match  : {proposed!r} -> existing {matched!r}")
+
+    if result.review_items:
+        print(f"\nNeeds manual review ({len(result.review_items)}) — NOT inserted:")
+        for item in result.review_items:
+            confidence = f"{item.confidence:.2f}" if item.confidence is not None else "n/a"
+            detail = item.payload.get("exercise_name") or item.payload.get("weight_kg") or ""
+            print(f"  - [{item.kind}] confidence={confidence}  {item.reason}"
+                  + (f"  ({detail})" if detail else ""))
+    else:
+        print("\nNothing needing review.")
+
+    return 1 if result.error else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,766 @@
+"""Shared extraction / validation / insert logic for the gym tracker.
+
+Both the CLI (`parse_workout_log.py`) and the web app (`app.py`) import from
+this module. Neither reimplements the Groq call, the confidence heuristic, the
+fuzzy exercise match, or the insert statements.
+
+Pipeline order:
+    raw journal text
+      -> Groq extraction (JSON mode, one retry)
+      -> Pydantic validation
+      -> computed confidence heuristic
+      -> fuzzy exercise-name match against existing `exercises` rows
+      -> rows >= CONFIDENCE_THRESHOLD inserted; the rest returned for review
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta
+from typing import Any, Iterable, Optional, Sequence
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+from rapidfuzz import fuzz
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection, Engine
+
+try:  # Python 3.9+
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python < 3.9 is unsupported anyway
+    ZoneInfo = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+# Entries scoring below this are surfaced for manual review and NOT inserted.
+CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.7"))
+
+# rapidfuzz score (0-100) at or above which a proposed exercise name is treated
+# as the same exercise as an existing row.
+FUZZY_MATCH_THRESHOLD = float(os.getenv("FUZZY_MATCH_THRESHOLD", "85"))
+
+# Groq's Llama chat models (llama-3.3-70b-versatile, llama-3.1-8b-instant) were
+# deprecated for free/developer tiers on 2026-06-17. openai/gpt-oss-120b is the
+# recommended general-purpose replacement. Re-check console.groq.com/docs/models
+# before assuming this is still current.
+GROQ_MODEL = os.getenv("GROQ_MODEL", "openai/gpt-oss-120b")
+
+# Single fixed timezone: this is a single-user personal tool, so local wall-clock
+# time in the journal is always interpreted in this zone and stored as UTC.
+LOCAL_TIMEZONE = os.getenv("LOCAL_TIMEZONE", "UTC")
+
+# Wall-clock time assumed for a session when the text carries no time marker.
+DEFAULT_SESSION_HOUR = int(os.getenv("DEFAULT_SESSION_HOUR", "18"))
+
+# Window used by the /log duplicate-submission guard.
+DUPLICATE_WINDOW_MINUTES = int(os.getenv("DUPLICATE_WINDOW_MINUTES", "5"))
+
+# Tokens that describe equipment or the muscle worked. When the ONLY difference
+# between two multi-word exercise names is tokens from this set, the names are
+# treated as the same exercise ("Barbell Chest Bench Press" == "Chest Bench
+# Press"). Anything outside this set — "incline", "front", "close grip",
+# "romanian" — marks a genuinely different movement and blocks the match. The
+# set is an allowlist so unknown words fail closed, i.e. into a separate row.
+QUALIFIER_TOKENS = frozenset(
+    {
+        "barbell", "dumbbell", "dumbell", "db", "bb", "machine", "cable",
+        "smith", "ez", "bar", "weighted",
+        "chest", "back", "shoulder", "shoulders", "leg", "legs", "arm", "arms",
+        "bicep", "biceps", "tricep", "triceps", "glute", "glutes",
+        "hamstring", "hamstrings", "quad", "quads", "calf", "calves",
+        "lat", "lats", "core", "ab", "abs", "trap", "traps",
+    }
+)
+
+_SYSTEM_PROMPT = """\
+You extract structured training data from messy free-text gym journal entries.
+The text is voice-to-text style: typos, missing punctuation, informal times, and
+personal commentary mixed in with the actual numbers.
+
+Return ONLY a JSON object with exactly this shape:
+
+{
+  "sets": [
+    {
+      "exercise_name": "Chest Bench Press",
+      "weight_kg": 24.0,
+      "reps": 12,
+      "set_number": 2,
+      "is_warmup": false,
+      "is_dropset": false,
+      "pain_flag": false,
+      "notes": "almost died",
+      "logged_at_local": "2026-08-14T18:20:00",
+      "raw_span": "Chest bench press 24kg 12 reps"
+    }
+  ],
+  "bodyweight": null
+}
+
+"bodyweight" is either null or:
+  {"weight_kg": 82.4, "body_fat_pct": null, "notes": null,
+   "logged_at_local": "2026-08-14T07:00:00", "raw_span": "was 82.4kg this morning"}
+
+Rules:
+- One object per SET performed. "3 sets of 10 at 40kg" is three set objects.
+- Normalize exercise names to title case and fix typos:
+  "ches bent prees" -> "Chest Bench Press", "shoulder pres" -> "Shoulder Press".
+  Use the same name for the same movement everywhere in the entry.
+- weight_kg is per-side load as written. "12.5kg each hand" -> 12.5.
+- set_number counts within that exercise, starting at 1, in the order written.
+- is_warmup true when the text says warm up / warmup / "warm up ish" / similar.
+- is_dropset true only when a drop set is explicitly described.
+- pain_flag true on ANY mention of pain, discomfort, injury, tweak, strain,
+  soreness that reads as a problem, or "felt something". Apply it to the set(s)
+  the mention relates to; if it is not tied to a specific set, apply it to every
+  set of the exercise it names.
+- logged_at_local: combine SESSION_DATE (given below) with any time marker in
+  the text ("6:20ish" -> 18:20 if the session reads as an evening workout,
+  06:20 if morning). Format "YYYY-MM-DDTHH:MM:SS", no timezone. If no time
+  marker applies to a set, use null.
+- raw_span: the exact substring of the input this set was read from. Copy it
+  verbatim; do not paraphrase. This is used to verify the extraction.
+- NEVER invent data. If a weight, rep count, or exercise name is not in the
+  text, use null. Do not guess a plausible value. Missing fields are handled
+  downstream; fabricated ones are not.
+- Do not report a confidence score. Confidence is computed separately.
+"""
+
+
+# --------------------------------------------------------------------------
+# Pydantic models
+# --------------------------------------------------------------------------
+
+
+class WorkoutSet(BaseModel):
+    """One performed set, mirroring the `workout_logs` columns."""
+
+    exercise_name: str = Field(min_length=1, max_length=120)
+    weight_kg: Optional[float] = Field(default=None, ge=0, le=1000)
+    reps: Optional[int] = Field(default=None, gt=0, le=1000)
+    set_number: Optional[int] = Field(default=None, gt=0, le=100)
+    is_warmup: bool = False
+    is_dropset: bool = False
+    pain_flag: bool = False
+    notes: Optional[str] = None
+    logged_at_local: Optional[str] = None
+    raw_span: Optional[str] = None
+    muscle_group: Optional[str] = None
+
+    @field_validator("exercise_name")
+    @classmethod
+    def _clean_name(cls, value: str) -> str:
+        cleaned = re.sub(r"\s+", " ", value).strip()
+        if not cleaned:
+            raise ValueError("exercise_name must not be blank")
+        return cleaned
+
+
+class BodyweightEntry(BaseModel):
+    """A bodyweight mention, mirroring the `bodyweight_logs` columns."""
+
+    weight_kg: float = Field(gt=0, le=500)
+    body_fat_pct: Optional[float] = Field(default=None, ge=0, le=100)
+    notes: Optional[str] = None
+    logged_at_local: Optional[str] = None
+    raw_span: Optional[str] = None
+
+
+@dataclass
+class ReviewItem:
+    """An extraction that did not clear CONFIDENCE_THRESHOLD, or failed validation."""
+
+    kind: str  # "workout_set" | "bodyweight" | "extraction"
+    reason: str
+    confidence: Optional[float]
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PipelineResult:
+    inserted_sets: int = 0
+    inserted_bodyweight: int = 0
+    review_items: list[ReviewItem] = field(default_factory=list)
+    exercises_created: list[str] = field(default_factory=list)
+    exercises_matched: list[tuple[str, str]] = field(default_factory=list)
+    duplicate_of_recent: bool = False
+    error: Optional[str] = None
+
+    @property
+    def total_inserted(self) -> int:
+        return self.inserted_sets + self.inserted_bodyweight
+
+
+# --------------------------------------------------------------------------
+# Pure helpers (no network, no database — these are what the unit tests cover)
+# --------------------------------------------------------------------------
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase, drop punctuation, collapse whitespace."""
+    lowered = re.sub(r"[^a-z0-9 ]", " ", (name or "").lower().strip())
+    return re.sub(r"\s+", " ", lowered).strip()
+
+
+def name_match_score(proposed: str, existing: str) -> float:
+    """Similarity (0-100) between two exercise names.
+
+    Base metric is `token_sort_ratio`, which is insensitive to word order but
+    still penalizes extra words — so "Chest Bench Press" and "Bench Press
+    (Chest)" score 100, while "Bench Press" and "Incline Bench Press" score 73.
+
+    A subset bonus lifts the score to `token_set_ratio` only when one name's
+    tokens are a strict subset of the other's AND every extra token is a known
+    equipment/muscle qualifier. That merges "Barbell Chest Bench Press" into
+    "Chest Bench Press" without merging "Squat" into "Front Squat". Both names
+    must have at least two tokens, so "Curl" never absorbs "Leg Curl".
+    """
+    left, right = normalize_name(proposed), normalize_name(existing)
+    if not left or not right:
+        return 0.0
+
+    score = float(fuzz.token_sort_ratio(left, right))
+
+    left_tokens, right_tokens = set(left.split()), set(right.split())
+    is_strict_subset = left_tokens < right_tokens or right_tokens < left_tokens
+    if (
+        left_tokens != right_tokens
+        and is_strict_subset
+        and len(left_tokens) >= 2
+        and len(right_tokens) >= 2
+        and (left_tokens ^ right_tokens) <= QUALIFIER_TOKENS
+    ):
+        score = max(score, float(fuzz.token_set_ratio(left, right)))
+
+    return score
+
+
+def find_matching_exercise(
+    proposed: str,
+    existing_names: Iterable[str],
+    threshold: float = FUZZY_MATCH_THRESHOLD,
+) -> Optional[str]:
+    """Return the best existing name at/above `threshold`, else None."""
+    best_name: Optional[str] = None
+    best_score = 0.0
+    for candidate in existing_names:
+        score = name_match_score(proposed, candidate)
+        if score > best_score:
+            best_name, best_score = candidate, score
+    return best_name if best_score >= threshold else None
+
+
+def compute_confidence(
+    exercise_name: Optional[str],
+    weight_kg: Optional[float],
+    reps: Optional[int],
+    raw_span: Optional[str],
+    raw_text: str,
+    validation_ok: bool = True,
+) -> float:
+    """Confidence from checkable signals only — never self-reported by the LLM.
+
+    Signals:
+      * Pydantic validation succeeded.
+      * Required fields (exercise name, weight, reps) came back non-null.
+      * String similarity between the normalized exercise name and the raw text
+        span it was supposedly read from — the grounding check that catches a
+        name the model invented rather than read.
+    """
+    if not validation_ok:
+        return 0.0
+    if not exercise_name or not exercise_name.strip():
+        return 0.0
+
+    score = 1.0
+    if weight_kg is None:
+        score -= 0.35
+    if reps is None:
+        score -= 0.35
+
+    span = (raw_span or "").strip()
+    if span:
+        haystack = span
+    else:
+        # No span to check against: fall back to the whole entry, and penalize,
+        # because grounding is that much weaker.
+        haystack = raw_text or ""
+        score -= 0.2
+
+    similarity = _grounding_similarity(exercise_name, haystack)
+    if similarity < 0.5:
+        score -= 0.35
+    elif similarity < 0.8:
+        score -= 0.15
+
+    return round(max(0.0, min(1.0, score)), 3)
+
+
+def _grounding_similarity(exercise_name: str, haystack: str) -> float:
+    """How strongly `exercise_name` is supported by the text it came from (0-1)."""
+    name, text_norm = normalize_name(exercise_name), normalize_name(haystack)
+    if not name or not text_norm:
+        return 0.0
+    return max(
+        fuzz.partial_ratio(name, text_norm),
+        fuzz.token_set_ratio(name, text_norm),
+    ) / 100.0
+
+
+def local_to_utc(local_dt: datetime, timezone_name: str = LOCAL_TIMEZONE) -> datetime:
+    """Attach the fixed local timezone to a naive datetime and convert to UTC."""
+    from datetime import timezone as _tz
+
+    if ZoneInfo is None:  # pragma: no cover
+        raise RuntimeError("zoneinfo unavailable; Python 3.9+ required")
+    tz = ZoneInfo(timezone_name)
+    aware = local_dt.replace(tzinfo=tz) if local_dt.tzinfo is None else local_dt
+    return aware.astimezone(_tz.utc)
+
+
+def resolve_logged_at(
+    logged_at_local: Optional[str],
+    session_date: date,
+    timezone_name: str = LOCAL_TIMEZONE,
+    default_hour: int = DEFAULT_SESSION_HOUR,
+) -> datetime:
+    """Turn the model's local-time guess into a UTC timestamp.
+
+    The model's value is only trusted when it parses AND lands on the session
+    date the user supplied. Anything else falls back to the session date at
+    `default_hour` — the model does not get to move a workout to another day.
+    """
+    if logged_at_local:
+        parsed: Optional[datetime] = None
+        candidate = logged_at_local.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%H:%M:%S", "%H:%M"):
+                try:
+                    parsed = datetime.strptime(logged_at_local.strip(), fmt)
+                    break
+                except ValueError:
+                    continue
+        if parsed is not None:
+            if parsed.year == 1900:  # time-only format
+                parsed = datetime.combine(session_date, parsed.time())
+            if parsed.tzinfo is not None:
+                parsed = parsed.replace(tzinfo=None)
+            if parsed.date() == session_date:
+                return local_to_utc(parsed, timezone_name)
+            logger.warning(
+                "Discarding extracted timestamp %s: not on session date %s",
+                logged_at_local,
+                session_date,
+            )
+
+    return local_to_utc(datetime.combine(session_date, time(hour=default_hour)), timezone_name)
+
+
+# --------------------------------------------------------------------------
+# Extraction (Groq)
+# --------------------------------------------------------------------------
+
+
+class ExtractionError(RuntimeError):
+    """Raised when extraction fails after the retry."""
+
+
+def _build_messages(raw_text: str, session_date: date) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": f"SESSION_DATE: {session_date.isoformat()}\n\nJOURNAL ENTRY:\n{raw_text}",
+        },
+    ]
+
+
+def extract_entities(
+    raw_text: str,
+    session_date: date,
+    client: Any = None,
+    model: str = GROQ_MODEL,
+) -> dict[str, Any]:
+    """Call Groq in JSON mode and return the parsed object.
+
+    JSON mode (`response_format={"type": "json_object"}`) is used rather than
+    trusting the prompt to produce valid JSON. One retry is attempted on an API
+    error or a parse failure; after that the caller routes the entry to review.
+    """
+    if client is None:
+        client = get_groq_client()
+
+    last_error: Optional[Exception] = None
+    for attempt in (1, 2):
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=_build_messages(raw_text, session_date),
+                response_format={"type": "json_object"},
+                temperature=0,
+            )
+            content = response.choices[0].message.content
+            payload = json.loads(content)
+            if not isinstance(payload, dict):
+                raise ValueError(f"expected a JSON object, got {type(payload).__name__}")
+            return payload
+        except Exception as exc:  # noqa: BLE001 - retry once on anything
+            last_error = exc
+            logger.warning("Extraction attempt %d/2 failed: %s", attempt, exc)
+
+    raise ExtractionError(f"extraction failed after retry: {last_error}")
+
+
+def get_groq_client() -> Any:
+    """Build a Groq client from GROQ_API_KEY (env var only, never hardcoded)."""
+    from groq import Groq
+
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY is not set")
+    return Groq(api_key=api_key)
+
+
+def validate_extraction(
+    payload: dict[str, Any],
+    raw_text: str,
+) -> tuple[list[tuple[WorkoutSet, float]], Optional[tuple[BodyweightEntry, float]], list[ReviewItem]]:
+    """Validate the raw extraction into models plus computed confidences."""
+    scored_sets: list[tuple[WorkoutSet, float]] = []
+    review: list[ReviewItem] = []
+
+    raw_sets = payload.get("sets") or []
+    if not isinstance(raw_sets, list):
+        review.append(
+            ReviewItem("extraction", "'sets' was not a list", None, {"sets": str(raw_sets)[:500]})
+        )
+        raw_sets = []
+
+    for index, item in enumerate(raw_sets):
+        if not isinstance(item, dict):
+            review.append(ReviewItem("workout_set", f"set {index} was not an object", 0.0,
+                                     {"raw": str(item)[:500]}))
+            continue
+        try:
+            workout_set = WorkoutSet.model_validate(item)
+        except ValidationError as exc:
+            review.append(
+                ReviewItem(
+                    "workout_set",
+                    f"failed validation: {_short_errors(exc)}",
+                    compute_confidence(None, None, None, None, raw_text, validation_ok=False),
+                    item,
+                )
+            )
+            continue
+
+        confidence = compute_confidence(
+            workout_set.exercise_name,
+            workout_set.weight_kg,
+            workout_set.reps,
+            workout_set.raw_span,
+            raw_text,
+        )
+        scored_sets.append((workout_set, confidence))
+
+    scored_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
+    raw_bodyweight = payload.get("bodyweight")
+    if isinstance(raw_bodyweight, dict):
+        try:
+            entry = BodyweightEntry.model_validate(raw_bodyweight)
+        except ValidationError as exc:
+            review.append(
+                ReviewItem("bodyweight", f"failed validation: {_short_errors(exc)}", 0.0, raw_bodyweight)
+            )
+        else:
+            scored_bodyweight = (entry, compute_bodyweight_confidence(entry, raw_text))
+    elif raw_bodyweight not in (None, ""):
+        review.append(
+            ReviewItem("bodyweight", "'bodyweight' was neither null nor an object", 0.0,
+                       {"raw": str(raw_bodyweight)[:500]})
+        )
+
+    return scored_sets, scored_bodyweight, review
+
+
+def _normalize_numeric_text(value: str) -> str:
+    """Lowercase and collapse whitespace while KEEPING digits and decimal points.
+
+    `normalize_name` strips punctuation, which would turn "82.4kg" into "82 4kg"
+    and make a correct reading look ungrounded. Number checks use this instead.
+    """
+    return re.sub(r"\s+", " ", (value or "").lower()).strip()
+
+
+def _number_appears_in(number: float, haystack: str) -> bool:
+    """True when `number` occurs in `haystack` as a standalone figure.
+
+    Digit boundaries stop "82" from matching inside "182.5".
+    """
+    candidates = {f"{number:g}", f"{number:.1f}"}
+    if float(number).is_integer():
+        candidates.add(str(int(number)))
+    return any(
+        re.search(rf"(?<!\d){re.escape(token)}(?!\d)", haystack) for token in candidates if token
+    )
+
+
+def compute_bodyweight_confidence(entry: BodyweightEntry, raw_text: str) -> float:
+    """Confidence for a bodyweight reading: does its number appear in the text?"""
+    haystack = _normalize_numeric_text(entry.raw_span or raw_text)
+    score = 1.0
+    if not (entry.raw_span or "").strip():
+        score -= 0.2
+    # The weight itself must be traceable to the source text.
+    if not _number_appears_in(float(entry.weight_kg), haystack):
+        score -= 0.5
+    return round(max(0.0, min(1.0, score)), 3)
+
+
+def _short_errors(exc: ValidationError) -> str:
+    parts = [f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()[:3]]
+    return "; ".join(parts)
+
+
+# --------------------------------------------------------------------------
+# Database
+# --------------------------------------------------------------------------
+
+
+def get_engine(database_url: Optional[str] = None) -> Engine:
+    url = database_url or os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL is not set")
+    # Free-tier Postgres drops idle connections; pre-ping avoids stale-handle errors.
+    return create_engine(url, pool_pre_ping=True, future=True)
+
+
+def load_exercise_names(conn: Connection) -> dict[str, int]:
+    rows = conn.execute(text("SELECT name, exercise_id FROM exercises")).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def get_or_create_exercise(
+    conn: Connection,
+    proposed_name: str,
+    muscle_group: Optional[str],
+    known: dict[str, int],
+) -> tuple[int, Optional[str], bool]:
+    """Resolve an exercise name to an id, fuzzy-matching before inserting.
+
+    Returns (exercise_id, matched_existing_name_or_None, created).
+    """
+    matched = find_matching_exercise(proposed_name, known.keys())
+    if matched is not None:
+        return known[matched], matched, False
+
+    row = conn.execute(
+        text(
+            """
+            INSERT INTO exercises (name, muscle_group)
+            VALUES (:name, :muscle_group)
+            ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+            RETURNING exercise_id
+            """
+        ),
+        {"name": proposed_name, "muscle_group": muscle_group},
+    ).fetchone()
+    exercise_id = int(row[0])
+    known[proposed_name] = exercise_id
+    return exercise_id, None, True
+
+
+_INSERT_WORKOUT_SET = text(
+    """
+    INSERT INTO workout_logs (
+        exercise_id, logged_at, weight_kg, reps, set_number,
+        is_warmup, is_dropset, pain_flag, notes, raw_source, extraction_confidence
+    ) VALUES (
+        :exercise_id, :logged_at, :weight_kg, :reps, :set_number,
+        :is_warmup, :is_dropset, :pain_flag, :notes, :raw_source, :extraction_confidence
+    )
+    """
+)
+
+_INSERT_BODYWEIGHT = text(
+    """
+    INSERT INTO bodyweight_logs (
+        logged_at, weight_kg, body_fat_pct, notes, raw_source, extraction_confidence
+    ) VALUES (
+        :logged_at, :weight_kg, :body_fat_pct, :notes, :raw_source, :extraction_confidence
+    )
+    """
+)
+
+
+def find_recent_submission(
+    engine: Engine,
+    raw_text: str,
+    window_minutes: int = DUPLICATE_WINDOW_MINUTES,
+) -> Optional[dict[str, int]]:
+    """Return counts for an identical entry inserted within the window, else None.
+
+    Backs the /log duplicate-submission guard: Render's free tier cold-starts for
+    30-50s, which is exactly when a user double-taps submit.
+    """
+    with engine.connect() as conn:
+        params = {"raw_source": raw_text, "window": f"{int(window_minutes)} minutes"}
+        sets = conn.execute(
+            text(
+                """
+                SELECT count(*) FROM workout_logs
+                WHERE raw_source = :raw_source
+                  AND created_at >= now() - CAST(:window AS interval)
+                """
+            ),
+            params,
+        ).scalar_one()
+        bodyweight = conn.execute(
+            text(
+                """
+                SELECT count(*) FROM bodyweight_logs
+                WHERE raw_source = :raw_source
+                  AND created_at >= now() - CAST(:window AS interval)
+                """
+            ),
+            params,
+        ).scalar_one()
+
+    if not sets and not bodyweight:
+        return None
+    return {"inserted_sets": int(sets), "inserted_bodyweight": int(bodyweight)}
+
+
+# --------------------------------------------------------------------------
+# Orchestration
+# --------------------------------------------------------------------------
+
+
+def process_entry(
+    raw_text: str,
+    session_date: date,
+    engine: Optional[Engine] = None,
+    client: Any = None,
+    check_duplicates: bool = False,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> PipelineResult:
+    """Run the full pipeline for one journal entry.
+
+    Called by both the CLI and the web app. `check_duplicates` is enabled by the
+    web app, where a double-tapped submit is a real risk.
+    """
+    raw_text = (raw_text or "").strip()
+    if not raw_text:
+        return PipelineResult(error="Empty entry — nothing to parse.")
+
+    if engine is None:
+        engine = get_engine()
+
+    if check_duplicates:
+        prior = find_recent_submission(engine, raw_text)
+        if prior is not None:
+            logger.info("Duplicate submission suppressed (%s)", prior)
+            return PipelineResult(
+                inserted_sets=prior["inserted_sets"],
+                inserted_bodyweight=prior["inserted_bodyweight"],
+                duplicate_of_recent=True,
+            )
+
+    try:
+        payload = extract_entities(raw_text, session_date, client=client)
+    except ExtractionError as exc:
+        logger.error("Extraction failed: %s", exc)
+        return PipelineResult(
+            error="Extraction failed after one retry — entry not inserted.",
+            review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
+        )
+
+    scored_sets, scored_bodyweight, review = validate_extraction(payload, raw_text)
+    result = PipelineResult(review_items=list(review))
+
+    accepted_sets = []
+    for workout_set, confidence in scored_sets:
+        if confidence < confidence_threshold:
+            result.review_items.append(
+                ReviewItem(
+                    "workout_set",
+                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
+                    confidence,
+                    workout_set.model_dump(),
+                )
+            )
+        else:
+            accepted_sets.append((workout_set, confidence))
+
+    accepted_bodyweight = None
+    if scored_bodyweight is not None:
+        entry, confidence = scored_bodyweight
+        if confidence < confidence_threshold:
+            result.review_items.append(
+                ReviewItem(
+                    "bodyweight",
+                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
+                    confidence,
+                    entry.model_dump(),
+                )
+            )
+        else:
+            accepted_bodyweight = (entry, confidence)
+
+    if not accepted_sets and accepted_bodyweight is None:
+        return result
+
+    with engine.begin() as conn:
+        known = load_exercise_names(conn)
+        for workout_set, confidence in accepted_sets:
+            exercise_id, matched_name, created = get_or_create_exercise(
+                conn, workout_set.exercise_name, workout_set.muscle_group, known
+            )
+            if created:
+                result.exercises_created.append(workout_set.exercise_name)
+            elif matched_name and matched_name != workout_set.exercise_name:
+                result.exercises_matched.append((workout_set.exercise_name, matched_name))
+
+            conn.execute(
+                _INSERT_WORKOUT_SET,
+                {
+                    "exercise_id": exercise_id,
+                    "logged_at": resolve_logged_at(workout_set.logged_at_local, session_date),
+                    "weight_kg": workout_set.weight_kg,
+                    "reps": workout_set.reps,
+                    "set_number": workout_set.set_number,
+                    "is_warmup": workout_set.is_warmup,
+                    "is_dropset": workout_set.is_dropset,
+                    "pain_flag": workout_set.pain_flag,
+                    "notes": workout_set.notes,
+                    "raw_source": raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_sets += 1
+
+        if accepted_bodyweight is not None:
+            entry, confidence = accepted_bodyweight
+            conn.execute(
+                _INSERT_BODYWEIGHT,
+                {
+                    "logged_at": resolve_logged_at(entry.logged_at_local, session_date),
+                    "weight_kg": entry.weight_kg,
+                    "body_fat_pct": entry.body_fat_pct,
+                    "notes": entry.notes,
+                    "raw_source": raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_bodyweight += 1
+
+    return result

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+# Render free-tier blueprint. Secrets are set in the dashboard, never here.
+services:
+  - type: web
+    name: gym-tracker
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
+    envVars:
+      - key: GROQ_API_KEY
+        sync: false
+      - key: DATABASE_URL
+        sync: false
+      - key: APP_USERNAME
+        sync: false
+      - key: APP_PASSWORD
+        sync: false
+      - key: GROQ_MODEL
+        value: openai/gpt-oss-120b
+      - key: LOCAL_TIMEZONE
+        value: UTC
+      - key: PAIN_SAFEGUARD_ENABLED
+        value: "true"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+groq>=0.11.0
+pydantic>=2.7
+sqlalchemy>=2.0
+psycopg2-binary>=2.9
+fastapi>=0.111
+uvicorn[standard]>=0.30
+python-multipart>=0.0.9
+rapidfuzz>=3.9

--- a/sample_entry.txt
+++ b/sample_entry.txt
@@ -1,0 +1,5 @@
+Chest bench press 20kg 12 reps warm up. Chest bench press 24kg 12 reps. Chest
+bench press 28kg 11 reps almost died. 6:20ish Dumbbell bench press 12.5kg each
+hand 11 reps warm up ish. Dumbell bench press 15kg each hand 10 reps. Dumbbell
+bench press 15kg each hand 9 reps. Shoulder pain noticed toward the end. Was
+82.4kg this morning btw. Finished with some cable flys, forgot the weight.

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,88 @@
+-- Gym Tracker schema (Postgres / Supabase free tier)
+--
+-- Design notes:
+--   * All `logged_at` columns are timestamptz. The application converts local
+--     wall-clock time (LOCAL_TIMEZONE env var) to UTC at insert time. This is a
+--     single-user personal tool, so one fixed timezone is assumed throughout.
+--   * `raw_source` keeps the original journal text for every row so any parse
+--     can be audited or re-run later.
+--   * `extraction_confidence` is computed by the pipeline from checkable
+--     signals (see pipeline.compute_confidence). It is never self-reported by
+--     the LLM. Rows below CONFIDENCE_THRESHOLD are not inserted at all, so in
+--     practice stored values are >= that threshold.
+--   * Schema is shaped for direct Power BI consumption: narrow fact tables
+--     (workout_logs, bodyweight_logs), one dimension table (exercises), and a
+--     precomputed report table (weekly_reports).
+--
+-- Safe to re-run: every object is created IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS exercises (
+    exercise_id  SERIAL PRIMARY KEY,
+    name         TEXT NOT NULL UNIQUE,
+    muscle_group TEXT
+);
+
+CREATE TABLE IF NOT EXISTS workout_logs (
+    log_id                BIGSERIAL PRIMARY KEY,
+    exercise_id           INTEGER NOT NULL REFERENCES exercises (exercise_id),
+    logged_at             TIMESTAMPTZ NOT NULL,
+    weight_kg             NUMERIC(6, 2),
+    reps                  INTEGER,
+    set_number            INTEGER,
+    is_warmup             BOOLEAN NOT NULL DEFAULT FALSE,
+    is_dropset            BOOLEAN NOT NULL DEFAULT FALSE,
+    pain_flag             BOOLEAN NOT NULL DEFAULT FALSE,
+    notes                 TEXT,
+    raw_source            TEXT,
+    extraction_confidence NUMERIC(4, 3),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT workout_logs_weight_nonneg CHECK (weight_kg IS NULL OR weight_kg >= 0),
+    CONSTRAINT workout_logs_reps_positive CHECK (reps IS NULL OR reps > 0),
+    CONSTRAINT workout_logs_confidence_range
+        CHECK (extraction_confidence IS NULL
+               OR (extraction_confidence >= 0 AND extraction_confidence <= 1))
+);
+
+CREATE TABLE IF NOT EXISTS bodyweight_logs (
+    log_id                BIGSERIAL PRIMARY KEY,
+    logged_at             TIMESTAMPTZ NOT NULL,
+    weight_kg             NUMERIC(5, 2) NOT NULL,
+    body_fat_pct          NUMERIC(4, 1),
+    notes                 TEXT,
+    raw_source            TEXT,
+    extraction_confidence NUMERIC(4, 3),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT bodyweight_logs_weight_positive CHECK (weight_kg > 0),
+    CONSTRAINT bodyweight_logs_bf_range
+        CHECK (body_fat_pct IS NULL OR (body_fat_pct >= 0 AND body_fat_pct <= 100)),
+    CONSTRAINT bodyweight_logs_confidence_range
+        CHECK (extraction_confidence IS NULL
+               OR (extraction_confidence >= 0 AND extraction_confidence <= 1))
+);
+
+-- week_start_date is UNIQUE so regenerating a report for an already-computed
+-- week is an upsert (ON CONFLICT ... DO UPDATE), never a duplicate row.
+CREATE TABLE IF NOT EXISTS weekly_reports (
+    report_id       SERIAL PRIMARY KEY,
+    week_start_date DATE NOT NULL UNIQUE,
+    summary_text    TEXT,
+    recommendations JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Progress queries are always "this exercise, over time".
+CREATE INDEX IF NOT EXISTS idx_workout_logs_exercise_logged_at
+    ON workout_logs (exercise_id, logged_at);
+
+-- Bodyweight trend is a straight time series.
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_logged_at
+    ON bodyweight_logs (logged_at);
+
+-- Supports the /log duplicate-submission guard, which looks up recent rows by
+-- their originating journal text.
+CREATE INDEX IF NOT EXISTS idx_workout_logs_created_at
+    ON workout_logs (created_at);
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_created_at
+    ON bodyweight_logs (created_at);

--- a/seed_sample_data.py
+++ b/seed_sample_data.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Seed a few weeks of realistic sample data so the weekly report can be tried out.
+
+    python seed_sample_data.py            # seed
+    python seed_sample_data.py --reset    # wipe logs first, then seed
+
+The generated pattern deliberately exercises every recommendation branch:
+  Chest Bench Press  - progressing, tops out the rep range  -> increase
+  Dumbbell Bench Press - flat e1RM for 3 sessions           -> deload or swap
+  Lat Pulldown       - flat, and carries a recent pain flag -> hold (pain safeguard)
+  Barbell Row        - flat                                 -> deload or swap
+  Leg Press          - flat                                 -> deload or swap
+With 5 regularly-trained exercises and 4 of them plateaued (80% >= 60%), this
+also trips the program-level stagnation flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime, time, timedelta
+
+from sqlalchemy import text
+
+import insights
+import pipeline
+
+# (exercise, muscle_group, warmup_kg, [(weight, [reps...]) per session], pain_on_sessions)
+PLAN = [
+    ("Chest Bench Press", "Chest", 20.0,
+     [(24.0, [10, 9, 8]), (24.0, [11, 10, 10]), (24.0, [12, 12, 12])], set()),
+    ("Dumbbell Bench Press", "Chest", 10.0,
+     [(15.0, [10, 9, 8]), (15.0, [10, 9, 8]), (15.0, [10, 9, 8])], set()),
+    ("Lat Pulldown", "Back", 25.0,
+     [(45.0, [10, 10, 9]), (45.0, [10, 9, 9]), (45.0, [10, 9, 9])], {2}),
+    ("Barbell Row", "Back", 30.0,
+     [(50.0, [9, 8, 8]), (50.0, [9, 8, 8]), (50.0, [9, 8, 8])], set()),
+    ("Leg Press", "Legs", 60.0,
+     [(120.0, [10, 10, 9]), (120.0, [10, 9, 9]), (120.0, [10, 9, 9])], set()),
+]
+
+BODYWEIGHTS = [83.1, 82.8, 82.4]
+
+
+def seed(engine, week_start: date) -> None:
+    # Sessions land in the three weeks ending with `week_start`'s week.
+    session_days = [week_start - timedelta(weeks=2), week_start - timedelta(weeks=1), week_start]
+
+    with engine.begin() as conn:
+        known = pipeline.load_exercise_names(conn)
+
+        for name, muscle_group, warmup_kg, sessions, pain_sessions in PLAN:
+            exercise_id, _, _ = pipeline.get_or_create_exercise(conn, name, muscle_group, known)
+            # Backfill the muscle group when the row already existed without one.
+            conn.execute(
+                text("UPDATE exercises SET muscle_group = :mg WHERE exercise_id = :id "
+                     "AND muscle_group IS NULL"),
+                {"mg": muscle_group, "id": exercise_id},
+            )
+
+            for index, (weight, reps_list) in enumerate(sessions):
+                day = session_days[index]
+                logged_at = pipeline.local_to_utc(datetime.combine(day, time(hour=18)))
+                pain = index in pain_sessions
+                raw = f"[seed] {name} session {index + 1} on {day.isoformat()}"
+
+                rows = [
+                    {
+                        "exercise_id": exercise_id, "logged_at": logged_at,
+                        "weight_kg": warmup_kg, "reps": 12, "set_number": 1,
+                        "is_warmup": True, "is_dropset": False, "pain_flag": False,
+                        "notes": "warm up", "raw_source": raw, "extraction_confidence": 1.0,
+                    }
+                ]
+                for set_number, reps in enumerate(reps_list, start=2):
+                    rows.append({
+                        "exercise_id": exercise_id, "logged_at": logged_at,
+                        "weight_kg": weight, "reps": reps, "set_number": set_number,
+                        "is_warmup": False, "is_dropset": False, "pain_flag": pain,
+                        "notes": "shoulder discomfort noted" if pain else None,
+                        "raw_source": raw, "extraction_confidence": 1.0,
+                    })
+                for row in rows:
+                    conn.execute(pipeline._INSERT_WORKOUT_SET, row)
+
+        for index, weight in enumerate(BODYWEIGHTS):
+            day = session_days[index]
+            conn.execute(
+                pipeline._INSERT_BODYWEIGHT,
+                {
+                    "logged_at": pipeline.local_to_utc(datetime.combine(day, time(hour=7))),
+                    "weight_kg": weight, "body_fat_pct": None, "notes": None,
+                    "raw_source": f"[seed] bodyweight {day.isoformat()}",
+                    "extraction_confidence": 1.0,
+                },
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reset", action="store_true",
+                        help="Delete all workout/bodyweight/report rows first")
+    parser.add_argument("--week-start", help="Monday of the most recent seeded week (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    engine = pipeline.get_engine()
+    if args.reset:
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM workout_logs"))
+            conn.execute(text("DELETE FROM bodyweight_logs"))
+            conn.execute(text("DELETE FROM weekly_reports"))
+        print("Cleared workout_logs, bodyweight_logs and weekly_reports.")
+
+    week_start = (
+        datetime.strptime(args.week_start, "%Y-%m-%d").date()
+        if args.week_start
+        else insights.week_start_for(date.today())
+    )
+    seed(engine, insights.week_start_for(week_start))
+    print(f"Seeded 3 weeks of sample data ending the week of "
+          f"{insights.week_start_for(week_start).isoformat()}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,576 @@
+"""Unit tests for Stage A — the pure functions that produce every report number.
+
+These are exactly the functions where a silent bug would emit a wrong training
+recommendation without anyone noticing, so each rule branch is covered.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+import insights
+from insights import (
+    Recommendation,
+    SetRecord,
+    deload_load,
+    detect_plateau,
+    detect_program_stagnation,
+    e1rm_series,
+    epley_1rm,
+    find_regularly_trained,
+    next_load,
+    rep_range_distribution,
+    recommend_for_exercise,
+    round_to_increment,
+    total_volume,
+    trailing_pain_streak,
+    volume_by_muscle_group,
+    warmup_load,
+    week_start_for,
+)
+
+MONDAY = date(2026, 8, 3)  # a Monday
+
+
+def make_session(
+    day: date,
+    weight: float,
+    reps_per_set: list[int],
+    *,
+    exercise: str = "Bench Press",
+    pain: bool = False,
+    warmup_reps: int | None = None,
+    muscle_group: str = "Chest",
+) -> list[SetRecord]:
+    records: list[SetRecord] = []
+    if warmup_reps is not None:
+        records.append(
+            SetRecord(exercise, day, weight * 0.5, warmup_reps, is_warmup=True,
+                      muscle_group=muscle_group)
+        )
+    for reps in reps_per_set:
+        records.append(
+            SetRecord(exercise, day, weight, reps, pain_flag=pain, muscle_group=muscle_group)
+        )
+    return records
+
+
+# --------------------------------------------------------------------------
+# Epley 1RM
+# --------------------------------------------------------------------------
+
+
+class TestEpley:
+    def test_known_value(self):
+        # 100kg x 10 -> 100 * (1 + 10/30) = 133.33
+        assert epley_1rm(100, 10) == pytest.approx(133.333, abs=0.001)
+
+    def test_single_rep_equals_weight(self):
+        assert epley_1rm(80, 1) == pytest.approx(80 * (1 + 1 / 30))
+
+    @pytest.mark.parametrize(
+        "weight,reps",
+        [(None, 10), (100, None), (None, None), (0, 10), (100, 0), (-5, 10), (100, -3)],
+    )
+    def test_missing_or_nonpositive_returns_none(self, weight, reps):
+        assert epley_1rm(weight, reps) is None
+
+    def test_more_reps_at_same_weight_scores_higher(self):
+        assert epley_1rm(60, 12) > epley_1rm(60, 8)
+
+
+# --------------------------------------------------------------------------
+# Plateau detection
+# --------------------------------------------------------------------------
+
+
+class TestPlateauDetection:
+    def test_flat_three_sessions_is_plateau(self):
+        series = [(MONDAY, 100.0), (MONDAY + timedelta(3), 100.0), (MONDAY + timedelta(7), 100.0)]
+        assert detect_plateau(series) is True
+
+    def test_declining_is_plateau(self):
+        series = [(MONDAY, 100.0), (MONDAY + timedelta(3), 98.0), (MONDAY + timedelta(7), 95.0)]
+        assert detect_plateau(series) is True
+
+    def test_clear_progress_is_not_plateau(self):
+        series = [(MONDAY, 100.0), (MONDAY + timedelta(3), 105.0), (MONDAY + timedelta(7), 110.0)]
+        assert detect_plateau(series) is False
+
+    def test_progress_only_in_the_middle_is_not_plateau(self):
+        # A real gain happened within the window, even though it regressed after.
+        series = [(MONDAY, 100.0), (MONDAY + timedelta(3), 108.0), (MONDAY + timedelta(7), 101.0)]
+        assert detect_plateau(series) is False
+
+    def test_two_sessions_is_not_enough(self):
+        assert detect_plateau([(MONDAY, 100.0), (MONDAY + timedelta(3), 100.0)]) is False
+
+    def test_empty_series(self):
+        assert detect_plateau([]) is False
+
+    def test_sub_tolerance_drift_still_counts_as_flat(self):
+        # +0.5% over the window is noise, not progress.
+        series = [(MONDAY, 100.0), (MONDAY + timedelta(3), 100.2), (MONDAY + timedelta(7), 100.5)]
+        assert detect_plateau(series, tolerance=0.01) is True
+
+    def test_only_the_trailing_window_matters(self):
+        # Old progress does not rescue three flat sessions at the end.
+        series = [
+            (MONDAY - timedelta(14), 80.0),
+            (MONDAY - timedelta(7), 95.0),
+            (MONDAY, 100.0),
+            (MONDAY + timedelta(3), 100.0),
+            (MONDAY + timedelta(7), 100.0),
+        ]
+        assert detect_plateau(series) is True
+
+    def test_e1rm_series_skips_sessions_without_working_sets(self):
+        sessions = {
+            MONDAY: [SetRecord("Bench Press", MONDAY, 40, 10, is_warmup=True)],
+            MONDAY + timedelta(3): [SetRecord("Bench Press", MONDAY + timedelta(3), 80, 8)],
+        }
+        series = e1rm_series(sessions)
+        assert [d for d, _ in series] == [MONDAY + timedelta(3)]
+
+
+# --------------------------------------------------------------------------
+# Regularly-trained + program stagnation rollup
+# --------------------------------------------------------------------------
+
+
+class TestRegularlyTrained:
+    def test_two_of_last_three_weeks_qualifies(self):
+        records = [
+            SetRecord("Bench Press", MONDAY, 60, 8),
+            SetRecord("Bench Press", MONDAY - timedelta(weeks=1), 60, 8),
+            SetRecord("Curl", MONDAY, 20, 10),  # one week only
+        ]
+        assert find_regularly_trained(records, MONDAY) == {"Bench Press"}
+
+    def test_outside_the_lookback_window_does_not_count(self):
+        records = [
+            SetRecord("Squat", MONDAY, 100, 5),
+            SetRecord("Squat", MONDAY - timedelta(weeks=5), 100, 5),
+        ]
+        assert find_regularly_trained(records, MONDAY) == set()
+
+    def test_week_start_for_snaps_to_monday(self):
+        assert week_start_for(date(2026, 8, 6)) == MONDAY  # Thursday -> Monday
+        assert week_start_for(MONDAY) == MONDAY
+
+
+class TestProgramStagnation:
+    def test_not_checked_when_too_few_exercises(self):
+        result = detect_program_stagnation(
+            regularly_trained={"A", "B", "C"}, plateaued={"A", "B", "C"}, min_exercises=4
+        )
+        assert result["checked"] is False
+        assert result["flagged"] is False
+        assert result["fraction"] is None
+        assert "at least 4" in result["reason"]
+
+    def test_minority_plateaued_does_not_flag(self):
+        result = detect_program_stagnation(
+            regularly_trained={"A", "B", "C", "D", "E"},
+            plateaued={"A", "B"},
+            min_exercises=4,
+            fraction_threshold=0.6,
+        )
+        assert result["checked"] is True
+        assert result["flagged"] is False
+        assert result["fraction"] == pytest.approx(0.4)
+
+    def test_majority_plateaued_flags(self):
+        result = detect_program_stagnation(
+            regularly_trained={"A", "B", "C", "D", "E"},
+            plateaued={"A", "B", "C", "D"},
+            min_exercises=4,
+            fraction_threshold=0.6,
+        )
+        assert result["flagged"] is True
+        assert result["fraction"] == pytest.approx(0.8)
+
+    def test_exactly_at_threshold_flags(self):
+        result = detect_program_stagnation(
+            regularly_trained={"A", "B", "C", "D", "E"},
+            plateaued={"A", "B", "C"},
+            min_exercises=4,
+            fraction_threshold=0.6,
+        )
+        assert result["fraction"] == pytest.approx(0.6)
+        assert result["flagged"] is True
+
+    def test_plateaued_irregular_exercises_are_ignored(self):
+        # "Z" is plateaued but not regularly trained, so it must not count.
+        result = detect_program_stagnation(
+            regularly_trained={"A", "B", "C", "D"},
+            plateaued={"A", "Z"},
+            min_exercises=4,
+            fraction_threshold=0.6,
+        )
+        assert result["plateaued_count"] == 1
+        assert result["flagged"] is False
+
+    def test_no_plateaus_at_all(self):
+        result = detect_program_stagnation({"A", "B", "C", "D"}, set(), min_exercises=4)
+        assert result["checked"] is True
+        assert result["flagged"] is False
+        assert result["fraction"] == 0.0
+
+
+# --------------------------------------------------------------------------
+# Load arithmetic
+# --------------------------------------------------------------------------
+
+
+class TestLoadArithmetic:
+    @pytest.mark.parametrize(
+        "raw,expected", [(63.0, 62.5), (61.0, 60.0), (105.0, 105.0), (26.2, 25.0), (26.3, 27.5)]
+    )
+    def test_round_to_increment(self, raw, expected):
+        assert round_to_increment(raw, 2.5) == expected
+
+    def test_next_load_is_always_higher(self):
+        for weight in (20, 24, 28, 60, 100, 142.5):
+            assert next_load(weight, 2.5) > weight
+
+    def test_next_load_lands_on_a_real_increment(self):
+        assert next_load(100, 2.5) == 105.0
+        assert next_load(60, 2.5) == 62.5
+
+    def test_next_load_on_light_weight_uses_one_full_increment(self):
+        # 5% of 20kg is 1kg, which no plate can express; one increment is correct.
+        assert next_load(20, 2.5) == 22.5
+
+    def test_deload_is_always_lower(self):
+        for weight in (20, 60, 100):
+            assert deload_load(weight, 2.5) < weight
+
+    def test_deload_is_about_ten_percent(self):
+        assert deload_load(100, 2.5) == 90.0
+
+    def test_warmup_load_is_forty_to_fifty_percent(self):
+        assert warmup_load(60, 2.5) == 27.5
+        assert 0.4 <= warmup_load(60, 2.5) / 60 <= 0.5
+
+    def test_warmup_load_never_zero(self):
+        assert warmup_load(2.0, 2.5) > 0
+
+
+# --------------------------------------------------------------------------
+# Progressive-overload rule branches
+# --------------------------------------------------------------------------
+
+
+class TestRecommendationBranches:
+    def test_increase_when_every_working_set_hits_top_of_range(self):
+        sessions = {MONDAY: make_session(MONDAY, 60, [12, 12, 12], warmup_reps=10)}
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.action == "increase"
+        assert rec.current_weight_kg == 60
+        assert rec.recommended_weight_kg == 62.5
+
+    def test_warmup_sets_do_not_block_an_increase(self):
+        # The warm-up is at 30kg x 10 — below the rep top — and must be ignored.
+        sessions = {MONDAY: make_session(MONDAY, 60, [12, 12], warmup_reps=10)}
+        assert recommend_for_exercise("Bench Press", sessions).action == "increase"
+
+    def test_hold_when_one_working_set_is_short_of_the_top(self):
+        sessions = {MONDAY: make_session(MONDAY, 60, [12, 12, 9])}
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.action == "hold"
+        assert rec.recommended_weight_kg == 60
+
+    def test_hold_when_a_working_set_misses_the_bottom_of_the_range(self):
+        sessions = {MONDAY: make_session(MONDAY, 60, [8, 6, 4])}
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.action == "hold"
+        assert "below 6 reps" in rec.reason
+
+    def test_deload_when_plateaued_three_sessions(self):
+        sessions = {}
+        for offset in (0, 3, 7):
+            day = MONDAY + timedelta(days=offset)
+            sessions[day] = make_session(day, 60, [8, 8, 8])
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.action == "deload_or_swap"
+        assert rec.plateaued is True
+        assert rec.recommended_weight_kg == 55.0
+
+    def test_deload_wording_is_a_suggestion_not_an_instruction(self):
+        sessions = {MONDAY + timedelta(d): make_session(MONDAY + timedelta(d), 60, [8, 8])
+                    for d in (0, 3, 7)}
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert "Consider" in rec.reason
+
+    def test_increase_outranks_plateau(self):
+        # Top of the range at the same load for 3 sessions reads as a flat e1RM,
+        # but the right answer is more weight, not a deload.
+        sessions = {MONDAY + timedelta(d): make_session(MONDAY + timedelta(d), 60, [12, 12])
+                    for d in (0, 3, 7)}
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.plateaued is True
+        assert rec.action == "increase"
+        assert rec.recommended_weight_kg == 62.5
+
+    def test_insufficient_data_when_no_sessions(self):
+        assert recommend_for_exercise("Bench Press", {}).action == "insufficient_data"
+
+    def test_insufficient_data_when_last_session_is_all_warmups(self):
+        sessions = {MONDAY: [SetRecord("Bench Press", MONDAY, 40, 10, is_warmup=True)]}
+        assert recommend_for_exercise("Bench Press", sessions).action == "insufficient_data"
+
+    def test_current_weight_is_the_heaviest_working_set(self):
+        records = [
+            SetRecord("Bench Press", MONDAY, 50, 12),
+            SetRecord("Bench Press", MONDAY, 60, 12),
+        ]
+        rec = recommend_for_exercise("Bench Press", {MONDAY: records})
+        assert rec.current_weight_kg == 60
+
+
+# --------------------------------------------------------------------------
+# Pain safeguard
+# --------------------------------------------------------------------------
+
+
+class TestPainSafeguard:
+    def _painful_sessions(self, pain_on_sessions: set[int], weight: float = 60):
+        sessions = {}
+        for index, offset in enumerate((0, 3, 7)):
+            day = MONDAY + timedelta(days=offset)
+            sessions[day] = make_session(
+                day, weight, [12, 12, 12], pain=index in pain_on_sessions
+            )
+        return sessions
+
+    def test_pain_blocks_an_otherwise_earned_increase(self):
+        sessions = self._painful_sessions({2})
+        rec = recommend_for_exercise("Bench Press", sessions, pain_safeguard_enabled=True)
+        assert rec.action == "hold_pain"
+        assert rec.pain_safeguard_applied is True
+        assert rec.recommended_weight_kg == rec.current_weight_kg == 60
+
+    def test_pain_safeguard_adds_one_light_warmup_set(self):
+        rec = recommend_for_exercise(
+            "Bench Press", self._painful_sessions({2}), pain_safeguard_enabled=True
+        )
+        assert rec.warmup_set_kg == 27.5
+        assert 0.4 <= rec.warmup_set_kg / rec.current_weight_kg <= 0.5
+
+    def test_disabling_the_safeguard_restores_the_normal_recommendation(self):
+        sessions = self._painful_sessions({2})
+        rec = recommend_for_exercise("Bench Press", sessions, pain_safeguard_enabled=False)
+        assert rec.action == "increase"
+        assert rec.recommended_weight_kg == 62.5
+        assert rec.pain_safeguard_applied is False
+        assert rec.warmup_set_kg is None
+
+    def test_pain_in_the_session_before_last_still_counts(self):
+        # "last 2 sessions", not "the last session".
+        rec = recommend_for_exercise("Bench Press", self._painful_sessions({1}))
+        assert rec.action == "hold_pain"
+
+    def test_pain_three_sessions_ago_does_not_count(self):
+        rec = recommend_for_exercise("Bench Press", self._painful_sessions({0}))
+        assert rec.action == "increase"
+
+    def test_no_escalation_at_two_consecutive_pain_sessions(self):
+        rec = recommend_for_exercise("Bench Press", self._painful_sessions({1, 2}))
+        assert rec.pain_safeguard_applied is True
+        assert rec.escalate_pain_to_professional is False
+
+    def test_escalates_at_three_consecutive_pain_sessions(self):
+        rec = recommend_for_exercise("Bench Press", self._painful_sessions({0, 1, 2}))
+        assert rec.escalate_pain_to_professional is True
+        assert "professional" in rec.pain_note
+
+    def test_pain_note_never_diagnoses_or_prescribes_rehab(self):
+        rec = recommend_for_exercise("Bench Press", self._painful_sessions({0, 1, 2}))
+        text = f"{rec.pain_note} {rec.reason}".lower()
+        for forbidden in ("rotator cuff", "rehab", "stretch", "strain", "tendon",
+                          "impingement", "mobility", "corrective"):
+            assert forbidden not in text
+
+    def test_pain_takes_precedence_over_plateau(self):
+        sessions = {}
+        for offset in (0, 3, 7):
+            day = MONDAY + timedelta(days=offset)
+            sessions[day] = make_session(day, 60, [8, 8, 8], pain=offset == 7)
+        rec = recommend_for_exercise("Bench Press", sessions)
+        assert rec.action == "hold_pain"
+        assert rec.plateaued is True
+        assert rec.recommended_weight_kg == 60  # not deloaded
+
+    def test_trailing_pain_streak_counts_only_consecutive_recent_sessions(self):
+        sessions = self._painful_sessions({0, 2})
+        assert trailing_pain_streak(sessions) == 1
+
+    def test_module_default_is_on(self):
+        assert insights.PAIN_SAFEGUARD_ENABLED is True
+
+
+# --------------------------------------------------------------------------
+# Aggregates
+# --------------------------------------------------------------------------
+
+
+class TestAggregates:
+    def test_rep_range_distribution_bands(self):
+        records = [
+            SetRecord("A", MONDAY, 100, 3),   # strength
+            SetRecord("A", MONDAY, 100, 5),   # strength
+            SetRecord("A", MONDAY, 60, 6),    # hypertrophy
+            SetRecord("A", MONDAY, 60, 12),   # hypertrophy (boundary)
+            SetRecord("A", MONDAY, 30, 15),   # endurance
+        ]
+        assert rep_range_distribution(records) == {
+            "strength": 2, "hypertrophy": 2, "endurance": 1
+        }
+
+    def test_warmups_excluded_from_distribution_and_volume(self):
+        records = [
+            SetRecord("A", MONDAY, 20, 20, is_warmup=True),
+            SetRecord("A", MONDAY, 60, 10),
+        ]
+        assert rep_range_distribution(records) == {"strength": 0, "hypertrophy": 1, "endurance": 0}
+        assert total_volume(records) == 600.0
+
+    def test_volume_by_muscle_group_rolls_up(self):
+        records = [
+            SetRecord("Bench", MONDAY, 60, 10, muscle_group="Chest"),
+            SetRecord("Fly", MONDAY, 15, 12, muscle_group="Chest"),
+            SetRecord("Row", MONDAY, 50, 10, muscle_group="Back"),
+        ]
+        assert volume_by_muscle_group(records) == {"Chest": 780.0, "Back": 500.0}
+
+    def test_incomplete_sets_contribute_no_volume(self):
+        records = [SetRecord("A", MONDAY, None, 10), SetRecord("A", MONDAY, 60, None)]
+        assert total_volume(records) == 0.0
+
+
+# --------------------------------------------------------------------------
+# Stage A end-to-end shape (still no LLM, no database)
+# --------------------------------------------------------------------------
+
+
+class TestBuildStageA:
+    def _program(self, plateaued: bool):
+        """Five exercises, three sessions each — flat if plateaued, rising if not."""
+        records: list[SetRecord] = []
+        names = ["Bench Press", "Squat", "Row", "Overhead Press", "Deadlift"]
+        for name in names:
+            for index, offset in enumerate((-14, -7, 0)):
+                day = MONDAY + timedelta(days=offset)
+                weight = 60 if plateaued else 60 + index * 5
+                records.extend(make_session(day, weight, [8, 8], exercise=name,
+                                            muscle_group="Full Body"))
+        return records
+
+    def test_flags_program_stagnation_when_all_regulars_are_flat(self):
+        stage_a = insights.build_stage_a(self._program(plateaued=True), MONDAY)
+        assert stage_a["program_note"]["stagnation_flagged"] is True
+        assert stage_a["program_note"]["suggestion"] is not None
+
+    def test_does_not_flag_when_everyone_is_progressing(self):
+        stage_a = insights.build_stage_a(self._program(plateaued=False), MONDAY)
+        assert stage_a["program_note"]["stagnation_flagged"] is False
+        assert stage_a["program_note"]["suggestion"] is None
+
+    def test_does_not_flag_with_too_few_exercises(self):
+        records = [r for r in self._program(plateaued=True)
+                   if r.exercise_name in {"Bench Press", "Squat"}]
+        stage_a = insights.build_stage_a(records, MONDAY)
+        assert stage_a["program_note"]["detail"]["checked"] is False
+        assert stage_a["program_note"]["stagnation_flagged"] is False
+
+    def test_program_suggestion_names_no_specific_program(self):
+        stage_a = insights.build_stage_a(self._program(plateaued=True), MONDAY)
+        suggestion = stage_a["program_note"]["suggestion"].lower()
+        for forbidden in ("push pull legs", "ppl", "5x5", "starting strength",
+                          "upper lower", "bro split", "531"):
+            assert forbidden not in suggestion
+
+    def test_every_recommendation_carries_a_computed_weight(self):
+        stage_a = insights.build_stage_a(self._program(plateaued=False), MONDAY)
+        assert stage_a["recommendations"]
+        for rec in stage_a["recommendations"].values():
+            assert rec["recommended_weight_kg"] is not None
+            assert isinstance(rec["recommended_weight_kg"], (int, float))
+
+    def test_fallback_summary_renders_without_an_llm(self):
+        stage_a = insights.build_stage_a(self._program(plateaued=True), MONDAY)
+        summary = insights.fallback_summary(stage_a)
+        assert "Week of 2026-08-03" in summary
+        assert "Program note" in summary
+
+
+# --------------------------------------------------------------------------
+# Stage B contract: the LLM narrates, it never computes
+# --------------------------------------------------------------------------
+
+
+class FakeNarrationClient:
+    def __init__(self, reply="## What improved\nSomething."):
+        self.reply = reply
+        self.calls: list[dict] = []
+        outer = self
+
+        class Completions:
+            def create(self, **kwargs):
+                outer.calls.append(kwargs)
+                if isinstance(outer.reply, Exception):
+                    raise outer.reply
+                return type("R", (), {"choices": [
+                    type("C", (), {"message": type("M", (), {"content": outer.reply})()})()
+                ]})()
+
+        self.chat = type("Chat", (), {"completions": Completions()})()
+
+
+class TestStageBContract:
+    def _stage_a(self):
+        records = [
+            SetRecord("Bench Press", MONDAY, 60, 12, muscle_group="Chest"),
+            SetRecord("Bench Press", MONDAY, 60, 12, muscle_group="Chest"),
+        ]
+        return insights.build_stage_a(records, MONDAY)
+
+    def test_stage_a_numbers_are_handed_to_the_model_as_input(self):
+        client = FakeNarrationClient()
+        insights.narrate(self._stage_a(), client=client)
+        user_message = client.calls[0]["messages"][1]["content"]
+        assert '"recommended_weight_kg": 62.5' in user_message
+
+    def test_prompt_forbids_altering_numbers(self):
+        client = FakeNarrationClient()
+        insights.narrate(self._stage_a(), client=client)
+        system_prompt = client.calls[0]["messages"][0]["content"].lower()
+        assert "may not alter, invent, recompute" in system_prompt
+        assert "may not create, change, or second-guess a recommendation" in system_prompt
+
+    def test_prompt_forbids_diagnosing_pain_or_prescribing_rehab(self):
+        client = FakeNarrationClient()
+        insights.narrate(self._stage_a(), client=client)
+        system_prompt = client.calls[0]["messages"][0]["content"].lower()
+        assert "never suggest a cause for the pain" in system_prompt
+        assert "rehab" in system_prompt
+
+    def test_prompt_forbids_inventing_a_replacement_program(self):
+        client = FakeNarrationClient()
+        insights.narrate(self._stage_a(), client=client)
+        system_prompt = client.calls[0]["messages"][0]["content"].lower()
+        assert "never invent a specific" in system_prompt
+
+    def test_narration_runs_at_zero_temperature(self):
+        client = FakeNarrationClient()
+        insights.narrate(self._stage_a(), client=client)
+        assert client.calls[0]["temperature"] == 0
+
+    def test_fallback_summary_carries_the_same_numbers_without_any_model(self):
+        stage_a = self._stage_a()
+        summary = insights.fallback_summary(stage_a)
+        assert "62.5kg" in summary
+        assert stage_a["recommendations"]["Bench Press"]["recommended_weight_kg"] == 62.5

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,428 @@
+"""Unit tests for pipeline.py's pure logic — confidence heuristic and fuzzy match.
+
+Both are pure functions with no network or database, and both are places where a
+silent bug corrupts the dataset quietly: a bad confidence score inserts junk, a
+bad fuzzy match fragments an exercise's progress history across several rows.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+import pipeline
+from pipeline import (
+    BodyweightEntry,
+    ExtractionError,
+    WorkoutSet,
+    compute_confidence,
+    extract_entities,
+    find_matching_exercise,
+    name_match_score,
+    normalize_name,
+    resolve_logged_at,
+    validate_extraction,
+)
+
+RAW_ENTRY = (
+    "Chest bench press 20kg 12 reps warm up. Chest bench press 24kg 12 reps. "
+    "6:20ish Dumbbell bench press 12.5kg each hand 11 reps. Shoulder pain noticed."
+)
+
+
+# --------------------------------------------------------------------------
+# Name normalization
+# --------------------------------------------------------------------------
+
+
+class TestNormalizeName:
+    def test_lowercases_and_collapses_whitespace(self):
+        assert normalize_name("  Chest   Bench  Press ") == "chest bench press"
+
+    def test_strips_punctuation(self):
+        assert normalize_name("Bench Press (Chest)") == "bench press chest"
+
+    def test_handles_empty(self):
+        assert normalize_name("") == ""
+
+
+# --------------------------------------------------------------------------
+# Fuzzy exercise matching
+# --------------------------------------------------------------------------
+
+
+class TestFuzzyMatch:
+    """The rule: token_sort_ratio, plus a token_set bonus only when the extra
+    tokens are known equipment/muscle qualifiers. Unknown extra words fail
+    closed into a separate exercise row."""
+
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("ches press", "Chest Press"),              # acceptance criterion
+            ("shoulder pres", "Shoulder Press"),
+            ("Lateral Raise", "Lateral Raises"),
+            ("Dumbell Bench Press", "Dumbbell Bench Press"),
+            ("Chest Bench Press", "Bench Press (Chest)"),
+            ("Barbell Chest Bench Press", "Chest Bench Press"),
+        ],
+    )
+    def test_same_exercise_matches(self, proposed, existing):
+        assert find_matching_exercise(proposed, [existing]) == existing
+
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Bench Press", "Incline Bench Press"),     # variation, not a qualifier
+            ("Squat", "Front Squat"),
+            ("Bench Press", "Close Grip Bench Press"),
+            ("Deadlift", "Romanian Deadlift"),
+            ("Bench Press", "Leg Press"),
+            ("Barbell Row", "Barbell Curl"),
+            ("Overhead Press", "Bench Press"),
+            ("Lat Pulldown", "Leg Press"),
+            ("Leg Curl", "Curl"),                       # single-token names never absorb
+        ],
+    )
+    def test_different_exercises_do_not_match(self, proposed, existing):
+        assert find_matching_exercise(proposed, [existing]) is None
+
+    def test_picks_the_best_of_several_candidates(self):
+        existing = ["Leg Press", "Chest Press", "Overhead Press"]
+        assert find_matching_exercise("ches press", existing) == "Chest Press"
+
+    def test_returns_none_against_an_empty_table(self):
+        assert find_matching_exercise("Bench Press", []) is None
+
+    def test_identical_name_scores_full(self):
+        assert name_match_score("Bench Press", "bench press") == 100.0
+
+    def test_threshold_is_respected(self):
+        # Same pair, above and below the cut.
+        assert find_matching_exercise("Bench Press", ["Incline Bench Press"], threshold=70) is not None
+        assert find_matching_exercise("Bench Press", ["Incline Bench Press"], threshold=85) is None
+
+    def test_blank_name_scores_zero(self):
+        assert name_match_score("", "Bench Press") == 0.0
+
+
+# --------------------------------------------------------------------------
+# Confidence heuristic
+# --------------------------------------------------------------------------
+
+
+class TestComputeConfidence:
+    def test_fully_grounded_set_scores_full(self):
+        score = compute_confidence(
+            "Chest Bench Press", 24.0, 12, "Chest bench press 24kg 12 reps", RAW_ENTRY
+        )
+        assert score == 1.0
+        assert score >= pipeline.CONFIDENCE_THRESHOLD
+
+    def test_failed_validation_scores_zero(self):
+        assert compute_confidence("Bench Press", 60, 10, "Bench Press", RAW_ENTRY,
+                                  validation_ok=False) == 0.0
+
+    @pytest.mark.parametrize("name", [None, "", "   "])
+    def test_missing_exercise_name_scores_zero(self, name):
+        assert compute_confidence(name, 60, 10, "whatever", RAW_ENTRY) == 0.0
+
+    def test_missing_weight_drops_below_threshold(self):
+        score = compute_confidence(
+            "Chest Bench Press", None, 12, "Chest bench press 12 reps", RAW_ENTRY
+        )
+        assert score < pipeline.CONFIDENCE_THRESHOLD
+
+    def test_missing_reps_drops_below_threshold(self):
+        score = compute_confidence(
+            "Chest Bench Press", 24.0, None, "Chest bench press 24kg", RAW_ENTRY
+        )
+        assert score < pipeline.CONFIDENCE_THRESHOLD
+
+    def test_missing_both_scores_lower_than_missing_one(self):
+        one = compute_confidence("Chest Bench Press", 24.0, None, "Chest bench press", RAW_ENTRY)
+        both = compute_confidence("Chest Bench Press", None, None, "Chest bench press", RAW_ENTRY)
+        assert both < one
+
+    def test_ungrounded_name_is_penalized(self):
+        """A name that does not appear in the span it supposedly came from is the
+        signal that the model invented it."""
+        grounded = compute_confidence(
+            "Chest Bench Press", 24.0, 12, "Chest bench press 24kg 12 reps", RAW_ENTRY
+        )
+        invented = compute_confidence(
+            "Leg Press Machine", 24.0, 12, "Chest bench press 24kg 12 reps", RAW_ENTRY
+        )
+        assert invented < grounded
+        assert invented < pipeline.CONFIDENCE_THRESHOLD
+
+    def test_missing_span_is_penalized_but_still_checked_against_full_text(self):
+        with_span = compute_confidence(
+            "Chest Bench Press", 24.0, 12, "Chest bench press 24kg 12 reps", RAW_ENTRY
+        )
+        without_span = compute_confidence("Chest Bench Press", 24.0, 12, None, RAW_ENTRY)
+        assert without_span < with_span
+        assert without_span == pytest.approx(0.8)
+
+    def test_typo_in_span_still_grounds_the_name(self):
+        # The LLM's job is to fix "ches bent prees"; that must not look invented.
+        score = compute_confidence(
+            "Chest Bench Press", 24.0, 12, "ches bent prees 24kg 12 reps", RAW_ENTRY
+        )
+        assert score >= pipeline.CONFIDENCE_THRESHOLD
+
+    def test_score_is_always_in_range(self):
+        worst = compute_confidence("X", None, None, None, "")
+        assert 0.0 <= worst <= 1.0
+
+    def test_confidence_is_never_read_from_the_model(self):
+        """A self-reported confidence field must not influence the score."""
+        payload = {
+            "sets": [
+                {
+                    "exercise_name": "Chest Bench Press",
+                    "weight_kg": None,
+                    "reps": None,
+                    "raw_span": "Chest bench press",
+                    "confidence": 0.99,  # model-supplied; must be ignored
+                }
+            ],
+            "bodyweight": None,
+        }
+        scored_sets, _, _ = validate_extraction(payload, RAW_ENTRY)
+        assert len(scored_sets) == 1
+        assert scored_sets[0][1] < pipeline.CONFIDENCE_THRESHOLD
+
+
+class TestBodyweightConfidence:
+    def test_number_present_in_span_scores_full(self):
+        entry = BodyweightEntry(weight_kg=82.4, raw_span="was 82.4kg this morning")
+        assert pipeline.compute_bodyweight_confidence(entry, RAW_ENTRY) == 1.0
+
+    def test_number_absent_from_text_is_penalized_below_threshold(self):
+        entry = BodyweightEntry(weight_kg=75.0, raw_span="was 82.4kg this morning")
+        score = pipeline.compute_bodyweight_confidence(entry, RAW_ENTRY)
+        assert score < pipeline.CONFIDENCE_THRESHOLD
+
+    def test_integer_weight_matches_integer_text(self):
+        entry = BodyweightEntry(weight_kg=82.0, raw_span="weighed 82 kg today")
+        assert pipeline.compute_bodyweight_confidence(entry, "weighed 82 kg today") == 1.0
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+class TestValidateExtraction:
+    def test_valid_payload_produces_scored_models(self):
+        payload = {
+            "sets": [
+                {
+                    "exercise_name": "Chest Bench Press",
+                    "weight_kg": 24.0,
+                    "reps": 12,
+                    "set_number": 2,
+                    "is_warmup": False,
+                    "pain_flag": False,
+                    "raw_span": "Chest bench press 24kg 12 reps",
+                }
+            ],
+            "bodyweight": {"weight_kg": 82.4, "raw_span": "82.4kg this morning"},
+        }
+        scored_sets, bodyweight, review = validate_extraction(payload, RAW_ENTRY)
+        assert len(scored_sets) == 1
+        assert isinstance(scored_sets[0][0], WorkoutSet)
+        assert bodyweight is not None and bodyweight[0].weight_kg == 82.4
+        assert review == []
+
+    def test_invalid_set_goes_to_review_not_into_the_data(self):
+        payload = {"sets": [{"exercise_name": "", "reps": -4}], "bodyweight": None}
+        scored_sets, _, review = validate_extraction(payload, RAW_ENTRY)
+        assert scored_sets == []
+        assert len(review) == 1
+        assert review[0].kind == "workout_set"
+
+    def test_one_bad_set_does_not_discard_the_good_ones(self):
+        payload = {
+            "sets": [
+                {"exercise_name": "Bench Press", "weight_kg": 60, "reps": 10,
+                 "raw_span": "Bench press 60kg 10 reps"},
+                {"exercise_name": "", "reps": 0},
+            ],
+            "bodyweight": None,
+        }
+        scored_sets, _, review = validate_extraction(payload, RAW_ENTRY)
+        assert len(scored_sets) == 1
+        assert len(review) == 1
+
+    def test_missing_keys_are_tolerated(self):
+        scored_sets, bodyweight, review = validate_extraction({}, RAW_ENTRY)
+        assert scored_sets == [] and bodyweight is None and review == []
+
+    def test_non_list_sets_goes_to_review(self):
+        _, _, review = validate_extraction({"sets": "nope"}, RAW_ENTRY)
+        assert review and review[0].kind == "extraction"
+
+    def test_bodyweight_of_wrong_type_goes_to_review(self):
+        _, bodyweight, review = validate_extraction({"bodyweight": "82kg"}, RAW_ENTRY)
+        assert bodyweight is None
+        assert review and review[0].kind == "bodyweight"
+
+
+# --------------------------------------------------------------------------
+# Timestamp resolution
+# --------------------------------------------------------------------------
+
+
+class TestResolveLoggedAt:
+    SESSION = date(2026, 8, 14)
+
+    def test_uses_the_extracted_time_when_it_is_on_the_session_date(self):
+        result = resolve_logged_at("2026-08-14T18:20:00", self.SESSION, "UTC")
+        assert result == datetime(2026, 8, 14, 18, 20, tzinfo=timezone.utc)
+
+    def test_converts_local_wall_clock_to_utc(self):
+        result = resolve_logged_at("2026-08-14T18:20:00", self.SESSION, "Asia/Karachi")
+        assert result == datetime(2026, 8, 14, 13, 20, tzinfo=timezone.utc)
+
+    def test_falls_back_to_the_default_hour_when_no_time_marker(self):
+        result = resolve_logged_at(None, self.SESSION, "UTC", default_hour=18)
+        assert result == datetime(2026, 8, 14, 18, 0, tzinfo=timezone.utc)
+
+    def test_a_timestamp_on_another_day_is_discarded(self):
+        """The model does not get to move a workout to a different date."""
+        result = resolve_logged_at("2026-08-01T09:00:00", self.SESSION, "UTC", default_hour=18)
+        assert result == datetime(2026, 8, 14, 18, 0, tzinfo=timezone.utc)
+
+    def test_unparseable_timestamp_falls_back(self):
+        result = resolve_logged_at("6:20ish", self.SESSION, "UTC", default_hour=18)
+        assert result == datetime(2026, 8, 14, 18, 0, tzinfo=timezone.utc)
+
+    def test_time_only_value_is_combined_with_the_session_date(self):
+        result = resolve_logged_at("18:20", self.SESSION, "UTC")
+        assert result == datetime(2026, 8, 14, 18, 20, tzinfo=timezone.utc)
+
+    def test_result_is_always_timezone_aware_utc(self):
+        assert resolve_logged_at(None, self.SESSION, "UTC").tzinfo == timezone.utc
+
+
+# --------------------------------------------------------------------------
+# Extraction transport: JSON mode + exactly one retry
+# --------------------------------------------------------------------------
+
+
+class FakeCompletions:
+    def __init__(self, behaviours):
+        self.behaviours = list(behaviours)
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        behaviour = self.behaviours.pop(0)
+        if isinstance(behaviour, Exception):
+            raise behaviour
+        return type(
+            "Response",
+            (),
+            {"choices": [type("Choice", (), {"message": type("Msg", (), {"content": behaviour})()})()]},
+        )()
+
+
+class FakeClient:
+    def __init__(self, behaviours):
+        self.completions = FakeCompletions(behaviours)
+        self.chat = type("Chat", (), {"completions": self.completions})()
+
+
+VALID_JSON = json.dumps({"sets": [], "bodyweight": None})
+
+
+class TestExtractEntities:
+    def test_uses_json_mode_and_zero_temperature(self):
+        client = FakeClient([VALID_JSON])
+        extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        kwargs = client.completions.calls[0]
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert kwargs["temperature"] == 0
+
+    def test_session_date_is_passed_to_the_model(self):
+        client = FakeClient([VALID_JSON])
+        extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert "2026-08-14" in client.completions.calls[0]["messages"][1]["content"]
+
+    def test_retries_once_on_an_api_error_then_succeeds(self):
+        client = FakeClient([RuntimeError("503 upstream"), VALID_JSON])
+        assert extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client) == {
+            "sets": [], "bodyweight": None
+        }
+        assert len(client.completions.calls) == 2
+
+    def test_retries_once_on_unparseable_json_then_succeeds(self):
+        client = FakeClient(["not json at all", VALID_JSON])
+        extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert len(client.completions.calls) == 2
+
+    def test_gives_up_after_exactly_one_retry(self):
+        client = FakeClient([RuntimeError("boom"), RuntimeError("boom again")])
+        with pytest.raises(ExtractionError):
+            extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert len(client.completions.calls) == 2
+
+    def test_a_json_array_is_rejected_as_not_an_object(self):
+        client = FakeClient(["[1, 2, 3]", "[4, 5]"])
+        with pytest.raises(ExtractionError):
+            extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+
+
+# --------------------------------------------------------------------------
+# Model constraints
+# --------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_exercise_name_is_whitespace_normalized(self):
+        assert WorkoutSet(exercise_name="  Chest   Bench Press ").exercise_name == "Chest Bench Press"
+
+    def test_blank_exercise_name_is_rejected(self):
+        with pytest.raises(Exception):
+            WorkoutSet(exercise_name="   ")
+
+    @pytest.mark.parametrize("field,value", [("reps", 0), ("reps", -1), ("weight_kg", -5)])
+    def test_impossible_values_are_rejected(self, field, value):
+        with pytest.raises(Exception):
+            WorkoutSet(exercise_name="Bench Press", **{field: value})
+
+    def test_bodyweight_requires_a_weight(self):
+        with pytest.raises(Exception):
+            BodyweightEntry()
+
+    def test_body_fat_pct_must_be_a_percentage(self):
+        with pytest.raises(Exception):
+            BodyweightEntry(weight_kg=82.4, body_fat_pct=150)
+
+
+# --------------------------------------------------------------------------
+# Numeric grounding (normalize_name strips decimal points, so numbers use their
+# own normalizer — this is the bug that made a correct "82.4kg" look invented)
+# --------------------------------------------------------------------------
+
+
+class TestNumericGrounding:
+    def test_decimal_weight_is_found_in_the_text(self):
+        assert pipeline._number_appears_in(82.4, "was 82.4kg this morning")
+
+    def test_integer_weight_is_found(self):
+        assert pipeline._number_appears_in(82.0, "weighed 82 kg today")
+
+    def test_does_not_match_inside_a_longer_number(self):
+        # "82" must not be satisfied by the "82" inside "182.5".
+        assert not pipeline._number_appears_in(82.0, "the bar was 182.5 total")
+
+    def test_absent_number_is_not_found(self):
+        assert not pipeline._number_appears_in(75.0, "was 82.4kg this morning")
+
+    def test_normalizer_preserves_decimals(self):
+        assert "82.4" in pipeline._normalize_numeric_text("Was  82.4KG this morning")


### PR DESCRIPTION
Implements the build spec: free-text gym journal entries in, structured Postgres rows out, with a weekly progress report on top.

## Architecture

```
Notes app (unchanged)
  -> paste into the mobile web form            app.py
  -> Groq extraction, JSON mode, 1 retry       pipeline.extract_entities
  -> Pydantic validation                       pipeline.validate_extraction
  -> computed confidence heuristic             pipeline.compute_confidence
  -> fuzzy match against existing exercises    pipeline.find_matching_exercise
  -> below threshold? -> review list, not inserted
  -> above threshold? -> parameterized INSERT into Postgres
```

`pipeline.py` holds all extraction/validation/insert logic; the CLI and the web app both import it and neither reimplements any of it.

## Verified against a real database

Postgres 16 was installed in the build environment and every acceptance criterion exercised end-to-end, with only the Groq network call stubbed:

- `schema.sql` runs clean on a fresh database and is re-runnable
- CLI parses the sample messy entry — 6 sets inserted; the weightless "cable flys" set scored 0.30 and landed in review, never reaching the `exercises` table
- Bodyweight `82.4kg` routed to `bodyweight_logs` at the correct 07:00 timestamp, separately from the sets in the same entry
- `"ches bench pres"` reused the existing `exercise_id` — no duplicate row
- Resubmitting identical text inserted nothing and returned the prior result
- Weekly report: increase / deload / pain-hold all correct; program stagnation flagged at 4-of-5 plateaued, and correctly *not* flagged with too few exercises or a minority plateaued
- Web app returns 401 without auth; model-supplied markup is escaped before rendering
- **147 unit tests pass**, requiring no network and no database

## Decisions worth reviewing

**Fuzzy matching needed more than a threshold.** All six rapidfuzz scorers were tested at 85 and none work: `token_set_ratio` merges "Bench Press" with "Incline Bench Press" (scores 100 — a real bug), while `token_sort_ratio` refuses "Barbell Chest Bench Press" ↔ "Chest Bench Press" (81), which the spec requires merging. Pure string distance cannot separate an equipment qualifier from a variation modifier. `name_match_score` uses `token_sort_ratio` as the base and only lifts to `token_set_ratio` when one name's tokens are a strict subset of the other's *and* every extra token is a known equipment/muscle qualifier. Unknown words fail closed, into a separate row. 17 cases pinned in tests.

**Increase outranks the plateau branch.** Hitting 12/12/12 at the same load for three sessions registers as a flat e1RM, so ranking plateau first would recommend deloading someone who is progressing. Pain still outranks both.

**Confidence is computed, never self-reported.** Derived from Pydantic validation success, whether required fields came back non-null, and whether the exercise name is grounded in the text span it came from. The model is explicitly instructed not to return a confidence number.

**Stage A / Stage B split.** Every number — e1RM, volume, percentages, recommended loads, plateau and stagnation flags — is computed in code. Groq only writes prose around finished numbers, under a prompt forbidding it from altering any figure or creating a recommendation. A failed narration falls back to a deterministic summary rather than losing the report.

**Model ID.** Groq deprecated `llama-3.3-70b-versatile` for free and developer tiers on 2026-06-17, so this defaults to `openai/gpt-oss-120b`, their recommended replacement.

## Known gaps

- `LOCAL_TIMEZONE` defaults to `UTC` and must be set before real logging, or timestamps will be wrong.
- Stage B prose was never exercised against live Groq (no API key in the build environment). The retry logic and prompt constraints are unit-tested against a fake client, but output quality is unverified.
- Sets logged without a weight score 0.65 and always go to review. This follows the spec's "required fields" rule, but means genuinely bodyweight lifts (pull-ups, dips) will need a manual look.
- Deload on light dumbbells overshoots — 15kg to 12.5kg is −16%, not −10%, because 2.5kg is the smallest step. `PLATE_INCREMENT_KG` is tunable.
- The iOS Shortcut was left unbuilt, per the spec's stretch-goal instruction.

## Security

Parameterized SQL throughout (`sqlalchemy.text()` with bound `:param`); no value is ever formatted into a query string. Secrets are env vars only, never hardcoded, rendered, or logged. HTTP Basic Auth on every route except `/healthz`, compared with `secrets.compare_digest` — safe only over HTTPS, and the app warns on any non-local plaintext request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_