### PR TITLE
Show resolved time and clean-rep split in dry-run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ python seed_sample_data.py --reset      # three weeks of sample data
 uvicorn app:app --reload                # then open http://127.0.0.1:8000
 ```
 
+`--dry-run` calls Groq and prints what came back without touching the database,
+so it needs only `GROQ_API_KEY`. It shows the resolved local time and the
+clean-rep split, which is the only way to check either before anything is
+inserted:
+
+```
+  [INSERT] 1.00   16:35  Dumbbell Shoulder Press      10kg x 10  (warmup)
+  [INSERT] 1.00  ~18:00  Lateral Raise                7.5kg x 10 (3 cheat -> 7 clean)
+  [REVIEW] 0.65  ~18:00  Skull Crusher                10kg x ?
+```
+
+A leading `~` means the text carried no time marker and the default session hour
+was applied — which is how you spot a time the extraction missed.
+
 ## The decisions worth knowing about
 
 ### The LLM does not produce any number in the report
@@ -260,7 +274,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-172 tests, no network and no database required — they cover the Stage A rule
+190 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -34,6 +34,50 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _local_time_label(workout_set, session_date: date) -> str:
+    """Resolved wall-clock time for a set, in LOCAL_TIMEZONE.
+
+    Prefixed with "~" when the text carried no usable time marker and the
+    default session hour was applied, so a missed "4:35" is visible.
+    """
+    from zoneinfo import ZoneInfo
+
+    # Read the zone once and use it for both the resolve and the display, so the
+    # two can never disagree.
+    zone_name = pipeline.LOCAL_TIMEZONE
+    resolved = pipeline.resolve_logged_at(
+        workout_set.logged_at_local, session_date, zone_name
+    )
+    local = resolved.astimezone(ZoneInfo(zone_name))
+    prefix = "" if (workout_set.logged_at_local or "").strip() else "~"
+    return f"{prefix}{local:%H:%M}"
+
+
+def format_set_line(workout_set, confidence: float, session_date: date) -> str:
+    """One dry-run line: verdict, confidence, resolved time, load, reps, flags."""
+    verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
+    weight = f"{workout_set.weight_kg:g}kg" if workout_set.weight_kg is not None else "?kg"
+    reps = str(workout_set.reps) if workout_set.reps is not None else "?"
+
+    detail = f"{weight} x {reps}"
+    if workout_set.cheat_reps and workout_set.reps is not None:
+        clean = max(0, workout_set.reps - workout_set.cheat_reps)
+        detail += f" ({workout_set.cheat_reps} cheat -> {clean} clean)"
+
+    flags = ""
+    if workout_set.is_warmup:
+        flags += "  (warmup)"
+    if workout_set.is_dropset:
+        flags += "  (dropset)"
+    if workout_set.pain_flag:
+        flags += "  (PAIN)"
+
+    return (
+        f"  [{verdict}] {confidence:.2f}  {_local_time_label(workout_set, session_date):>6}  "
+        f"{workout_set.exercise_name:<28} {detail}{flags}"
+    )
+
+
 def _parse_date(value: str) -> date:
     try:
         return datetime.strptime(value, "%Y-%m-%d").date()
@@ -62,15 +106,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         payload = pipeline.extract_entities(raw_text, session_date)
         scored_sets, scored_bodyweight, review = pipeline.validate_extraction(payload, raw_text)
-        print(f"Dry run — nothing inserted. Session date: {session_date}\n")
+        print(f"Dry run — nothing inserted. Session date: {session_date}")
+        print(f"Times shown in {pipeline.LOCAL_TIMEZONE}; \"~\" means no time marker "
+              f"in the text, so the default hour was used.\n")
         for workout_set, confidence in scored_sets:
-            verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
-            print(
-                f"  [{verdict}] {confidence:.2f}  {workout_set.exercise_name} "
-                f"{workout_set.weight_kg}kg x {workout_set.reps}"
-                + ("  (warmup)" if workout_set.is_warmup else "")
-                + ("  (PAIN)" if workout_set.pain_flag else "")
-            )
+            print(format_set_line(workout_set, confidence, session_date))
         if scored_bodyweight:
             entry, confidence = scored_bodyweight
             verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,100 @@
+"""Tests for the dry-run line formatter.
+
+Pure string formatting, but it is the only place the extracted timestamp and
+cheat-rep count are visible before anything reaches the database — so a bug
+here means testing the extraction blind.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+
+import pytest
+
+import parse_workout_log
+import pipeline
+from parse_workout_log import format_set_line
+from pipeline import WorkoutSet
+
+SESSION = date(2026, 8, 19)
+
+
+def line_for(**kwargs) -> str:
+    defaults = dict(exercise_name="Lateral Raise", weight_kg=7.5, reps=10)
+    defaults.update(kwargs)
+    confidence = defaults.pop("confidence", 1.0)
+    return format_set_line(WorkoutSet(**defaults), confidence, SESSION)
+
+
+class TestVerdict:
+    def test_above_threshold_is_insert(self):
+        assert "[INSERT]" in line_for(confidence=1.0)
+
+    def test_below_threshold_is_review(self):
+        assert "[REVIEW]" in line_for(confidence=0.65)
+
+    def test_confidence_is_shown(self):
+        assert "0.65" in line_for(confidence=0.65)
+
+
+class TestRepsAndWeight:
+    def test_plain_set(self):
+        assert "7.5kg x 10" in line_for()
+
+    def test_missing_weight_and_reps_render_as_question_marks(self):
+        assert "?kg x ?" in line_for(weight_kg=None, reps=None)
+
+    def test_integer_weight_has_no_trailing_zero(self):
+        assert "30kg" in line_for(weight_kg=30.0)
+
+
+class TestCheatReps:
+    def test_cheat_reps_show_the_clean_count(self):
+        assert "(3 cheat -> 7 clean)" in line_for(reps=10, cheat_reps=3)
+
+    def test_no_annotation_when_nothing_was_cheated(self):
+        assert "cheat" not in line_for(reps=10, cheat_reps=0)
+
+    def test_fully_cheated_set_shows_zero_clean(self):
+        assert "(5 cheat -> 0 clean)" in line_for(reps=5, cheat_reps=5)
+
+
+class TestFlags:
+    def test_warmup(self):
+        assert "(warmup)" in line_for(is_warmup=True)
+
+    def test_dropset(self):
+        assert "(dropset)" in line_for(is_dropset=True)
+
+    def test_pain(self):
+        assert "(PAIN)" in line_for(pain_flag=True)
+
+    def test_no_flags_on_a_plain_working_set(self):
+        line = line_for()
+        assert "(warmup)" not in line and "(PAIN)" not in line
+
+
+class TestTimeLabel:
+    def test_extracted_afternoon_time_is_shown(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        assert "16:35" in line_for(logged_at_local="2026-08-19T16:35:00")
+
+    def test_missing_time_marker_is_flagged_with_a_tilde(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        line = line_for(logged_at_local=None)
+        assert "~" in line
+
+    def test_supplied_time_is_not_flagged(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        assert "~" not in line_for(logged_at_local="2026-08-19T16:35:00")
+
+    def test_time_is_rendered_in_the_configured_local_zone(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        # 16:35 local is stored as 11:35Z, and must display as 16:35 again.
+        assert "16:35" in line_for(logged_at_local="2026-08-19T16:35:00")
+
+    def test_a_timestamp_on_the_wrong_day_falls_back_to_the_default_hour(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        line = line_for(logged_at_local="2026-01-01T09:00:00")
+        assert "09:00" not in line


### PR DESCRIPTION
The dry run printed only weight and reps, so the two things most recently changed in extraction — the resolved timestamp and the cheat-rep count — couldn't be checked without querying the database afterwards. That made it a poor tool for exactly the cases it was added to catch.

## Before

```
  [INSERT] 1.00  Chest Bench Press 24.0kg x 12
  [REVIEW] 0.30  Cable Fly Nonekg x None
```

## After

```
  [INSERT] 1.00   16:35  Dumbbell Shoulder Press      10kg x 10  (warmup)
  [INSERT] 1.00   16:46  Dumbbell Shoulder Press      12.5kg x 10
  [INSERT] 1.00  ~18:00  Lateral Raise                7.5kg x 10 (3 cheat -> 7 clean)
  [INSERT] 1.00  ~18:00  Face Pull                    30kg x 12
  [REVIEW] 0.65  ~18:00  Skull Crusher                10kg x ?
  [INSERT] 1.00  ~18:00  Dumbbell Bench Press         15kg x 10  (PAIN)
```

Each line now carries the resolved wall-clock time in `LOCAL_TIMEZONE` and, where reps were cheated, the clean-rep split. A leading `~` marks a set whose text carried no usable time marker and fell back to the default session hour — so a missed `4:35` is visible rather than silent. `dropset` now shows alongside `warmup` and `PAIN`, and missing values render as `?` instead of `None`.

## A bug the tests found

Extracting the formatting into `format_set_line` (a pure function) and testing it surfaced an inconsistency: the label resolved the timestamp through `resolve_logged_at`'s default timezone, which is **bound at import**, while displaying it in the timezone read at **call time**. Those agree whenever both come from the same environment variable, which is why it went unnoticed in every prior run. The zone is now read once and used for both conversions.

## Tests

**190 pass** (up from 172). `tests/test_cli_output.py` adds 18 covering verdict and confidence rendering, the clean-rep annotation (including a fully-cheated set), each flag, missing weight/reps, and the time label — extracted time shown, `~` on fallback, correct rendering under a non-UTC zone, and a timestamp on the wrong day falling back rather than being displayed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_