### PR TITLE
Treat a blank environment variable as unset

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 # Serverless loaders import this file by path rather than as part of a package,
@@ -34,11 +34,24 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 # running normally, where the directory is already there.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import insights  # noqa: E402 - must follow the sys.path bootstrap above
-import pipeline  # noqa: E402
+# These imports are the ones that break on a misconfigured serverless deploy,
+# either because the sibling files were not bundled or because the loader did
+# not put this directory on the path. Left unguarded the whole module fails to
+# import and the platform reports an opaque "function crashed" with the real
+# reason buried in provider logs. Capturing it here lets the running app serve
+# the reason instead.
+_STARTUP_ERROR: Optional[str] = None
+try:
+    import insights  # noqa: E402 - must follow the sys.path bootstrap above
+    import pipeline  # noqa: E402
+except Exception:  # noqa: BLE001 - report anything that stops the app booting
+    import traceback
+
+    _STARTUP_ERROR = traceback.format_exc()
+    insights = pipeline = None  # type: ignore[assignment]
 
 logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    level=pipeline.env("LOG_LEVEL", "INFO").upper() if pipeline else "INFO",
     format='%(asctime)s level=%(levelname)s logger=%(name)s %(message)s',
 )
 logger = logging.getLogger("gym_tracker.app")
@@ -105,6 +118,17 @@ def require_auth(request: Request, credentials: HTTPBasicCredentials = Depends(s
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
+    if _STARTUP_ERROR is not None:
+        # Every route depends on the modules that failed to import, so serve the
+        # reason rather than a stack-less 500 from the platform.
+        logger.error("event=startup_failed path=%s", request.url.path)
+        return PlainTextResponse(
+            "The application failed to start.\n\n"
+            "This is an import error, not a configuration one - no secrets are "
+            "shown below.\n\n" + _STARTUP_ERROR,
+            status_code=500,
+        )
+
     started = time.perf_counter()
     try:
         response = await call_next(request)

--- a/insights.py
+++ b/insights.py
@@ -26,6 +26,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 import pipeline
+from pipeline import env
 
 logger = logging.getLogger(__name__)
 
@@ -36,32 +37,32 @@ logger = logging.getLogger(__name__)
 # Program-level stagnation is meaningless on a handful of exercises: with 2-3
 # logged, "60% plateaued" is noise. Require at least this many regularly-trained
 # exercises before the check runs at all.
-PROGRAM_STAGNATION_MIN_EXERCISES = int(os.getenv("PROGRAM_STAGNATION_MIN_EXERCISES", "4"))
+PROGRAM_STAGNATION_MIN_EXERCISES = int(env("PROGRAM_STAGNATION_MIN_EXERCISES", "4"))
 
 # Fraction of regularly-trained exercises that must be simultaneously plateaued.
-PROGRAM_STAGNATION_FRACTION = float(os.getenv("PROGRAM_STAGNATION_FRACTION", "0.6"))
+PROGRAM_STAGNATION_FRACTION = float(env("PROGRAM_STAGNATION_FRACTION", "0.6"))
 
 # Pain safeguard defaults to ON. Only an explicit env var turns it off; no code
 # path may skip the check on its own.
-PAIN_SAFEGUARD_ENABLED = os.getenv("PAIN_SAFEGUARD_ENABLED", "true").strip().lower() not in {
+PAIN_SAFEGUARD_ENABLED = env("PAIN_SAFEGUARD_ENABLED", "true").lower() not in {
     "false", "0", "no", "off",
 }
 
 # Working rep range used by the progressive-overload rules.
-WORKING_REP_RANGE_LOW = int(os.getenv("WORKING_REP_RANGE_LOW", "6"))
-WORKING_REP_RANGE_HIGH = int(os.getenv("WORKING_REP_RANGE_HIGH", "12"))
+WORKING_REP_RANGE_LOW = int(env("WORKING_REP_RANGE_LOW", "6"))
+WORKING_REP_RANGE_HIGH = int(env("WORKING_REP_RANGE_HIGH", "12"))
 
 # Smallest real load change available in the gym, in kg.
-PLATE_INCREMENT_KG = float(os.getenv("PLATE_INCREMENT_KG", "2.5"))
+PLATE_INCREMENT_KG = float(env("PLATE_INCREMENT_KG", "2.5"))
 
 # How much history each report considers.
-ANALYSIS_WEEKS = int(os.getenv("ANALYSIS_WEEKS", "6"))
+ANALYSIS_WEEKS = int(env("ANALYSIS_WEEKS", "6"))
 
 # Sessions of flat-or-declining e1RM that count as a per-exercise plateau.
-PLATEAU_MIN_SESSIONS = int(os.getenv("PLATEAU_MIN_SESSIONS", "3"))
+PLATEAU_MIN_SESSIONS = int(env("PLATEAU_MIN_SESSIONS", "3"))
 
 # Growth below this fraction over the window still counts as flat.
-PLATEAU_TOLERANCE = float(os.getenv("PLATEAU_TOLERANCE", "0.01"))
+PLATEAU_TOLERANCE = float(env("PLATEAU_TOLERANCE", "0.01"))
 
 GROQ_MODEL = pipeline.GROQ_MODEL
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -54,28 +54,41 @@ except ImportError:  # pragma: no cover - python-dotenv is optional
 # Configuration
 # --------------------------------------------------------------------------
 
+
+def env(name: str, default: str) -> str:
+    """Environment value, treating an empty or blank one as absent.
+
+    os.getenv returns "" for a variable that exists but has no value, so the
+    default never applies and float("") raises at import. Hosting dashboards
+    make that easy to do by accident, and the resulting crash happens before
+    any request is served, with no obvious link to the blank field.
+    """
+    value = os.getenv(name)
+    return value.strip() if value and value.strip() else default
+
+
 # Entries scoring below this are surfaced for manual review and NOT inserted.
-CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.7"))
+CONFIDENCE_THRESHOLD = float(env("CONFIDENCE_THRESHOLD", "0.7"))
 
 # rapidfuzz score (0-100) at or above which a proposed exercise name is treated
 # as the same exercise as an existing row.
-FUZZY_MATCH_THRESHOLD = float(os.getenv("FUZZY_MATCH_THRESHOLD", "85"))
+FUZZY_MATCH_THRESHOLD = float(env("FUZZY_MATCH_THRESHOLD", "85"))
 
 # Groq's Llama chat models (llama-3.3-70b-versatile, llama-3.1-8b-instant) were
 # deprecated for free/developer tiers on 2026-06-17. openai/gpt-oss-120b is the
 # recommended general-purpose replacement. Re-check console.groq.com/docs/models
 # before assuming this is still current.
-GROQ_MODEL = os.getenv("GROQ_MODEL", "openai/gpt-oss-120b")
+GROQ_MODEL = env("GROQ_MODEL", "openai/gpt-oss-120b")
 
 # Single fixed timezone: this is a single-user personal tool, so local wall-clock
 # time in the journal is always interpreted in this zone and stored as UTC.
-LOCAL_TIMEZONE = os.getenv("LOCAL_TIMEZONE", "UTC")
+LOCAL_TIMEZONE = env("LOCAL_TIMEZONE", "UTC")
 
 # Wall-clock time assumed for a session when the text carries no time marker.
-DEFAULT_SESSION_HOUR = int(os.getenv("DEFAULT_SESSION_HOUR", "18"))
+DEFAULT_SESSION_HOUR = int(env("DEFAULT_SESSION_HOUR", "18"))
 
 # Window used by the /log duplicate-submission guard.
-DUPLICATE_WINDOW_MINUTES = int(os.getenv("DUPLICATE_WINDOW_MINUTES", "5"))
+DUPLICATE_WINDOW_MINUTES = int(env("DUPLICATE_WINDOW_MINUTES", "5"))
 
 # Serverless platforms hand each request its own short-lived process, so a
 # connection pool held between requests is never reused and only consumes

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,6 +8,7 @@ bad fuzzy match fragments an exercise's progress history across several rows.
 from __future__ import annotations
 
 import json
+import os
 from datetime import date, datetime, timezone
 
 import pytest
@@ -529,3 +530,83 @@ class TestEnginePooling:
         monkeypatch.delenv("DATABASE_URL", raising=False)
         with pytest.raises(RuntimeError, match="DATABASE_URL"):
             pipeline.get_engine()
+
+
+# --------------------------------------------------------------------------
+# Empty environment variables must not crash the app at import
+# --------------------------------------------------------------------------
+
+
+class TestEnvHelper:
+    """os.getenv returns "" for a variable that exists but is blank, so the
+    default never applies. On Vercel that made float("") raise at import, which
+    the platform reported only as an opaque function crash."""
+
+    def test_unset_falls_back_to_the_default(self, monkeypatch):
+        monkeypatch.delenv("SOME_SETTING", raising=False)
+        assert pipeline.env("SOME_SETTING", "0.7") == "0.7"
+
+    def test_empty_string_falls_back_to_the_default(self, monkeypatch):
+        monkeypatch.setenv("SOME_SETTING", "")
+        assert pipeline.env("SOME_SETTING", "0.7") == "0.7"
+
+    def test_whitespace_only_falls_back_to_the_default(self, monkeypatch):
+        monkeypatch.setenv("SOME_SETTING", "   ")
+        assert pipeline.env("SOME_SETTING", "0.7") == "0.7"
+
+    def test_a_real_value_wins(self, monkeypatch):
+        monkeypatch.setenv("SOME_SETTING", "0.9")
+        assert pipeline.env("SOME_SETTING", "0.7") == "0.9"
+
+    def test_surrounding_whitespace_is_stripped(self, monkeypatch):
+        """Dashboard fields pick up stray spaces on paste."""
+        monkeypatch.setenv("SOME_SETTING", "  0.9  ")
+        assert pipeline.env("SOME_SETTING", "0.7") == "0.9"
+
+    @pytest.mark.parametrize(
+        "name,default",
+        [
+            ("CONFIDENCE_THRESHOLD", "0.7"),
+            ("FUZZY_MATCH_THRESHOLD", "85"),
+            ("DEFAULT_SESSION_HOUR", "18"),
+            ("DUPLICATE_WINDOW_MINUTES", "5"),
+            ("PLATE_INCREMENT_KG", "2.5"),
+            ("PLATEAU_TOLERANCE", "0.01"),
+        ],
+    )
+    def test_every_numeric_setting_survives_being_blank(self, name, default, monkeypatch):
+        monkeypatch.setenv(name, "")
+        assert float(pipeline.env(name, default)) == float(default)
+
+    def test_modules_import_with_every_setting_blank(self, monkeypatch):
+        """The regression: a blank value anywhere must not stop the app booting."""
+        import importlib
+
+        for name in (
+            "CONFIDENCE_THRESHOLD", "FUZZY_MATCH_THRESHOLD", "GROQ_MODEL",
+            "LOCAL_TIMEZONE", "DEFAULT_SESSION_HOUR", "DUPLICATE_WINDOW_MINUTES",
+            "PLATE_INCREMENT_KG", "ANALYSIS_WEEKS", "PLATEAU_MIN_SESSIONS",
+            "PLATEAU_TOLERANCE", "WORKING_REP_RANGE_LOW", "WORKING_REP_RANGE_HIGH",
+            "PROGRAM_STAGNATION_MIN_EXERCISES", "PROGRAM_STAGNATION_FRACTION",
+            "PAIN_SAFEGUARD_ENABLED", "LOG_LEVEL",
+        ):
+            monkeypatch.setenv(name, "")
+
+        import insights
+
+        reloaded_pipeline = importlib.reload(pipeline)
+        reloaded_insights = importlib.reload(insights)
+        try:
+            assert reloaded_pipeline.CONFIDENCE_THRESHOLD == 0.7
+            assert reloaded_pipeline.LOCAL_TIMEZONE == "UTC"
+            assert reloaded_insights.PLATE_INCREMENT_KG == 2.5
+            # Blank must not silently disable the safeguard.
+            assert reloaded_insights.PAIN_SAFEGUARD_ENABLED is True
+        finally:
+            for name in list(os.environ):
+                if name.startswith(("CONFIDENCE", "FUZZY", "GROQ", "LOCAL", "DEFAULT",
+                                    "DUPLICATE", "PLATE", "ANALYSIS", "PLATEAU",
+                                    "WORKING", "PROGRAM", "PAIN", "LOG_LEVEL")):
+                    monkeypatch.delenv(name, raising=False)
+            importlib.reload(pipeline)
+            importlib.reload(insights)

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "app.py": { "maxDuration": 60 }
+    "app.py": {
+      "maxDuration": 60,
+      "includeFiles": "*.py"
+    }
   }
 }


### PR DESCRIPTION
The Vercel runtime log finally gave the real failure:

```
File "/var/task/pipeline.py", line 58, in <module>
  CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.7"))
ValueError: could not convert string to float: ''
```

## Cause

`os.getenv` returns `""` for a variable that **exists but has no value**, so the default never applies and `float("")` raises.

`CONFIDENCE_THRESHOLD` had been created in the Vercel dashboard with a blank value — trivial to do by accident, and it gives no hint that it's the cause: the crash happens at import, before any request is served, and the platform reports only `FUNCTION_INVOCATION_FAILED`.

## Fix

Every setting read at import now goes through `pipeline.env`, which falls back to the default when the value is missing, empty, or whitespace-only, and strips surrounding whitespace so a value pasted with a stray space still works. Covers `pipeline`, `insights`, and the log level in `app`.

Reproduced and verified:

```
$ CONFIDENCE_THRESHOLD="" LOG_LEVEL="" PLATE_INCREMENT_KG="" python -c "import app"
  imported OK
  CONFIDENCE_THRESHOLD = 0.7
  LOCAL_TIMEZONE       = UTC
  PLATE_INCREMENT_KG   = 2.5
```

`PAIN_SAFEGUARD_ENABLED` was already safe by accident — `""` isn't in the set of false-like values — but it now goes through the same path rather than relying on that. A test asserts a blank value can't silently disable the safeguard.

## What the traceback also settled

Two earlier hypotheses were right, one was wrong. `/var/task/insights.py` and `/var/task/pipeline.py` both appear in the trace, so **the files were bundled and the `sys.path` bootstrap did work** — this was simply the next error behind it. The `includeFiles` addition is belt-and-braces, not a fix.

## Also: the app now reports its own startup failures

`app.py` captures an import failure and serves the traceback instead of letting the module fail to load. Three rounds here were spent reading an opaque platform error page while the real reason sat in provider logs. A running app can just say what went wrong.

## Tests

**217 pass** (up from 205). The regression test reloads both modules with *every* setting blank and asserts the defaults hold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_