### PR TITLE
Add a dependency-free probe for bisecting the failing deployment

### DIFF
--- a/api/ping.py
+++ b/api/ping.py
@@ -1,0 +1,22 @@
+"""Dependency-free probe for bisecting a failing deployment.
+
+Imports nothing from this project and nothing from requirements.txt. So:
+
+  /api/ping responds, / does not  -> Vercel's Python runtime is fine and the
+                                     failure is in importing the application
+                                     (a dependency, or module-level code)
+  neither responds                -> the failure is in the Vercel configuration
+                                     or the build itself, before our code runs
+
+Safe to delete once the deployment is healthy.
+"""
+
+from http.server import BaseHTTPRequestHandler
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - name required by BaseHTTPRequestHandler
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(b"ping ok - the vercel python runtime is working\n")

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -168,6 +168,22 @@ class TestVercelEntrypoint:
         assert config["rewrites"][0]["destination"] == "/api/index"
         assert "api/index.py" in config["functions"]
 
+    def test_probe_is_excluded_from_the_catch_all_rewrite(self):
+        """/api/ping must reach its own handler, not the application."""
+        import json
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parent.parent
+        config = json.loads((root / "vercel.json").read_text())
+        source = config["rewrites"][0]["source"]
+        pattern = re.compile("^" + source.replace("/((?!api/ping).*)", "/(?!api/ping).*") + "$")
+
+        assert pattern.match("/")
+        assert pattern.match("/log")
+        assert not pattern.match("/api/ping")
+        assert (root / "api" / "ping.py").is_file()
+
     def test_tzdata_is_pinned(self):
         """zoneinfo reads the OS tz database; slim images often lack it."""
         from pathlib import Path

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/api/index" }
+    { "source": "/((?!api/ping).*)", "destination": "/api/index" }
   ],
   "functions": {
     "api/index.py": { "maxDuration": 60 }


### PR DESCRIPTION
The Vercel deployment still returns `FUNCTION_INVOCATION_FAILED` after the entrypoint fix in #6, and diagnosing it from the browser error page has now been wrong twice. That page reports only *that* the function crashed, never *why*.

`api/ping.py` imports nothing from this project and nothing from `requirements.txt`. It separates the two possibilities the error page conflates:

| Result | Meaning |
|---|---|
| `/api/ping` responds, `/` does not | Vercel's runtime and routing are fine — the failure is importing the app (a dependency, or module-level code) |
| Neither responds | The failure is in configuration or the build, before any of our code runs |

The catch-all rewrite gains a negative lookahead so the probe reaches its own handler instead of being swallowed:

```json
{ "source": "/((?!api/ping).*)", "destination": "/api/index" }
```

Verified the routing behaves:

```
/                rewritten=True   (want True)   ok
/log             rewritten=True   (want True)   ok
/weekly-report   rewritten=True   (want True)   ok
/healthz         rewritten=True   (want True)   ok
/api/ping        rewritten=False  (want False)  ok
```

The probe is deliberately trivial, standard-library only, and safe to delete once the deployment is healthy. **205 tests pass.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_