### PR TITLE
Fix pain attribution, track cheat reps, and close two name-matching gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ psql "$DATABASE_URL" -f schema.sql
 
 `schema.sql` is safe to re-run — every object is `IF NOT EXISTS`.
 
+**Existing databases:** apply anything in `migrations/` that postdates your
+setup. They are additive and re-runnable:
+
+```bash
+psql "$DATABASE_URL" -f migrations/001_add_cheat_reps.sql
+```
+
+**Supabase:** enable RLS on all four tables. The app connects as the table owner
+so it bypasses RLS, but Supabase auto-exposes a REST API over the `public`
+schema to the anon key, and without RLS that key can read and delete your data.
+No policies are needed — RLS on with zero policies denies the API entirely:
+
+```sql
+ALTER TABLE exercises       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workout_logs    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bodyweight_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE weekly_reports  ENABLE ROW LEVEL SECURITY;
+```
+
 ### Try it
 
 ```bash
@@ -101,6 +120,11 @@ Bench Press", "Bench Press (Chest)" and "Barbell Chest Bench Press" become three
 rows and your progress history splits three ways — which defeats the point of
 tracking.
 
+Real journal entries also produce `Skullcrushers` vs `Skull Crushers` (word
+boundaries only) and `Cable Hammer Curls` vs `Hammer Curl` (an equipment
+qualifier and a plural at once). Names are singularized before comparison, and
+compared with spaces stripped as an extra signal, so both merge.
+
 No single rapidfuzz scorer gets this right. `token_set_ratio` merges "Bench
 Press" with "Incline Bench Press" (score 100), and `token_sort_ratio` refuses to
 merge "Barbell Chest Bench Press" with "Chest Bench Press" (score 81). So
@@ -113,6 +137,20 @@ Unknown words fail closed, into a separate row.
 
 Both names must have at least two tokens for the subset bonus, so "Curl" never
 absorbs "Leg Curl". Threshold is 85, tunable via `FUZZY_MATCH_THRESHOLD`.
+
+### Cheat reps are counted, not flagged
+
+Entries like `Lateral raises 7.5kg 10 reps 3 were cheat` mean three reps *inside*
+a ten-rep set were completed with momentum — not three cheat sets. So
+`cheat_reps` is a count, and **clean reps** (`reps - cheat_reps`) drive estimated
+1RM and the rep-range rules. Volume still uses total reps, because the work was
+performed.
+
+This matters more than it looks. Scoring those ten reps as clean inflates that
+set's e1RM by 8%, and at the top of the range it flips the recommendation
+outright: 12 reps with 3 cheat reps is 9 clean reps, which is a hold, not the
+load increase you would otherwise be told to take on a lift you cheated to
+finish.
 
 ### Recommendation precedence
 
@@ -222,7 +260,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-147 tests, no network and no database required — they cover the Stage A rule
+172 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/insights.py
+++ b/insights.py
@@ -79,6 +79,7 @@ class SetRecord:
     session_date: date
     weight_kg: Optional[float] = None
     reps: Optional[int] = None
+    cheat_reps: int = 0
     is_warmup: bool = False
     pain_flag: bool = False
     muscle_group: Optional[str] = None
@@ -116,6 +117,18 @@ def epley_1rm(weight_kg: Optional[float], reps: Optional[int]) -> Optional[float
     return float(weight_kg) * (1.0 + reps / 30.0)
 
 
+def clean_reps(record: SetRecord) -> Optional[int]:
+    """Reps performed without cheating or assistance.
+
+    A cheated rep does not demonstrate strength at that load, so clean reps —
+    not total reps — drive estimated 1RM and the rep-range rules. Volume still
+    uses total reps, because the work was performed.
+    """
+    if record.reps is None:
+        return None
+    return max(0, record.reps - (record.cheat_reps or 0))
+
+
 def is_working_set(record: SetRecord) -> bool:
     """A set that counts toward progression: not a warm-up, and fully logged."""
     return (
@@ -147,7 +160,10 @@ def e1rm_series(sessions: dict[date, list[SetRecord]]) -> list[tuple[date, float
     for session_date in sorted(sessions):
         estimates = [
             value
-            for value in (epley_1rm(r.weight_kg, r.reps) for r in working_sets(sessions[session_date]))
+            for value in (
+                epley_1rm(r.weight_kg, clean_reps(r))
+                for r in working_sets(sessions[session_date])
+            )
             if value is not None
         ]
         if estimates:
@@ -386,7 +402,6 @@ def recommend_for_exercise(
         )
 
     current_weight = max(float(s.weight_kg) for s in last_working)  # type: ignore[arg-type]
-    top_set_reps = [s.reps for s in last_working if float(s.weight_kg) == current_weight]  # type: ignore[arg-type]
     target_reps = f"{rep_low}-{rep_high}"
 
     recent_two = ordered_dates[-2:]
@@ -424,7 +439,7 @@ def recommend_for_exercise(
         )
 
     # 2. Top of the rep range on every working set -> add load.
-    if all((s.reps or 0) >= rep_high for s in last_working):
+    if all((clean_reps(s) or 0) >= rep_high for s in last_working):
         return Recommendation(
             exercise=exercise,
             action="increase",
@@ -455,7 +470,7 @@ def recommend_for_exercise(
         )
 
     # 4. Otherwise hold and repeat.
-    missed_bottom = any((s.reps or 0) < rep_low for s in last_working)
+    missed_bottom = any((clean_reps(s) or 0) < rep_low for s in last_working)
     reason = (
         f"A working set fell below {rep_low} reps last session — repeat {current_weight:g}kg "
         "and build reps first."
@@ -717,7 +732,7 @@ def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord
     query = text(
         """
         SELECT e.name, e.muscle_group, w.logged_at, w.weight_kg, w.reps,
-               w.is_warmup, w.pain_flag
+               w.cheat_reps, w.is_warmup, w.pain_flag
         FROM workout_logs w
         JOIN exercises e ON e.exercise_id = w.exercise_id
         WHERE w.logged_at >= :since AND w.logged_at < :until
@@ -734,7 +749,8 @@ def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord
         rows = conn.execute(query, {"since": since_utc, "until": until_utc}).fetchall()
 
     records = []
-    for name, muscle_group, logged_at, weight_kg, reps, is_warmup, pain_flag in rows:
+    for (name, muscle_group, logged_at, weight_kg, reps, cheat_reps,
+         is_warmup, pain_flag) in rows:
         records.append(
             SetRecord(
                 exercise_name=name,
@@ -742,6 +758,7 @@ def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord
                 session_date=logged_at.astimezone(local_zone).date(),
                 weight_kg=float(weight_kg) if weight_kg is not None else None,
                 reps=int(reps) if reps is not None else None,
+                cheat_reps=int(cheat_reps or 0),
                 is_warmup=bool(is_warmup),
                 pain_flag=bool(pain_flag),
             )

--- a/migrations/001_add_cheat_reps.sql
+++ b/migrations/001_add_cheat_reps.sql
@@ -1,0 +1,15 @@
+-- Adds cheat_reps to workout_logs.
+--
+-- Run once against a database created before this column existed. Additive and
+-- non-destructive: existing rows default to 0 cheat reps, which is how they
+-- were already being scored.
+
+ALTER TABLE workout_logs
+    ADD COLUMN IF NOT EXISTS cheat_reps INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE workout_logs
+    DROP CONSTRAINT IF EXISTS workout_logs_cheat_reps_valid;
+
+ALTER TABLE workout_logs
+    ADD CONSTRAINT workout_logs_cheat_reps_valid
+    CHECK (cheat_reps >= 0 AND (reps IS NULL OR cheat_reps <= reps));

--- a/pipeline.py
+++ b/pipeline.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from typing import Any, Iterable, Optional, Sequence
 
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from rapidfuzz import fuzz
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Connection, Engine
@@ -92,6 +92,7 @@ Return ONLY a JSON object with exactly this shape:
       "exercise_name": "Chest Bench Press",
       "weight_kg": 24.0,
       "reps": 12,
+      "cheat_reps": 0,
       "set_number": 2,
       "is_warmup": false,
       "is_dropset": false,
@@ -114,6 +115,13 @@ Rules:
   "ches bent prees" -> "Chest Bench Press", "shoulder pres" -> "Shoulder Press".
   Use the same name for the same movement everywhere in the entry.
 - weight_kg is per-side load as written. "12.5kg each hand" -> 12.5.
+- cheat_reps: how many reps in THIS set were completed with cheating, momentum
+  or assistance. "10 reps 3 were cheat" -> reps 10, cheat_reps 3. Also covers
+  "3 cheat", "last 2 were assisted", "2 forced reps", "final rep was a grinder
+  with help". Default 0. cheat_reps must never exceed reps.
+- "each hand" / "per hand" / "each side" applies to every LATER set of the same
+  exercise in the entry even when written only once. Keep reporting the per-hand
+  number for those sets.
 - set_number counts within that exercise, starting at 1, in the order written.
 - is_warmup true when the text says warm up / warmup / "warm up ish" / similar.
 - is_dropset true only when a drop set is explicitly described.
@@ -130,9 +138,11 @@ Rules:
     shoulder press.
   - Never spread a single pain mention across every exercise in the entry.
 - logged_at_local: combine SESSION_DATE (given below) with any time marker in
-  the text ("6:20ish" -> 18:20 if the session reads as an evening workout,
-  06:20 if morning). Format "YYYY-MM-DDTHH:MM:SS", no timezone. If no time
-  marker applies to a set, use null.
+  the text. A bare time with no am/pm that sits in a workout sequence is
+  afternoon or evening: "4:35" -> 16:35, "6:20ish" -> 18:20. Read a time as
+  morning only when the text says so ("this morning", "am", "before work").
+  Format "YYYY-MM-DDTHH:MM:SS", no timezone. If no time marker applies to a
+  set, use null.
 - raw_span: the exact substring of the input this set was read from. Copy it
   verbatim; do not paraphrase. This is used to verify the extraction.
 - NEVER invent data. If a weight, rep count, or exercise name is not in the
@@ -153,6 +163,7 @@ class WorkoutSet(BaseModel):
     exercise_name: str = Field(min_length=1, max_length=120)
     weight_kg: Optional[float] = Field(default=None, ge=0, le=1000)
     reps: Optional[int] = Field(default=None, gt=0, le=1000)
+    cheat_reps: int = Field(default=0, ge=0, le=1000)
     set_number: Optional[int] = Field(default=None, gt=0, le=100)
     is_warmup: bool = False
     is_dropset: bool = False
@@ -161,6 +172,15 @@ class WorkoutSet(BaseModel):
     logged_at_local: Optional[str] = None
     raw_span: Optional[str] = None
     muscle_group: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _cheat_reps_within_reps(self) -> "WorkoutSet":
+        """A set cannot contain more cheat reps than reps."""
+        if self.reps is not None and self.cheat_reps > self.reps:
+            raise ValueError(
+                f"cheat_reps ({self.cheat_reps}) exceeds reps ({self.reps})"
+            )
+        return self
 
     @field_validator("exercise_name")
     @classmethod
@@ -217,6 +237,26 @@ def normalize_name(name: str) -> str:
     return re.sub(r"\s+", " ", lowered).strip()
 
 
+def _singularize(token: str) -> str:
+    """Crude singularizer so "Curls" and "Curl" compare equal.
+
+    Words ending in "ss" are left alone, which is what keeps "press" from
+    becoming "pres".
+    """
+    if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+        return token[:-1]
+    return token
+
+
+def normalize_tokens(name: str) -> list[str]:
+    """Normalized, singularized tokens of an exercise name."""
+    return [_singularize(token) for token in normalize_name(name).split() if token]
+
+
+# Compared against singularized tokens, so the qualifier set is singularized too.
+_QUALIFIER_TOKENS_SINGULAR = frozenset(_singularize(t) for t in QUALIFIER_TOKENS)
+
+
 def name_match_score(proposed: str, existing: str) -> float:
     """Similarity (0-100) between two exercise names.
 
@@ -230,20 +270,27 @@ def name_match_score(proposed: str, existing: str) -> float:
     "Chest Bench Press" without merging "Squat" into "Front Squat". Both names
     must have at least two tokens, so "Curl" never absorbs "Leg Curl".
     """
-    left, right = normalize_name(proposed), normalize_name(existing)
-    if not left or not right:
+    left_list, right_list = normalize_tokens(proposed), normalize_tokens(existing)
+    if not left_list or not right_list:
         return 0.0
+    left, right = " ".join(left_list), " ".join(right_list)
 
     score = float(fuzz.token_sort_ratio(left, right))
 
-    left_tokens, right_tokens = set(left.split()), set(right.split())
+    # "Skullcrushers" vs "Skull Crushers" differ only in word boundaries, which
+    # token-based scorers cannot see. Comparing with spaces stripped catches it,
+    # and stays low for genuinely different names ("benchpress" vs
+    # "inclinebenchpress" scores 74).
+    score = max(score, float(fuzz.ratio(left.replace(" ", ""), right.replace(" ", ""))))
+
+    left_tokens, right_tokens = set(left_list), set(right_list)
     is_strict_subset = left_tokens < right_tokens or right_tokens < left_tokens
     if (
         left_tokens != right_tokens
         and is_strict_subset
         and len(left_tokens) >= 2
         and len(right_tokens) >= 2
-        and (left_tokens ^ right_tokens) <= QUALIFIER_TOKENS
+        and (left_tokens ^ right_tokens) <= _QUALIFIER_TOKENS_SINGULAR
     ):
         score = max(score, float(fuzz.token_set_ratio(left, right)))
 
@@ -590,10 +637,10 @@ def get_or_create_exercise(
 _INSERT_WORKOUT_SET = text(
     """
     INSERT INTO workout_logs (
-        exercise_id, logged_at, weight_kg, reps, set_number,
+        exercise_id, logged_at, weight_kg, reps, cheat_reps, set_number,
         is_warmup, is_dropset, pain_flag, notes, raw_source, extraction_confidence
     ) VALUES (
-        :exercise_id, :logged_at, :weight_kg, :reps, :set_number,
+        :exercise_id, :logged_at, :weight_kg, :reps, :cheat_reps, :set_number,
         :is_warmup, :is_dropset, :pain_flag, :notes, :raw_source, :extraction_confidence
     )
     """
@@ -745,6 +792,7 @@ def process_entry(
                     "logged_at": resolve_logged_at(workout_set.logged_at_local, session_date),
                     "weight_kg": workout_set.weight_kg,
                     "reps": workout_set.reps,
+                    "cheat_reps": workout_set.cheat_reps,
                     "set_number": workout_set.set_number,
                     "is_warmup": workout_set.is_warmup,
                     "is_dropset": workout_set.is_dropset,

--- a/pipeline.py
+++ b/pipeline.py
@@ -118,9 +118,17 @@ Rules:
 - is_warmup true when the text says warm up / warmup / "warm up ish" / similar.
 - is_dropset true only when a drop set is explicitly described.
 - pain_flag true on ANY mention of pain, discomfort, injury, tweak, strain,
-  soreness that reads as a problem, or "felt something". Apply it to the set(s)
-  the mention relates to; if it is not tied to a specific set, apply it to every
-  set of the exercise it names.
+  soreness that reads as a problem, or "felt something".
+  - Effort is NOT pain. "almost died", "brutal", "killed me", "barely got it",
+    "struggled", "tough", "burned" describe how hard a set was, not an injury.
+    Leave pain_flag false for those.
+  - If the mention names an exercise, apply it to every working set of that
+    exercise.
+  - If it names no exercise ("shoulder pain noticed toward the end"), apply it
+    to the sets of the exercise described most recently BEFORE the mention in
+    the text. A body part is not an exercise: "shoulder pain" does not mean the
+    shoulder press.
+  - Never spread a single pain mention across every exercise in the entry.
 - logged_at_local: combine SESSION_DATE (given below) with any time marker in
   the text ("6:20ish" -> 18:20 if the session reads as an evening workout,
   06:20 if morning). Format "YYYY-MM-DDTHH:MM:SS", no timezone. If no time

--- a/schema.sql
+++ b/schema.sql
@@ -28,6 +28,10 @@ CREATE TABLE IF NOT EXISTS workout_logs (
     logged_at             TIMESTAMPTZ NOT NULL,
     weight_kg             NUMERIC(6, 2),
     reps                  INTEGER,
+    -- Reps within the set completed with momentum/assistance ("10 reps, 3 were
+    -- cheat"). Clean reps = reps - cheat_reps, and clean reps are what drive
+    -- estimated 1RM and the rep-range rules; total reps still drive volume.
+    cheat_reps            INTEGER NOT NULL DEFAULT 0,
     set_number            INTEGER,
     is_warmup             BOOLEAN NOT NULL DEFAULT FALSE,
     is_dropset            BOOLEAN NOT NULL DEFAULT FALSE,
@@ -39,6 +43,8 @@ CREATE TABLE IF NOT EXISTS workout_logs (
 
     CONSTRAINT workout_logs_weight_nonneg CHECK (weight_kg IS NULL OR weight_kg >= 0),
     CONSTRAINT workout_logs_reps_positive CHECK (reps IS NULL OR reps > 0),
+    CONSTRAINT workout_logs_cheat_reps_valid
+        CHECK (cheat_reps >= 0 AND (reps IS NULL OR cheat_reps <= reps)),
     CONSTRAINT workout_logs_confidence_range
         CHECK (extraction_confidence IS NULL
                OR (extraction_confidence >= 0 AND extraction_confidence <= 1))

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -574,3 +574,59 @@ class TestStageBContract:
         summary = insights.fallback_summary(stage_a)
         assert "62.5kg" in summary
         assert stage_a["recommendations"]["Bench Press"]["recommended_weight_kg"] == 62.5
+
+
+# --------------------------------------------------------------------------
+# Cheat reps: "10 reps 3 were cheat" is a count within a set, not a set flag
+# --------------------------------------------------------------------------
+
+
+class TestCheatReps:
+    def test_clean_reps_subtracts_cheat_reps(self):
+        assert insights.clean_reps(SetRecord("Lateral Raise", MONDAY, 7.5, 10, cheat_reps=3)) == 7
+
+    def test_defaults_to_all_reps_clean(self):
+        assert insights.clean_reps(SetRecord("Lateral Raise", MONDAY, 7.5, 10)) == 10
+
+    def test_missing_reps_stays_none(self):
+        assert insights.clean_reps(SetRecord("Lateral Raise", MONDAY, 7.5, None)) is None
+
+    def test_never_goes_negative(self):
+        assert insights.clean_reps(SetRecord("X", MONDAY, 10, 5, cheat_reps=9)) == 0
+
+    def test_e1rm_uses_clean_reps_not_total(self):
+        cheated = SetRecord("Lateral Raise", MONDAY, 7.5, 10, cheat_reps=3)
+        strict = SetRecord("Lateral Raise", MONDAY, 7.5, 7)
+        series_cheated = e1rm_series({MONDAY: [cheated]})
+        series_strict = e1rm_series({MONDAY: [strict]})
+        assert series_cheated == series_strict
+        assert series_cheated[0][1] == pytest.approx(9.25)
+
+    def test_counting_cheat_reps_as_clean_would_inflate_e1rm(self):
+        inflated = epley_1rm(7.5, 10)
+        honest = epley_1rm(7.5, 7)
+        assert inflated > honest
+
+    def test_a_fully_cheated_set_contributes_no_e1rm(self):
+        sets = {MONDAY: [SetRecord("X", MONDAY, 40, 8, cheat_reps=8)]}
+        assert e1rm_series(sets) == []
+
+    def test_volume_still_counts_every_rep_performed(self):
+        # The work happened, even if some reps were assisted.
+        record = SetRecord("Lateral Raise", MONDAY, 7.5, 10, cheat_reps=3)
+        assert total_volume([record]) == 75.0
+
+    def test_cheat_reps_can_flip_increase_into_hold(self):
+        strict = {MONDAY: [SetRecord("Lateral Raise", MONDAY, 7.5, 12)]}
+        assert recommend_for_exercise("Lateral Raise", strict).action == "increase"
+
+        cheated = {MONDAY: [SetRecord("Lateral Raise", MONDAY, 7.5, 12, cheat_reps=3)]}
+        rec = recommend_for_exercise("Lateral Raise", cheated)
+        assert rec.action == "hold"
+        assert rec.recommended_weight_kg == 7.5
+
+    def test_cheat_reps_can_trip_the_missed_bottom_rule(self):
+        sets = {MONDAY: [SetRecord("X", MONDAY, 40, 8, cheat_reps=4)]}  # 4 clean, below 6
+        rec = recommend_for_exercise("X", sets)
+        assert rec.action == "hold"
+        assert "below 6 reps" in rec.reason

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -426,3 +426,66 @@ class TestNumericGrounding:
 
     def test_normalizer_preserves_decimals(self):
         assert "82.4" in pipeline._normalize_numeric_text("Was  82.4KG this morning")
+
+
+# --------------------------------------------------------------------------
+# cheat_reps on the extraction model
+# --------------------------------------------------------------------------
+
+
+class TestCheatRepsModel:
+    def test_defaults_to_zero(self):
+        assert WorkoutSet(exercise_name="Lateral Raise", reps=10).cheat_reps == 0
+
+    def test_accepts_a_count_within_the_set(self):
+        s = WorkoutSet(exercise_name="Lateral Raise", weight_kg=7.5, reps=10, cheat_reps=3)
+        assert s.cheat_reps == 3
+
+    def test_rejects_more_cheat_reps_than_reps(self):
+        with pytest.raises(Exception, match="cheat_reps"):
+            WorkoutSet(exercise_name="Lateral Raise", reps=8, cheat_reps=9)
+
+    def test_allows_a_fully_cheated_set(self):
+        assert WorkoutSet(exercise_name="X", reps=5, cheat_reps=5).cheat_reps == 5
+
+    def test_rejects_negative(self):
+        with pytest.raises(Exception):
+            WorkoutSet(exercise_name="X", reps=5, cheat_reps=-1)
+
+
+# --------------------------------------------------------------------------
+# Matcher gaps found on real journal entries
+# --------------------------------------------------------------------------
+
+
+class TestRealEntryNameMatching:
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Skull Crushers", "Skullcrushers"),      # word boundary only
+            ("Cable Hammer Curls", "Hammer Curl"),    # qualifier + plural at once
+            ("Dumbbell Press", "Dumbbell Shoulder Press"),
+            ("Lateral Raises", "Lateral Raise"),
+            ("Face Pull", "Face Pulls"),
+        ],
+    )
+    def test_same_exercise_still_merges(self, proposed, existing):
+        assert find_matching_exercise(proposed, [existing]) == existing
+
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Dumbbell Press", "Dumbbell Bench Press"),   # shoulder vs chest
+            ("Lateral Raises", "Front Raises"),
+            ("Bench Press", "Incline Bench Press"),
+            ("Squat", "Front Squat"),
+        ],
+    )
+    def test_different_exercises_still_separate(self, proposed, existing):
+        assert find_matching_exercise(proposed, [existing]) is None
+
+    def test_singularizer_leaves_double_s_words_alone(self):
+        assert pipeline._singularize("press") == "press"
+        assert pipeline._singularize("curls") == "curl"
+        assert pipeline._singularize("raises") == "raise"
+        assert pipeline._singularize("abs") == "abs"  # too short to strip


### PR DESCRIPTION
Three fixes, all found by running **real journal entries** through the pipeline against live Groq. The original build was validated against `sample_entry.txt`, which was an imitation of the author's writing style — every one of these was invisible until real text went through.

## 1. Pain flags were attributed backwards

A live run on `sample_entry.txt` set `pain_flag` on *"Chest bench press 28kg 11 reps almost died"* and set nothing at all for *"Shoulder pain noticed toward the end"*.

Two gaps in the prompt caused it. Nothing stated that effort language differs from injury, so "almost died" read as distress. And the fallback for an untargeted mention was "apply it to every set of the exercise it names" — meaningless when the mention names no exercise, as this one doesn't. With no branch to follow, the model attached the flag to the nearest emotive phrase.

This is the failure direction the safeguard exists to prevent: as extracted, it would have held load on the exercise that was merely hard and **recommended a load increase on the one that actually hurt**.

The rule now states that effort words aren't pain, and that a mention naming no exercise attaches to the exercise described most recently before it, with a note that a body part is not an exercise name.

## 2. Cheat reps are a count, not a flag

`Lateral raises 7.5kg 10 reps 3 were cheat` means three reps *inside* a ten-rep set used momentum — not three cheat sets. A set-level boolean can't express that, so `workout_logs` gains a `cheat_reps` column.

**Clean reps** (`reps - cheat_reps`) now drive estimated 1RM and the rep-range rules. Volume still uses total reps, because the work was performed.

Not cosmetic:

```
counted as 10 reps : e1RM = 10.00 kg
counted as 7 clean : e1RM =  9.25 kg    ← 8.1% inflation

12 reps, 0 cheat -> 12 clean -> INCREASE
12 reps, 3 cheat ->  9 clean -> HOLD
```

A recommendation flip — the difference between adding weight and holding it on a lift that was cheated to finish.

## 3. Two exercise-name matching gaps

| Pair | Old score | Result |
|---|---|---|
| `Skullcrushers` ~ `Skull Crushers` | 59.3 | would split |
| `Cable Hammer Curls` ~ `Hammer Curl` | 75.9 | would split |

The first differs only in word boundaries, which token-based scorers can't see. The second differs by an equipment qualifier *and* a plural at once, which defeated the subset bonus — `curl` isn't a member of a token set containing `curls`, so the subset test failed.

Both would have silently split one exercise into two progress histories, which is the exact failure the fuzzy match exists to prevent. Names are now singularized before comparison (double-`s` words like "press" are left alone) and also compared with spaces stripped. All 22 pairs behave, including every pair that must stay separate — `Dumbbell Press` / `Dumbbell Bench Press`, `Bench Press` / `Incline Bench Press`, `Squat` / `Front Squat`.

## Prompt also learns

- cheat-rep notation (`"3 were cheat"`, `"last 2 were assisted"`, `"2 forced reps"`)
- `"each hand"` carries forward to later sets of the same exercise when written only once
- a bare time in a workout sequence is afternoon/evening, so `4:35` resolves to **16:35**, not 04:35

## Verification

End-to-end against Postgres 16 using the real entry:

```
inserted=11  review=1
  REVIEW: Skullcrushers -> confidence 0.65 below threshold 0.70
--- lateral raise sets ---
    set 3: 7.50kg x 10 reps (3 cheat -> 7 clean)
--- first logged time ---
    2026-08-19 16:35:00+00:00
--- recommendations ---
    Face Pull       increase   30.0 -> 32.5kg
    Lateral Raise   hold        7.5 ->  7.5kg
```

Also confirmed: `schema.sql` runs clean on a fresh database and stays idempotent; `migrations/001_add_cheat_reps.sql` applies to a database built from the previous schema while preserving existing rows, is re-runnable, and its CHECK constraint rejects `cheat_reps > reps`.

**172 tests pass** (up from 147), covering clean-rep arithmetic, the e1RM and rule branches cheat reps affect, `cheat_reps > reps` rejection, and both matcher gaps with the real names as cases.

## Migration required

This adds a column, so an existing database needs:

```bash
psql "$DATABASE_URL" -f migrations/001_add_cheat_reps.sql
```

Additive and non-destructive — existing rows default to 0 cheat reps, which is how they were already being scored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_