### PR TITLE
Support serverless deployment, and add Vercel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,27 @@ the pooled connection URI as `DATABASE_URL`. Free projects pause after 7 days of
 inactivity; at normal logging frequency you will not notice, but that is why the
 first request after a long gap can be slow.
 
-**Web app — Render free tier.**
+**Web app — Vercel (Hobby).** Free, no card. Vercel auto-detects the FastAPI
+`app` in `app.py`, so there is nothing to configure beyond environment variables.
+
+- Import the repo at vercel.com, accept the detected settings
+- Set `DATABASE_URL`, `GROQ_API_KEY`, `APP_USERNAME`, `APP_PASSWORD` and
+  `LOCAL_TIMEZONE` in Project Settings → Environment Variables (`.env` is
+  gitignored, so it is not deployed)
+- `vercel.json` pins `maxDuration` to 60s, which covers a Groq call plus inserts
+
+Use the Supabase **transaction pooler (port 6543)** rather than session mode
+here. Serverless gives each request its own short-lived process, and the
+transaction pooler is built for exactly that churn. Session mode on 5432 also
+works, since the app already avoids retaining a pool.
+
+That last part matters: Vercel sets `VERCEL=1`, which switches
+`pipeline.get_engine` to SQLAlchemy's `NullPool`. A pool held between requests
+can never be reused when the process does not outlive the request, and would
+just hold Postgres slots open for nothing. Set `SERVERLESS=true` by hand on any
+other serverless host.
+
+**Web app — Render free tier** (alternative; now requires a card on file).**
 
 - Build: `pip install -r requirements.txt`
 - Start: `uvicorn app:app --host 0.0.0.0 --port $PORT`
@@ -294,7 +314,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-196 tests, no network and no database required — they cover the Stage A rule
+201 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/pipeline.py
+++ b/pipeline.py
@@ -26,6 +26,7 @@ from typing import Any, Iterable, Optional, Sequence
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from rapidfuzz import fuzz
 from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
 from sqlalchemy.engine import Connection, Engine
 
 try:  # Python 3.9+
@@ -75,6 +76,14 @@ DEFAULT_SESSION_HOUR = int(os.getenv("DEFAULT_SESSION_HOUR", "18"))
 
 # Window used by the /log duplicate-submission guard.
 DUPLICATE_WINDOW_MINUTES = int(os.getenv("DUPLICATE_WINDOW_MINUTES", "5"))
+
+# Serverless platforms hand each request its own short-lived process, so a
+# connection pool held between requests is never reused and only consumes
+# Postgres connection slots. Vercel sets VERCEL=1 itself; SERVERLESS is the
+# manual override for anywhere else.
+SERVERLESS = bool(os.getenv("VERCEL")) or os.getenv("SERVERLESS", "").strip().lower() in {
+    "1", "true", "yes", "on",
+}
 
 # Tokens that describe equipment or the muscle worked. When the ONLY difference
 # between two multi-word exercise names is tokens from this set, the names are
@@ -605,11 +614,19 @@ def _short_errors(exc: ValidationError) -> str:
 # --------------------------------------------------------------------------
 
 
-def get_engine(database_url: Optional[str] = None) -> Engine:
+def get_engine(database_url: Optional[str] = None, serverless: Optional[bool] = None) -> Engine:
     url = database_url or os.getenv("DATABASE_URL")
     if not url:
         raise RuntimeError("DATABASE_URL is not set")
-    # Free-tier Postgres drops idle connections; pre-ping avoids stale-handle errors.
+
+    if SERVERLESS if serverless is None else serverless:
+        # One connection per request, closed on release. Pooling across
+        # invocations is impossible when the process does not outlive them, and
+        # a retained pool would just hold Postgres slots open for nothing.
+        return create_engine(url, poolclass=NullPool, future=True)
+
+    # Long-running process: pool, and pre-ping because free-tier Postgres drops
+    # idle connections and a stale handle would otherwise surface as an error.
     return create_engine(url, pool_pre_ping=True, future=True)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -489,3 +489,43 @@ class TestRealEntryNameMatching:
         assert pipeline._singularize("curls") == "curl"
         assert pipeline._singularize("raises") == "raise"
         assert pipeline._singularize("abs") == "abs"  # too short to strip
+
+
+# --------------------------------------------------------------------------
+# Connection pooling: serverless invocations must not retain a pool
+# --------------------------------------------------------------------------
+
+
+class TestEnginePooling:
+    URL = "postgresql+psycopg2://u:p@localhost:55432/db"
+
+    def test_long_running_process_uses_a_real_pool(self):
+        from sqlalchemy.pool import NullPool
+
+        engine = pipeline.get_engine(self.URL, serverless=False)
+        assert not isinstance(engine.pool, NullPool)
+
+    def test_serverless_uses_nullpool(self):
+        from sqlalchemy.pool import NullPool
+
+        engine = pipeline.get_engine(self.URL, serverless=True)
+        assert isinstance(engine.pool, NullPool)
+
+    def test_vercel_env_var_switches_it_on(self, monkeypatch):
+        monkeypatch.setenv("VERCEL", "1")
+        import importlib
+
+        reloaded = importlib.reload(pipeline)
+        try:
+            assert reloaded.SERVERLESS is True
+        finally:
+            monkeypatch.delenv("VERCEL", raising=False)
+            importlib.reload(pipeline)
+
+    def test_off_by_default(self):
+        assert pipeline.SERVERLESS is False
+
+    def test_missing_url_still_raises(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            pipeline.get_engine()

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/app.py" }
+  ],
+  "functions": {
+    "app.py": { "maxDuration": 60 }
+  }
+}


### PR DESCRIPTION
Render now requires a card on file for its free tier, so Vercel's Hobby plan becomes the deployment target. Vercel detects the FastAPI `app` in `app.py` on its own, so the app needs no restructuring — but serverless changes one thing that matters.

## Connection pooling

Each request on Vercel gets its own short-lived process. A SQLAlchemy pool held between requests **can never be reused** when the process doesn't outlive the request, and holds Postgres connection slots open for nothing in the meantime.

`get_engine` now selects `NullPool` when running serverless — one connection per request, closed on release — and keeps the pooled, pre-pinging engine for long-running hosts:

```python
if SERVERLESS if serverless is None else serverless:
    return create_engine(url, poolclass=NullPool, future=True)
return create_engine(url, pool_pre_ping=True, future=True)
```

Detection is automatic (Vercel sets `VERCEL=1`); `SERVERLESS=true` is the manual override for other platforms. The explicit argument makes both paths directly testable.

## A correction

I'd previously argued against Vercel on the grounds that Hobby caps functions at 10 seconds. **That was wrong.** Hobby allows up to 60s, and up to 300s with Fluid compute (now the default). Either is ample for a Groq call plus inserts, or for Stage A queries plus Stage B narration. `vercel.json` pins `maxDuration` to 60.

## Verification

Against Postgres 16 with `VERCEL=1` set, exercising the real app through `TestClient`:

```
SERVERLESS detected: True
engine pool class  : Engine / NullPool
  [PASS] 401 without auth
  [PASS] form loads
  [PASS] insert works under NullPool
  [PASS] 6 sequential requests, no connection exhaustion
  [PASS] cheat_reps persisted  -- (10, 3, ...)
  [PASS] 16:35 Karachi stored as 11:35Z
  [PASS] weekly report route works
```

The timezone line is worth noting — it's the first end-to-end confirmation that `Asia/Karachi` round-trips correctly through `timestamptz`.

**201 tests pass** (up from 196). Five new cover pool selection: a real pool for long-running processes, `NullPool` when serverless, `VERCEL=1` flipping it via a module reload, off by default, and a missing `DATABASE_URL` still raising.

## Deploying

Import the repo at vercel.com and accept the detected settings. Set `DATABASE_URL`, `GROQ_API_KEY`, `APP_USERNAME`, `APP_PASSWORD`, `LOCAL_TIMEZONE` in Project Settings → Environment Variables — `.env` is gitignored, so it isn't deployed.

Prefer the Supabase **transaction pooler (port 6543)** over session mode here; it's built for exactly this request churn. Session mode on 5432 also works, since the app no longer retains a pool.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_