### PR TITLE
Add a fitted trend line and weekly rate to each exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ number on a chart and the same number in the report cannot drift apart.
 
 A few decisions that are easy to get wrong:
 
+- **Each exercise carries a fitted trend line and its slope in kg/week.** The
+  shape of a line does not give the rate: two lifts can both end higher while
+  one is gaining three times as fast. The line drawn and the rate quoted beside
+  it come from the same least-squares fit, computed server-side, so they cannot
+  disagree.
 - **Every chart plots one series**, so there is no categorical palette and no
   legend - the card title names what is plotted. The single hue is validated
   against both the light and dark chart surfaces.

--- a/charts.py
+++ b/charts.py
@@ -237,7 +237,7 @@ PROGRESS_JS = """
   }
 
   // --- line chart: trend over time, one series ------------------------------
-  function lineChart(host, rows, unit, height) {
+  function lineChart(host, rows, unit, height, trend) {
     var W = host.clientWidth || 320, H = height || 190;
     var padL = 42, padR = 30, padT = 14, padB = 24;
     var svg = el('svg', { width: W, height: H });
@@ -259,6 +259,10 @@ PROGRESS_JS = """
     var Y = function (v) { return padT + ih - ((v - lo) / (hi - lo)) * ih; };
 
     var ticks = flat ? [vals[0]] : [lo, hi];
+    if (trend) {   // keep a steep fit inside the plot rather than clipping it
+      var tlo = Math.min(trend[0][1], trend[1][1]), thi = Math.max(trend[0][1], trend[1][1]);
+      if (tlo < lo) lo = tlo; if (thi > hi) hi = thi;
+    }
     ticks.forEach(function (v) {
       var y = Y(v);
       svg.appendChild(el('line', { x1: padL, y1: y, x2: W - padR, y2: y,
@@ -269,9 +273,22 @@ PROGRESS_JS = """
       svg.appendChild(t);
     });
 
+    if (trend) {
+      // Context, not a second series: de-emphasis ink, drawn under the data.
+      // The rate it represents is stated in the card subtitle, so it needs no
+      // legend entry of its own.
+      svg.appendChild(el('line', { x1: X(0), y1: Y(trend[0][1]),
+        x2: X(rows.length - 1), y2: Y(trend[1][1]),
+        stroke: tok('--ink-muted'), 'stroke-width': 2, 'stroke-linecap': 'round',
+        'stroke-opacity': 0.45 }));
+    }
     var d = rows.map(function (r, i) { return (i ? 'L' : 'M') + X(i) + ',' + Y(r[1]); }).join(' ');
-    svg.appendChild(el('path', { d: d + ' L' + X(rows.length - 1) + ',' + (padT + ih) +
-      ' L' + X(0) + ',' + (padT + ih) + ' Z', fill: tok('--series-1'), 'fill-opacity': 0.10 }));
+    if (!flat) {
+      // A constant series gets no area fill: the wash would hang below a
+      // mid-plot line and read as bottom-heavy magnitude that isn't varying.
+      svg.appendChild(el('path', { d: d + ' L' + X(rows.length - 1) + ',' + (padT + ih) +
+        ' L' + X(0) + ',' + (padT + ih) + ' Z', fill: tok('--series-1'), 'fill-opacity': 0.10 }));
+    }
     svg.appendChild(el('path', { d: d, fill: 'none', stroke: tok('--series-1'),
       'stroke-width': 2, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' }));
 
@@ -354,7 +371,7 @@ PROGRESS_JS = """
       } else if (kind.indexOf('e1rm:') === 0) {
         var idx = parseInt(kind.split(':')[1], 10);
         var s = DATA.exercise_e1rm[idx];
-        if (s) lineChart(host, s.points, 'kg', 150);
+        if (s) lineChart(host, s.points, 'kg', 150, s.trend);
       }
     });
   }
@@ -464,9 +481,12 @@ def render_progress_body(data: dict[str, Any]) -> str:
     for index, series in enumerate(data["exercise_e1rm"]):
         first, last = series["points"][0][1], series["points"][-1][1]
         change = last - first
+        slope = series.get("slope_per_week")
+        rate = f"{slope:+.1f} kg/week" if slope is not None else "not enough sessions"
         smalls.append(
             f'<div class="small"><h3>{html.escape(series["exercise"])}</h3>'
-            f'<p class="sub">{change:+.1f} kg over {len(series["points"])} sessions</p>'
+            f'<p class="sub">{rate} &middot; {change:+.1f} kg over '
+            f'{len(series["points"])} sessions</p>'
             f'<div class="plot" data-chart="e1rm:{index}"></div></div>'
         )
         for day, value in series["points"]:
@@ -474,7 +494,8 @@ def render_progress_body(data: dict[str, Any]) -> str:
 
     e1rm_card = _card(
         "Estimated 1RM by exercise",
-        "Epley, from clean reps only - cheat reps are excluded. Most-trained first.",
+        "Epley, from clean reps only. The grey line is the fitted trend; the rate "
+        "beside each name is its slope.",
         f'<div class="smalls">{"".join(smalls)}</div>' if smalls
         else '<p class="empty">Needs at least two sessions of an exercise to show a trend.</p>',
         _table(["Exercise", "Session", "e1RM (kg)"], e1rm_rows, "Table view") if e1rm_rows else "",

--- a/insights.py
+++ b/insights.py
@@ -887,6 +887,50 @@ def weekly_volume_series(
     return [(week, round(totals[week], 1)) for week in week_starts]
 
 
+def trend_slope_per_week(points: list[tuple[date, float]]) -> Optional[float]:
+    """Least-squares slope of a series, in units per week.
+
+    Answers "how fast am I improving on this lift", which the shape of the line
+    alone does not: two lifts can both rise while one is gaining three times as
+    fast. Returns None below two points, or when every session lands on the same
+    day and the slope would be a division by zero.
+    """
+    if len(points) < 2:
+        return None
+    origin = points[0][0]
+    xs = [(day - origin).days for day, _ in points]
+    ys = [value for _, value in points]
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator == 0:
+        return None
+    slope_per_day = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / denominator
+    return round(slope_per_day * 7, 2)
+
+
+def trend_endpoints(
+    points: list[tuple[date, float]]
+) -> Optional[tuple[tuple[date, float], tuple[date, float]]]:
+    """The fitted line's two endpoints, from the same fit as the slope.
+
+    Computed here rather than in the browser so the line drawn and the rate
+    quoted beside it come from one calculation and cannot disagree.
+    """
+    slope = trend_slope_per_week(points)
+    if slope is None:
+        return None
+    origin = points[0][0]
+    span = (points[-1][0] - origin).days
+    mean_y = sum(value for _, value in points) / len(points)
+    mean_x = sum((day - origin).days for day, _ in points) / len(points)
+    per_day = slope / 7
+    start = mean_y + (0 - mean_x) * per_day
+    end = mean_y + (span - mean_x) * per_day
+    return (points[0][0], round(start, 2)), (points[-1][0], round(end, 2))
+
+
 def exercise_e1rm_series(
     records: Iterable[SetRecord], limit: int = 6, min_sessions: int = 2
 ) -> list[tuple[str, list[tuple[date, float]]]]:
@@ -971,7 +1015,15 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
         "weekly_volume": [[week.isoformat(), value] for week, value in
                           weekly_volume_series(records, week_starts)],
         "exercise_e1rm": [
-            {"exercise": name, "points": [[day.isoformat(), value] for day, value in points]}
+            {
+                "exercise": name,
+                "points": [[day.isoformat(), value] for day, value in points],
+                "slope_per_week": trend_slope_per_week(points),
+                "trend": (
+                    [[day.isoformat(), value] for day, value in trend_endpoints(points)]
+                    if trend_endpoints(points) else None
+                ),
+            }
             for name, points in exercise_e1rm_series(records)
         ],
         "bodyweight": [[day.isoformat(), value] for day, value in bodyweight],

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -167,3 +167,78 @@ class TestRendering:
         would make the tooltip an injection point."""
         assert not re.search(r"\.innerHTML\s*[=+]", charts.PROGRESS_JS)
         assert "textContent" in charts.PROGRESS_JS
+
+
+# --------------------------------------------------------------------------
+# Trend: the rate of improvement, which the shape of a line does not give
+# --------------------------------------------------------------------------
+
+
+class TestTrendSlope:
+    def _series(self, values, step_days=7):
+        return [(MONDAY + timedelta(days=i * step_days), v) for i, v in enumerate(values)]
+
+    def test_steady_gain(self):
+        assert insights.trend_slope_per_week(self._series([60, 62.5, 65])) == 2.5
+
+    def test_flat_series_is_zero_not_none(self):
+        """Zero is a real answer - "you are not progressing" is information."""
+        assert insights.trend_slope_per_week(self._series([60, 60, 60])) == 0.0
+
+    def test_decline_is_negative(self):
+        assert insights.trend_slope_per_week(self._series([60, 58, 56])) == -2.0
+
+    def test_fits_through_noise(self):
+        """Two lifts can both end higher while one is gaining far faster; the
+        endpoints alone cannot tell them apart."""
+        slope = insights.trend_slope_per_week(self._series([60, 64, 62, 68]))
+        assert 1.5 < slope < 3.0
+
+    def test_endpoints_ignored_in_favour_of_the_whole_series(self):
+        spiky = self._series([60, 75, 61, 62])       # one outlier session
+        assert insights.trend_slope_per_week(spiky) < 5.0
+
+    def test_single_point_has_no_slope(self):
+        assert insights.trend_slope_per_week(self._series([60])) is None
+
+    def test_all_points_on_one_day_has_no_slope(self):
+        same_day = [(MONDAY, 60.0), (MONDAY, 62.0)]
+        assert insights.trend_slope_per_week(same_day) is None
+
+    def test_daily_spacing_still_reports_per_week(self):
+        daily = self._series([60, 61, 62, 63, 64, 65, 66, 67], step_days=1)
+        assert insights.trend_slope_per_week(daily) == 7.0
+
+
+class TestTrendEndpoints:
+    def test_endpoints_match_the_quoted_slope(self):
+        """Drawn line and quoted rate come from one fit, so they cannot disagree."""
+        points = [(MONDAY + timedelta(days=i * 7), v) for i, v in enumerate([60, 64, 62, 68])]
+        slope = insights.trend_slope_per_week(points)
+        (start_day, start), (end_day, end) = insights.trend_endpoints(points)
+        weeks = (end_day - start_day).days / 7
+        assert (end - start) / weeks == pytest.approx(slope, abs=0.02)
+
+    def test_none_when_there_is_no_fit(self):
+        assert insights.trend_endpoints([(MONDAY, 60.0)]) is None
+
+    def test_endpoints_span_the_series(self):
+        points = [(MONDAY + timedelta(days=i * 7), v) for i, v in enumerate([60, 62, 64])]
+        (first, _), (last, _) = insights.trend_endpoints(points)
+        assert first == points[0][0] and last == points[-1][0]
+
+
+class TestTrendRendering:
+    def test_rate_is_shown_beside_each_exercise(self):
+        data = TestRendering()._data()
+        data["exercise_e1rm"][0]["slope_per_week"] = 1.63
+        data["exercise_e1rm"][0]["trend"] = [[MONDAY.isoformat(), 80.0],
+                                             [(MONDAY + timedelta(7)).isoformat(), 82.0]]
+        body = charts.render_progress_body(data)
+        assert "+1.6 kg/week" in body
+
+    def test_missing_slope_says_so_rather_than_showing_a_number(self):
+        data = TestRendering()._data()
+        data["exercise_e1rm"][0]["slope_per_week"] = None
+        data["exercise_e1rm"][0]["trend"] = None
+        assert "not enough sessions" in charts.render_progress_body(data)


### PR DESCRIPTION
Follows #10. The per-exercise charts showed the *shape* of progress but not its *rate* — which is the thing actually being asked when someone wants to know how they're improving. Two lifts can both end higher while one is gaining three times as fast, and the endpoints alone can't tell them apart.

## What it adds

Each exercise carries a least-squares fit drawn as a grey line under the data, with its slope stated in kg/week beside the name:

```
Overhead Press      +1.6 kg/week · +11.4 kg over 8 sessions
Chest Bench Press   +0.2 kg/week ·  +1.6 kg over 6 sessions
Barbell Row         +0.0 kg/week ·  +0.0 kg over 6 sessions
```

The total change stays alongside the rate, since a rate alone hides how long the window is.

## Why a fit, not first-vs-last

Chest Bench Press in the seeded data zigzags — up, down hard, up again. Eyeballing that line you can't tell whether it's progressing; the fit rises steadily through it and says it is, slowly.

Using endpoints instead, one lucky or bad session would redefine the whole trend. The fit uses every session, so an outlier nudges the line rather than dictating it — there's a test with a deliberately spiky series asserting exactly that.

**The drawn line and the quoted rate come from the same function, computed server-side**, so they cannot drift apart. Same principle as the weekly report: one calculation, one source of truth.

Sessions sharing a date, and single-session exercises, report **no slope** rather than a fabricated one — `trend_slope_per_week` returns `None` instead of dividing by zero, and the card says "not enough sessions".

## Also

Flat series lose their area fill. The wash hung below a mid-plot line and read as bottom-heavy magnitude, on a series whose entire point is that nothing changed.

## Verification

Seeded a genuinely progressing lift alongside the seeder's deliberate plateaus and screenshotted the result — the fit tracks visibly through noise, and sits under the data line where progress is already linear. Re-audited at 360, 390 and 900px: no overflow, no clipping, no console errors.

**249 tests pass** (up from 236), covering steady gain, flat (zero is a real answer — "you are not progressing" is information), decline, noise, outliers, single points, same-day sessions, daily spacing reported per week, and that the endpoints reproduce the quoted slope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_