### PR TITLE
Make the two extraction attempts differ, and cap reasoning effort

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ GROQ_API_KEY=gsk_your_key_here
 # general-purpose replacement. Re-check console.groq.com/docs/models before
 # assuming this is still current.
 GROQ_MODEL=openai/gpt-oss-120b
+# gpt-oss models reason before answering and share the completion budget between
+# the reasoning and the answer. At the default "medium" effort a long
+# deliberation can leave nothing for the JSON, which Groq rejects as
+# json_validate_failed with an empty failed_generation.
+GROQ_REASONING_EFFORT=low
+GROQ_MAX_COMPLETION_TOKENS=8000
 
 # --- Database -------------------------------------------------------------
 # Supabase free tier connection string (use the pooled connection URI).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ create or second-guess a recommendation. If the Groq call fails, you get
 `fallback_summary()` — the same numbers, less polish. A failed narration never
 costs you the report and never tempts anyone into letting the model fill a gap.
 
+### The two extraction attempts are deliberately different
+
+The first call uses Groq's JSON mode. The second drops it and parses the object
+out of the text.
+
+That is not belt-and-braces, it is the point. At `temperature=0` an identical
+retry reproduces an identical failure, so repeating the first call buys nothing
+against a deterministic error - and `json_validate_failed` is exactly that.
+
+`gpt-oss` models also reason before answering, at medium effort by default, and
+reasoning shares the completion budget with the answer. A long deliberation can
+leave nothing for the JSON, which the server then rejects as
+`json_validate_failed` with an empty `failed_generation`. `GROQ_REASONING_EFFORT`
+defaults to `low` and `GROQ_MAX_COMPLETION_TOKENS` to 8000 so there is room for
+both; extraction from text does not need deep deliberation. Both are sent via
+`extra_body`, so they work whatever `groq` SDK version is installed and are
+ignored by models that do not support them.
+
 ### Confidence is computed, not asked for
 
 LLMs are badly calibrated at rating their own certainty, so the model is

--- a/pipeline.py
+++ b/pipeline.py
@@ -80,6 +80,14 @@ FUZZY_MATCH_THRESHOLD = float(env("FUZZY_MATCH_THRESHOLD", "85"))
 # before assuming this is still current.
 GROQ_MODEL = env("GROQ_MODEL", "openai/gpt-oss-120b")
 
+# gpt-oss models reason before answering, at "medium" effort by default. Reasoning
+# shares the completion budget with the answer, so a long deliberation can leave
+# nothing for the JSON - which the server rejects as json_validate_failed with an
+# empty failed_generation. Low effort plus a generous budget keeps room for both;
+# this is extraction from text, not a task needing deep deliberation.
+GROQ_REASONING_EFFORT = env("GROQ_REASONING_EFFORT", "low")
+GROQ_MAX_COMPLETION_TOKENS = int(env("GROQ_MAX_COMPLETION_TOKENS", "8000"))
+
 # Single fixed timezone: this is a single-user personal tool, so local wall-clock
 # time in the journal is always interpreted in this zone and stored as UTC.
 LOCAL_TIMEZONE = env("LOCAL_TIMEZONE", "UTC")
@@ -486,38 +494,103 @@ def _build_messages(raw_text: str, session_date: date) -> list[dict[str, str]]:
     ]
 
 
+def extract_json_object(content: Optional[str]) -> dict[str, Any]:
+    """Parse a JSON object from a model response, tolerating surrounding text.
+
+    Used by the fallback attempt, which runs without JSON mode and so may get
+    prose or a fenced block around the object. Scans for the first balanced
+    top-level {...}, ignoring braces inside strings.
+    """
+    if not content or not content.strip():
+        raise ValueError("model returned an empty response")
+    text_value = content.strip()
+    try:
+        payload = json.loads(text_value)
+    except json.JSONDecodeError:
+        start = text_value.find("{")
+        if start == -1:
+            raise ValueError("no JSON object in the response")
+        depth, in_string, escaped, end = 0, False, False, -1
+        for index in range(start, len(text_value)):
+            char = text_value[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            elif char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = index + 1
+                    break
+        if end == -1:
+            raise ValueError("unterminated JSON object in the response")
+        payload = json.loads(text_value[start:end])
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected a JSON object, got {type(payload).__name__}")
+    return payload
+
+
+def _extraction_attempts(model: str) -> list[dict[str, Any]]:
+    """The two attempts, deliberately different from each other.
+
+    At temperature 0 an identical retry reproduces an identical failure, so a
+    repeat of the first call buys nothing against a deterministic error - which
+    is exactly what json_validate_failed is. The second attempt therefore drops
+    JSON mode and parses the object out of the text instead, so a failure caused
+    by the server-side JSON validator has a way through.
+    """
+    extra: dict[str, Any] = {"max_completion_tokens": GROQ_MAX_COMPLETION_TOKENS}
+    # Sent through extra_body rather than a named argument so it works whatever
+    # groq SDK version is installed, and is simply ignored by models without it.
+    if "gpt-oss" in model and GROQ_REASONING_EFFORT:
+        extra["reasoning_effort"] = GROQ_REASONING_EFFORT
+    return [
+        {"response_format": {"type": "json_object"}, "extra_body": dict(extra)},
+        {"extra_body": dict(extra)},
+    ]
+
+
 def extract_entities(
     raw_text: str,
     session_date: date,
     client: Any = None,
     model: str = GROQ_MODEL,
 ) -> dict[str, Any]:
-    """Call Groq in JSON mode and return the parsed object.
+    """Call Groq and return the parsed object.
 
-    JSON mode (`response_format={"type": "json_object"}`) is used rather than
-    trusting the prompt to produce valid JSON. One retry is attempted on an API
-    error or a parse failure; after that the caller routes the entry to review.
+    The first attempt uses JSON mode (`response_format={"type": "json_object"}`)
+    rather than trusting the prompt alone. The second drops it and parses the
+    object out of the text, because the failure JSON mode produces most often -
+    the server rejecting an empty generation - repeats identically at
+    temperature 0. After both, the caller routes the entry to manual review.
     """
     if client is None:
         client = get_groq_client()
 
     last_error: Optional[Exception] = None
-    for attempt in (1, 2):
+    attempts = _extraction_attempts(model)
+    for number, options in enumerate(attempts, start=1):
         try:
             response = client.chat.completions.create(
                 model=model,
                 messages=_build_messages(raw_text, session_date),
-                response_format={"type": "json_object"},
                 temperature=0,
+                **options,
             )
-            content = response.choices[0].message.content
-            payload = json.loads(content)
-            if not isinstance(payload, dict):
-                raise ValueError(f"expected a JSON object, got {type(payload).__name__}")
-            return payload
-        except Exception as exc:  # noqa: BLE001 - retry once on anything
+            return extract_json_object(response.choices[0].message.content)
+        except Exception as exc:  # noqa: BLE001 - fall through to the next attempt
             last_error = exc
-            logger.warning("Extraction attempt %d/2 failed: %s", attempt, exc)
+            logger.warning(
+                "Extraction attempt %d/%d failed (json_mode=%s): %s",
+                number, len(attempts), "response_format" in options, exc,
+            )
 
     raise ExtractionError(f"extraction failed after retry: {last_error}")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -661,3 +661,111 @@ class TestReplaceIsOptIn:
         """Nothing to insert means nothing should have been deleted."""
         result = pipeline.process_entry("   ", date(2026, 8, 20))
         assert result.replaced is None and result.error
+
+
+# --------------------------------------------------------------------------
+# Extraction transport, after json_validate_failed on a reasoning model
+# --------------------------------------------------------------------------
+
+
+class TestJsonObjectExtraction:
+    """The fallback attempt runs without JSON mode, so the reply can carry
+    prose or a fenced block around the object."""
+
+    def test_plain_object(self):
+        assert pipeline.extract_json_object('{"sets": []}') == {"sets": []}
+
+    def test_fenced_block(self):
+        raw = '```json\n{"sets": [1]}\n```'
+        assert pipeline.extract_json_object(raw) == {"sets": [1]}
+
+    def test_prose_either_side(self):
+        raw = 'Here is the data:\n{"sets": [2]}\nHope that helps.'
+        assert pipeline.extract_json_object(raw) == {"sets": [2]}
+
+    def test_a_brace_inside_a_string_does_not_end_the_object(self):
+        raw = '{"sets": [], "note": "a } brace"}'
+        assert pipeline.extract_json_object(raw)["note"] == "a } brace"
+
+    def test_nested_objects(self):
+        assert pipeline.extract_json_object('{"a": {"b": {"c": 1}}}') == {"a": {"b": {"c": 1}}}
+
+    @pytest.mark.parametrize("value", ["", "   ", None])
+    def test_empty_response_is_rejected(self, value):
+        """The exact failure seen in production: the model emitted nothing."""
+        with pytest.raises(ValueError, match="empty"):
+            pipeline.extract_json_object(value)
+
+    def test_no_object_is_rejected(self):
+        with pytest.raises(ValueError, match="no JSON object"):
+            pipeline.extract_json_object("I could not parse that")
+
+    def test_array_is_rejected(self):
+        with pytest.raises(ValueError, match="expected a JSON object"):
+            pipeline.extract_json_object("[1, 2, 3]")
+
+    def test_unterminated_object_is_rejected(self):
+        with pytest.raises(ValueError, match="unterminated"):
+            pipeline.extract_json_object('{"sets": [1, 2')
+
+
+class TestExtractionAttemptsDiffer:
+    """At temperature 0 an identical retry reproduces an identical failure, so
+    the second attempt has to change something to be worth making."""
+
+    def test_first_attempt_uses_json_mode_and_the_second_does_not(self):
+        first, second = pipeline._extraction_attempts("openai/gpt-oss-120b")
+        assert first["response_format"] == {"type": "json_object"}
+        assert "response_format" not in second
+
+    def test_reasoning_effort_is_sent_for_gpt_oss(self):
+        """Reasoning shares the completion budget with the answer; at the
+        default effort it can consume all of it and emit nothing."""
+        for options in pipeline._extraction_attempts("openai/gpt-oss-120b"):
+            assert options["extra_body"]["reasoning_effort"] == "low"
+
+    def test_reasoning_effort_is_omitted_for_other_models(self):
+        for options in pipeline._extraction_attempts("llama-3.3-70b-versatile"):
+            assert "reasoning_effort" not in options["extra_body"]
+
+    def test_a_completion_budget_is_always_set(self):
+        for options in pipeline._extraction_attempts("openai/gpt-oss-120b"):
+            assert options["extra_body"]["max_completion_tokens"] > 0
+
+    def test_attempts_do_not_share_a_mutable_body(self):
+        first, second = pipeline._extraction_attempts("openai/gpt-oss-120b")
+        first["extra_body"]["max_completion_tokens"] = 1
+        assert second["extra_body"]["max_completion_tokens"] != 1
+
+
+class TestExtractionFallback:
+    def test_falls_back_to_text_parsing_when_json_mode_fails(self):
+        """json_validate_failed on the first call must not doom the entry."""
+        client = FakeClient([
+            RuntimeError("400 json_validate_failed ... 'failed_generation': ''"),
+            'Sure:\n```json\n{"sets": [], "bodyweight": null}\n```',
+        ])
+        result = extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert result == {"sets": [], "bodyweight": None}
+        assert len(client.completions.calls) == 2
+
+    def test_the_second_call_really_drops_json_mode(self):
+        client = FakeClient([RuntimeError("json_validate_failed"), '{"sets": []}'])
+        extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert "response_format" in client.completions.calls[0]
+        assert "response_format" not in client.completions.calls[1]
+
+    # These go through the module rather than the names imported at the top of
+    # this file: another test reloads pipeline, which rebinds its classes, so a
+    # name captured at import time would no longer be the class actually raised.
+    def test_an_empty_generation_on_both_attempts_goes_to_review(self):
+        client = FakeClient(["", ""])
+        with pytest.raises(pipeline.ExtractionError):
+            pipeline.extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert len(client.completions.calls) == 2
+
+    def test_still_only_two_calls_in_total(self):
+        client = FakeClient([RuntimeError("a"), RuntimeError("b")])
+        with pytest.raises(pipeline.ExtractionError):
+            pipeline.extract_entities(RAW_ENTRY, date(2026, 8, 14), client=client)
+        assert len(client.completions.calls) == 2


### PR DESCRIPTION
Live extraction failed with a 400 from Groq:

```
json_validate_failed — "Failed to validate JSON. Please adjust your prompt."
'failed_generation': ''
```

## Cause

The **empty `failed_generation`** is the tell. `gpt-oss` models reason before answering, at `medium` effort by default, and that reasoning **shares the completion budget with the answer**. A long deliberation leaves nothing for the JSON, and the server rejects the empty generation.

`GROQ_REASONING_EFFORT` now defaults to `low` and `GROQ_MAX_COMPLETION_TOKENS` to `8000`, so there's room for both — extraction from a journal entry doesn't need deep deliberation. Both go through `extra_body`, so they work whatever `groq` SDK version is installed and are ignored by models without them; `reasoning_effort` is only sent to `gpt-oss` models.

## The retry was doing nothing

The same failure exposed a design flaw. Both attempts sent an **identical request at `temperature=0`** — so a deterministic failure reproduced exactly and the retry bought nothing. `json_validate_failed` is precisely that kind of failure.

The second attempt now **drops JSON mode** and parses the object out of the text, so a failure caused by the server-side validator has a route through:

```python
first, second = _extraction_attempts("openai/gpt-oss-120b")
first["response_format"] == {"type": "json_object"}   # JSON mode
"response_format" not in second                        # text, then parse
```

`extract_json_object` scans for the first balanced top-level object, ignoring braces inside strings — which also handles the fenced blocks and surrounding prose that come back once JSON mode is off:

```
ok  plain                    ok  empty        → rejected
ok  fenced                   ok  no object    → rejected
ok  prose either side        ok  array        → rejected
ok  brace inside a string    ok  unterminated → rejected
ok  nested objects
```

## A test-pollution bug worth noting

Two new tests passed alone and failed in the suite. An earlier test calls `importlib.reload(pipeline)` to check configuration defaults, and **a reload rebinds the module's classes** — so `ExtractionError`, captured by the import at the top of the test file, was no longer the class actually being raised. Those assertions now go through the module. Verified across several suite orderings.

**280 tests pass** (up from 260).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Z1gChZdP9CJgmTvgFfUe)_