### PR TITLE
Offer add or replace when a day already has entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ worth getting looked at. That is the whole of it — the Stage B prompt forbids 
 model from going further, and a unit test asserts the note never mentions a
 diagnosis or a corrective exercise.
 
+### Two entries on the same day
+
+Logging a second time against a date that already has rows asks which you meant:
+
+- **Add** (the default) - a second session that day, or sets you forgot. Rows
+  accumulate, which is what you want for a morning and an evening session.
+- **Replace** - discard everything already logged on that date and use this
+  entry instead. For correcting a bad parse, not for adding.
+
+Replace is deliberately never the default, and never implicit. Two safeguards
+back it: the delete and the insert that follows commit in one transaction, so a
+failure mid-way cannot leave the day emptied with nothing put back; and it only
+runs when there is something to insert, so a failed extraction or an
+all-review entry leaves the existing day untouched.
+
+The delete window is a UTC range covering one *local* day, so it cannot reach
+into a neighbouring date - tested at an offset zone, not just UTC.
+
+`--replace` does the same from the CLI.
+
 ### Duplicate submissions
 
 Render's free tier cold-starts in 30–50s after idle, which is exactly when you

--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 h1 { font-size: 1.35rem; margin: 0 0 1rem; }
 h2 { font-size: 1.1rem; margin: 1.4rem 0 .5rem; }
 label { display: block; font-weight: 600; margin: .9rem 0 .3rem; }
-input[type=date], textarea, button { width: 100%; font-size: 1rem; padding: .7rem;
+input[type=date], textarea, button, select { width: 100%; font-size: 1rem; padding: .7rem;
        border-radius: .5rem; border: 1px solid #8884; font-family: inherit; }
 textarea { min-height: 11rem; resize: vertical; }
 button { margin-top: 1rem; font-weight: 600; border: 0; background: #2563eb; color: #fff; }
@@ -258,6 +258,14 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
             f"{html.escape(session_date.isoformat())}.</div>"
         )
 
+    if result.replaced:
+        removed = result.replaced
+        parts.append(
+            '<div class="card warn"><strong>Replaced that day.</strong> Removed '
+            f"{removed['sets']} set(s) and {removed['bodyweight']} bodyweight "
+            "entry/entries logged earlier on this date before saving this one.</div>"
+        )
+
     if result.exercises_created:
         names = ", ".join(html.escape(name) for name in result.exercises_created)
         parts.append(f'<div class="card muted">New exercises created: {names}</div>')
@@ -316,11 +324,18 @@ async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
   <label for="raw_text">Journal entry</label>
   <textarea id="raw_text" name="raw_text" required
     placeholder="Paste straight from Notes. Messy is fine."></textarea>
+  <label for="mode">If that day already has entries</label>
+  <select id="mode" name="mode">
+    <option value="add" selected>Add to them &mdash; a second session, or more sets</option>
+    <option value="replace">Replace them &mdash; discard that day and use this instead</option>
+  </select>
   <button type="submit">Parse &amp; save</button>
 </form>
 <p class="muted">Sets below the confidence threshold
 ({pipeline.CONFIDENCE_THRESHOLD:.0%}) are listed for review instead of being saved.
-Bodyweight mentions in the same entry are picked up automatically.</p>
+Bodyweight mentions in the same entry are picked up automatically.
+<strong>Replace</strong> deletes everything already logged on that date, so use it to
+correct a bad entry &mdash; not to add an evening session.</p>
 """,
     )
 
@@ -329,6 +344,7 @@ Bodyweight mentions in the same entry are picked up automatically.</p>
 async def log_entry(
     session_date: str = Form(...),
     raw_text: str = Form(...),
+    mode: str = Form("add"),
     _user: str = Depends(require_auth),
 ) -> HTMLResponse:
     try:
@@ -345,15 +361,18 @@ async def log_entry(
         parsed_date,
         engine=get_engine(),
         check_duplicates=True,
+        replace_existing=(mode == "replace"),
     )
     logger.info(
-        "event=log_processed date=%s inserted_sets=%d inserted_bodyweight=%d "
-        "review=%d duplicate=%s",
+        "event=log_processed date=%s mode=%s inserted_sets=%d inserted_bodyweight=%d "
+        "review=%d duplicate=%s replaced=%s",
         parsed_date,
+        mode,
         result.inserted_sets,
         result.inserted_bodyweight,
         len(result.review_items),
         result.duplicate_of_recent,
+        result.replaced,
     )
     return _page(
         "Result",

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -33,6 +33,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Report where each setting comes from, test the connections, and exit",
     )
     parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Discard everything already logged on that date before inserting",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Extract and score without inserting anything",
@@ -274,12 +279,15 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  [REVIEW] {item.kind}: {item.reason}")
         return 0
 
-    result = pipeline.process_entry(raw_text, session_date)
+    result = pipeline.process_entry(raw_text, session_date, replace_existing=args.replace)
 
     if result.error:
         print(f"Error: {result.error}", file=sys.stderr)
 
     print(f"Session date : {session_date}")
+    if result.replaced:
+        print(f"Replaced     : removed {result.replaced['sets']} set(s), "
+              f"{result.replaced['bodyweight']} bodyweight entry/entries")
     print(f"Inserted     : {result.inserted_sets} set(s), "
           f"{result.inserted_bodyweight} bodyweight entry/entries")
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -255,6 +255,7 @@ class PipelineResult:
     exercises_created: list[str] = field(default_factory=list)
     exercises_matched: list[tuple[str, str]] = field(default_factory=list)
     duplicate_of_recent: bool = False
+    replaced: Optional[dict[str, int]] = None
     error: Optional[str] = None
 
     @property
@@ -405,13 +406,20 @@ def _grounding_similarity(exercise_name: str, haystack: str) -> float:
     ) / 100.0
 
 
-def local_to_utc(local_dt: datetime, timezone_name: str = LOCAL_TIMEZONE) -> datetime:
-    """Attach the fixed local timezone to a naive datetime and convert to UTC."""
+def local_to_utc(local_dt: datetime, timezone_name: Optional[str] = None) -> datetime:
+    """Attach the fixed local timezone to a naive datetime and convert to UTC.
+
+    The zone is resolved at call time, not bound as a default argument. A
+    default would freeze whatever LOCAL_TIMEZONE held at import, so a later
+    change to it would silently not apply - which matters most for the delete
+    window in `_local_day_bounds`, where a stale zone would remove the wrong
+    day's rows.
+    """
     from datetime import timezone as _tz
 
     if ZoneInfo is None:  # pragma: no cover
         raise RuntimeError("zoneinfo unavailable; Python 3.9+ required")
-    tz = ZoneInfo(timezone_name)
+    tz = ZoneInfo(timezone_name or LOCAL_TIMEZONE)
     aware = local_dt.replace(tzinfo=tz) if local_dt.tzinfo is None else local_dt
     return aware.astimezone(_tz.utc)
 
@@ -419,8 +427,8 @@ def local_to_utc(local_dt: datetime, timezone_name: str = LOCAL_TIMEZONE) -> dat
 def resolve_logged_at(
     logged_at_local: Optional[str],
     session_date: date,
-    timezone_name: str = LOCAL_TIMEZONE,
-    default_hour: int = DEFAULT_SESSION_HOUR,
+    timezone_name: Optional[str] = None,
+    default_hour: Optional[int] = None,
 ) -> datetime:
     """Turn the model's local-time guess into a UTC timestamp.
 
@@ -428,6 +436,9 @@ def resolve_logged_at(
     date the user supplied. Anything else falls back to the session date at
     `default_hour` — the model does not get to move a workout to another day.
     """
+    timezone_name = timezone_name or LOCAL_TIMEZONE
+    default_hour = DEFAULT_SESSION_HOUR if default_hour is None else default_hour
+
     if logged_at_local:
         parsed: Optional[datetime] = None
         candidate = logged_at_local.strip().replace("Z", "+00:00")
@@ -701,6 +712,48 @@ _INSERT_BODYWEIGHT = text(
 )
 
 
+def _local_day_bounds(session_date: date) -> tuple[datetime, datetime]:
+    """The UTC window covering one local calendar day."""
+    start = local_to_utc(datetime.combine(session_date, time.min))
+    end = local_to_utc(datetime.combine(session_date + timedelta(days=1), time.min))
+    return start, end
+
+
+def count_entries_for_date(engine: Engine, session_date: date) -> dict[str, int]:
+    """How much is already logged against a local date."""
+    start, end = _local_day_bounds(session_date)
+    params = {"start": start, "end": end}
+    with engine.connect() as conn:
+        sets = conn.execute(
+            text("SELECT count(*) FROM workout_logs WHERE logged_at >= :start AND logged_at < :end"),
+            params,
+        ).scalar_one()
+        bodyweight = conn.execute(
+            text("SELECT count(*) FROM bodyweight_logs "
+                 "WHERE logged_at >= :start AND logged_at < :end"),
+            params,
+        ).scalar_one()
+    return {"sets": int(sets), "bodyweight": int(bodyweight)}
+
+
+def delete_entries_for_date(conn: Connection, session_date: date) -> dict[str, int]:
+    """Remove every log row on a local date. Caller owns the transaction.
+
+    Takes a Connection rather than an Engine so the delete and the insert that
+    replaces it commit together: a failure mid-way must never leave the day
+    emptied with nothing put back.
+    """
+    start, end = _local_day_bounds(session_date)
+    params = {"start": start, "end": end}
+    sets = conn.execute(
+        text("DELETE FROM workout_logs WHERE logged_at >= :start AND logged_at < :end"), params
+    ).rowcount
+    bodyweight = conn.execute(
+        text("DELETE FROM bodyweight_logs WHERE logged_at >= :start AND logged_at < :end"), params
+    ).rowcount
+    return {"sets": int(sets or 0), "bodyweight": int(bodyweight or 0)}
+
+
 def find_recent_submission(
     engine: Engine,
     raw_text: str,
@@ -751,6 +804,7 @@ def process_entry(
     client: Any = None,
     check_duplicates: bool = False,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    replace_existing: bool = False,
 ) -> PipelineResult:
     """Run the full pipeline for one journal entry.
 
@@ -819,6 +873,11 @@ def process_entry(
         return result
 
     with engine.begin() as conn:
+        if replace_existing:
+            # Only reached when there is something to put back - the early
+            # return above means a failed extraction never empties the day.
+            result.replaced = delete_entries_for_date(conn, session_date)
+            logger.info("Replaced %s on %s", result.replaced, session_date)
         known = load_exercise_names(conn)
         for workout_set, confidence in accepted_sets:
             exercise_id, matched_name, created = get_or_create_exercise(

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -188,3 +188,30 @@ class TestVercelEntrypoint:
             Path(__file__).resolve().parent.parent / "requirements.txt"
         ).read_text()
         assert "tzdata" in requirements
+
+
+class TestSameDayMode:
+    """Replace deletes a whole day, so it must never be the default anywhere."""
+
+    def test_cli_replace_flag_defaults_off(self):
+        args = parse_workout_log.parse_args(["entry.txt", "2026-08-20"])
+        assert args.replace is False
+
+    def test_cli_replace_flag_can_be_set(self):
+        args = parse_workout_log.parse_args(["entry.txt", "2026-08-20", "--replace"])
+        assert args.replace is True
+
+    def test_form_offers_both_modes_with_add_selected(self):
+        import app as app_module
+
+        page = app_module._page("t", "").body.decode()
+        assert 'name="mode"' not in page   # the nav page has no form
+
+    def test_form_markup_defaults_to_add(self):
+        import inspect
+
+        import app as app_module
+
+        source = inspect.getsource(app_module.index)
+        assert 'value="add" selected' in source
+        assert 'value="replace"' in source

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -610,3 +610,54 @@ class TestEnvHelper:
                     monkeypatch.delenv(name, raising=False)
             importlib.reload(pipeline)
             importlib.reload(insights)
+
+
+# --------------------------------------------------------------------------
+# Same-day handling: add vs replace
+# --------------------------------------------------------------------------
+
+
+class TestLocalDayBounds:
+    """Replace deletes by a UTC window covering one LOCAL day. Getting the
+    window wrong would delete a neighbouring day's rows."""
+
+    def test_utc_day_is_midnight_to_midnight(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        start, end = pipeline._local_day_bounds(date(2026, 8, 20))
+        assert start == datetime(2026, 8, 20, tzinfo=timezone.utc)
+        assert end == datetime(2026, 8, 21, tzinfo=timezone.utc)
+
+    def test_offset_zone_shifts_the_window(self, monkeypatch):
+        """Karachi is UTC+5, so its day runs 19:00 the previous day to 19:00."""
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        start, end = pipeline._local_day_bounds(date(2026, 8, 20))
+        assert start == datetime(2026, 8, 19, 19, 0, tzinfo=timezone.utc)
+        assert end == datetime(2026, 8, 20, 19, 0, tzinfo=timezone.utc)
+
+    def test_window_is_exactly_one_day(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        start, end = pipeline._local_day_bounds(date(2026, 8, 20))
+        assert end - start == timedelta(days=1)
+
+    def test_consecutive_days_abut_without_overlapping(self, monkeypatch):
+        """An overlap would let replace delete part of the neighbouring day."""
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        _, first_end = pipeline._local_day_bounds(date(2026, 8, 20))
+        second_start, _ = pipeline._local_day_bounds(date(2026, 8, 21))
+        assert first_end == second_start
+
+
+class TestReplaceIsOptIn:
+    def test_process_entry_defaults_to_adding(self):
+        import inspect
+
+        signature = inspect.signature(pipeline.process_entry)
+        assert signature.parameters["replace_existing"].default is False
+
+    def test_result_reports_nothing_replaced_by_default(self):
+        assert pipeline.PipelineResult().replaced is None
+
+    def test_empty_entry_never_reports_a_replace(self):
+        """Nothing to insert means nothing should have been deleted."""
+        result = pipeline.process_entry("   ", date(2026, 8, 20))
+        assert result.replaced is None and result.error


### PR DESCRIPTION
Logging twice against the same date previously just accumulated rows, with no way to correct a bad parse from the app — a fat-fingered entry was stuck until someone deleted it in the database by hand. The only guard keyed on identical text within five minutes, so resubmitting the same entry later silently inserted a second copy.

## What changes

The form now asks which you meant:

- **Add** (default) — a second session that day, or sets you forgot. Keeps the existing behaviour.
- **Replace** — discard everything already logged on that date and use this entry instead.

`--replace` does the same from the CLI. The result page reports exactly what was removed.

## Why replace is hard to trigger by accident

It deletes a whole day, so it's never the default and never implicit. Two things back it:

**The delete and the insert commit in one transaction.** `delete_entries_for_date` takes a `Connection` rather than an `Engine` specifically so this can't be got wrong at the call site — a failure between them can't leave the day emptied with nothing put back.

**It only runs once there's something to insert.** A failed extraction, or an entry landing entirely in review, leaves the existing day alone.

## A latent bug the tests surfaced

`local_to_utc` took its timezone as a **default argument, bound at import**. Monkeypatching `LOCAL_TIMEZONE` didn't affect it, and any later change to the setting would silently not apply.

Production never noticed, because both values come from the same environment variable — but the *delete window* depends on that zone, and a stale one would remove a neighbouring day's rows. Both `local_to_utc` and `resolve_logged_at` now resolve it at call time.

This is the third instance of this pattern in the codebase (after the CLI's time label), so it's worth naming: a module-level config value used as a function default freezes at import.

## Verification

Against Postgres:

```
[PASS] both sessions kept  -- (2, 1)
[PASS] counts that local date  -- {'sets': 2, 'bodyweight': 1}
[PASS] only the new set remains  -- (1, 0)
[PASS] reports what it removed  -- {'sets': 2, 'bodyweight': 1}
[PASS] the other day survived
[PASS] nothing was deleted  (failed extraction)
[PASS] nothing was deleted  (all-review entry)
```

**260 tests pass.** The day-boundary tests run at an offset zone (`Asia/Karachi`, UTC+5) rather than UTC, where an off-by-one window would be invisible — including that consecutive days abut exactly, since an overlap would let replace reach into the neighbouring date.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_