### PR TITLE
Fix the Vercel entrypoint, and pin tzdata

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,14 @@
+"""Vercel serverless entrypoint.
+
+vercel.json rewrites every route here. The repo root holds app.py, pipeline.py
+and insights.py, so it has to be importable from inside api/.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app import app  # noqa: E402 - the path setup above must run first
+
+__all__ = ["app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ uvicorn[standard]>=0.30
 python-multipart>=0.0.9
 rapidfuzz>=3.9
 python-dotenv>=1.0
+# zoneinfo reads the IANA database from the OS. Slim serverless images often
+# ship without it, which makes ZoneInfo("Asia/Karachi") raise at runtime.
+tzdata>=2024.1

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -135,3 +135,44 @@ class TestMask:
 
     def test_short_secret_is_fully_starred(self):
         assert parse_workout_log._mask("APP_PASSWORD", "abc123") == "******"
+
+
+# --------------------------------------------------------------------------
+# Vercel entrypoint: api/index.py must expose the same app, importable from api/
+# --------------------------------------------------------------------------
+
+
+class TestVercelEntrypoint:
+    def test_entrypoint_exports_the_same_app(self):
+        import importlib.util
+        from pathlib import Path
+
+        entry = Path(__file__).resolve().parent.parent / "api" / "index.py"
+        assert entry.is_file(), "api/index.py is the Vercel entrypoint and must exist"
+
+        spec = importlib.util.spec_from_file_location("vercel_entry", entry)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        import app as app_module
+
+        assert module.app is app_module.app
+
+    def test_vercel_json_routes_to_the_entrypoint(self):
+        import json
+        from pathlib import Path
+
+        config = json.loads(
+            (Path(__file__).resolve().parent.parent / "vercel.json").read_text()
+        )
+        assert config["rewrites"][0]["destination"] == "/api/index"
+        assert "api/index.py" in config["functions"]
+
+    def test_tzdata_is_pinned(self):
+        """zoneinfo reads the OS tz database; slim images often lack it."""
+        from pathlib import Path
+
+        requirements = (
+            Path(__file__).resolve().parent.parent / "requirements.txt"
+        ).read_text()
+        assert "tzdata" in requirements

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/app.py" }
+    { "source": "/(.*)", "destination": "/api/index" }
   ],
   "functions": {
-    "app.py": { "maxDuration": 60 }
+    "api/index.py": { "maxDuration": 60 }
   }
 }


### PR DESCRIPTION
The first Vercel deploy built successfully but every invocation failed with `FUNCTION_INVOCATION_FAILED` / `500`.

## Cause

My own `vercel.json` from the previous PR:

```json
"rewrites": [{ "source": "/(.*)", "destination": "/app.py" }],
"functions": { "app.py": { "maxDuration": 60 } }
```

Vercel rewrites target **routes, not files**, so `/app.py` never resolved — and the `functions` entry on a root-level file conflicted with framework detection.

Ruled out the alternative first: `app.py` imports cleanly with **no environment variables set at all**, which is what a cold start does, so this was never an import-time configuration failure.

## Fix

The explicit entrypoint pattern, which doesn't depend on auto-detection and so behaves the same however Vercel classifies the project:

- **`api/index.py`** — puts the repo root on `sys.path` and re-exports the app
- **`vercel.json`** — rewrites `/(.*)` → `/api/index`

Verified it imports from inside `api/` with all five routes present:

```
api/index.py imported OK -> FastAPI
routes: ['/', '/healthz', '/log', '/openapi.json', '/weekly-report']
```

## A second bug, caught before it bit

`tzdata` wasn't pinned. `zoneinfo` reads the IANA database from the OS, and slim serverless images frequently ship without it — `ZoneInfo("Asia/Karachi")` would have raised at runtime.

Not the cause of this crash, since nothing resolves a timezone at import. It would have surfaced on the **first insert** instead, which is a considerably worse place to discover it — after deployment looked healthy.

## Tests

**204 pass** (up from 201). Three new ones cover the deployment surface itself, which had no coverage at all until now:

- `api/index.py` exports the same FastAPI instance as `app.py`
- `vercel.json` rewrites to `/api/index` and declares that function
- `tzdata` stays pinned in `requirements.txt`

These are cheap and they fail loudly if someone edits the deploy config without updating the entrypoint — which is exactly the mistake this PR is fixing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_