### PR TITLE
Add static muscle group lookup table for exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Notes app (unchanged)
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
+| `muscle_groups.py` | Static exercise-name -> primary muscle group tables and lookup |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
+| `backfill_muscle_groups.py` | One-off: fills `muscle_group` for exercises logged before the lookup existed |
 | `tests/` | Unit tests for the Stage A rules and the confidence / fuzzy-match logic |
 | `sample_entry.txt` | A messy journal entry in the real style, for trying the CLI |
 
@@ -218,6 +220,51 @@ Unknown words fail closed, into a separate row.
 
 Both names must have at least two tokens for the subset bonus, so "Curl" never
 absorbs "Leg Curl". Threshold is 85, tunable via `FUZZY_MATCH_THRESHOLD`.
+
+### Muscle groups come from a table, not the model
+
+`exercises.muscle_group` is written by `get_or_create_exercise` only on INSERT,
+so it is decided once per distinct movement and then never revisited — a few
+dozen decisions over the life of the tool, not one per set. That makes it a
+lookup, not a judgement, and `muscle_groups.py` holds the table.
+
+Asking the model instead would have cost nothing in tokens — the field would
+ride along in the extraction JSON that is already requested. The reason not to
+is `GROQ_REASONING_EFFORT=low`: gpt-oss shares one completion budget between its
+reasoning and its answer, so adding a *classification* subtask to an
+*extraction* task buys a `json_validate_failed` risk on long entries in exchange
+for an answer a `dict` already knows. Asking the user instead would tax every
+log for information the exercise name already carries.
+
+Resolution runs four passes, most specific first: the full name against the
+table, the name with equipment tokens stripped, a muscle named in the name, then
+the movement verb. The table is consulted first because the obvious heuristic is
+wrong on exactly the names that matter — `Chest Supported Row` is a back
+exercise, `Leg Raise` is a core exercise, and `Leg Curl` is not a biceps
+exercise. `press` and `raise` are deliberately absent from the verb fallback:
+they span chest, shoulders and legs, so a guess would mislabel about a third of
+what it caught.
+
+Unrecognized names resolve to `None`, stored as NULL and reported as
+"Unassigned" — the same fail-closed rule the qualifier allowlist uses. Nothing
+is ever guessed onto the axis the weekly report's volume figures are grouped by.
+
+**Primary mover only.** The column is a single `TEXT` and the chart sums over
+it. A bench press is chest, triceps and front delts; recording all three would
+make "volume by muscle group" stop summing to actual total volume.
+
+`EQUIPMENT_TOKENS` is looser than the identity-matching `QUALIFIER_TOKENS`
+above, on purpose: seated and standing calf raises are two exercises that must
+keep separate progress histories but share one muscle group. Stripping a token
+there never merges two exercises, it only lets them share a lookup key. Genuine
+variations — `incline`, `close grip`, `romanian` — stay out of it, because they
+change which muscle leads the lift.
+
+Exercises logged before any of this existed carry NULL. `python
+backfill_muscle_groups.py --dry-run` shows what the table would fill in;
+without the flag it writes them. It only ever touches NULL rows, so a
+hand-corrected group is never overwritten, and it lists the names it did not
+recognize — that list is what to add to `EXERCISE_MUSCLE_GROUPS`.
 
 ### Cheat reps are counted, not flagged
 
@@ -411,12 +458,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-201 tests, no network and no database required — they cover the Stage A rule
+545 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
-threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution, and JSON-mode retry behaviour. These are pure functions, so they are
-cheap to cover, and they are exactly the code where a silent bug produces a wrong
+threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
+resolution, and JSON-mode retry behaviour, and the muscle-group tables — both
+their resolution cases and mechanical guards that every key is in the normalized
+form lookup actually produces. These are pure functions, so they are cheap to
+cover, and they are exactly the code where a silent bug produces a wrong
 training recommendation that nobody notices.
 
 ## Not built (by design)

--- a/backfill_muscle_groups.py
+++ b/backfill_muscle_groups.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fill in `exercises.muscle_group` for rows created before it was resolved.
+
+    python backfill_muscle_groups.py --dry-run   # show what would change
+    python backfill_muscle_groups.py             # apply
+
+Every exercise logged before the static lookup existed was inserted with a NULL
+muscle group, which `insights.volume_by_muscle_group` reports as "Unassigned" -
+so the whole training history collapses into one bar. This walks those rows
+through `pipeline.resolve_muscle_group` and writes back the ones it recognizes.
+
+Only NULL rows are touched. A group already stored - whether it came from the
+table, from `seed_sample_data.py`, or from a hand-written correction - is left
+exactly as it is, so re-running this can never overwrite a deliberate value.
+Names the table does not recognize stay NULL and are listed at the end, which is
+the signal for what to add to `muscle_groups.EXERCISE_MUSCLE_GROUPS`.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import text
+
+import pipeline
+
+
+def backfill(engine, dry_run: bool = False) -> tuple[int, list[str]]:
+    """Resolve NULL muscle groups. Returns (updated_count, unresolved_names)."""
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT exercise_id, name FROM exercises "
+                "WHERE muscle_group IS NULL ORDER BY name"
+            )
+        ).fetchall()
+
+        updated = 0
+        unresolved: list[str] = []
+        for exercise_id, name in rows:
+            group = pipeline.resolve_muscle_group(name)
+            if group is None:
+                unresolved.append(name)
+                continue
+
+            print(f"  {name}  ->  {group}")
+            if not dry_run:
+                conn.execute(
+                    text("UPDATE exercises SET muscle_group = :group "
+                         "WHERE exercise_id = :id AND muscle_group IS NULL"),
+                    {"group": group, "id": exercise_id},
+                )
+            updated += 1
+
+    return updated, unresolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the resolutions without writing them")
+    args = parser.parse_args()
+
+    updated, unresolved = backfill(pipeline.get_engine(), dry_run=args.dry_run)
+
+    verb = "Would update" if args.dry_run else "Updated"
+    print(f"\n{verb} {updated} exercise(s).")
+
+    if unresolved:
+        print(f"\n{len(unresolved)} name(s) the table does not recognize; these stay "
+              f"NULL and show as 'Unassigned':")
+        for name in unresolved:
+            print(f"  {name}")
+        print("\nAdd them to muscle_groups.EXERCISE_MUSCLE_GROUPS and re-run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/muscle_groups.py
+++ b/muscle_groups.py
@@ -1,0 +1,351 @@
+"""Static exercise-name -> primary muscle group resolution.
+
+Why static rather than asking the LLM or the user:
+  * `exercises.muscle_group` is a property of the exercise, not of a log entry.
+    `pipeline.get_or_create_exercise` writes it only on INSERT, so the value is
+    decided once per distinct movement and then never revisited - a few dozen
+    decisions over the life of the tool, not one per set.
+  * The answer is a lookup, not a judgement. A table is free, instant,
+    deterministic and unit-testable, which the same table asked of a model at
+    `reasoning_effort=low` is not.
+
+This module is a leaf: it deliberately imports nothing from `pipeline`, so the
+name-normalization helpers stay single-sourced there and there is no import
+cycle. Callers hand it already-normalized tokens; `pipeline.resolve_muscle_group`
+is the public entry point that does the normalizing.
+
+PRIMARY MOVER ONLY. `exercises.muscle_group` is a single TEXT column and the
+volume chart sums over it, so an exercise is attributed to exactly one group.
+A bench press is chest, triceps and front delts; recording all three would make
+"volume by muscle group" stop summing to actual total volume. Secondary movers
+are out of scope until the column becomes an array.
+
+Unknown names resolve to None, which is stored as NULL and reported as
+"Unassigned" by `insights.volume_by_muscle_group`. The tables are an allowlist:
+they fail closed rather than guessing, matching how `pipeline.QUALIFIER_TOKENS`
+treats unrecognized words.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+# Every value the resolver may return. `insights` renders None as "Unassigned";
+# it is not a group and so is not listed here.
+CANONICAL_GROUPS = (
+    "Chest",
+    "Back",
+    "Shoulders",
+    "Biceps",
+    "Triceps",
+    "Legs",
+    "Glutes",
+    "Core",
+    "Forearms",
+    "Full Body",
+)
+
+# Tokens dropped before the second lookup pass, so "Dumbbell Bench Press" and
+# "Bench Press" reach the same table entry without the table enumerating every
+# equipment permutation.
+#
+# This is a LOOSER list than `pipeline.QUALIFIER_TOKENS`, and deliberately so.
+# That set governs exercise IDENTITY, where "seated" vs "standing" must stay two
+# separate rows with separate progress histories. Muscle group is a coarser
+# question: seated and standing calf raises are different exercises that train
+# the same muscle. Stripping a token here therefore never merges two exercises,
+# it only lets them share one lookup key.
+#
+# Genuine movement variations stay OUT of this set. "incline", "decline",
+# "front", "close grip" and "romanian" change which muscle leads the lift, so
+# stripping them would produce a wrong group, not a coarser one.
+EQUIPMENT_TOKENS = frozenset(
+    {
+        "barbell", "dumbbell", "dumbell", "db", "bb", "machine", "cable",
+        "smith", "ez", "bar", "weighted", "bodyweight", "banded", "band",
+        "seated", "standing", "lying", "single", "one", "alternating", "alt",
+    }
+)
+
+# Explicit movement -> primary mover. Keys are normalized and singularized the
+# way `pipeline.normalize_tokens` produces them: lowercase, punctuation gone,
+# trailing plural "s" dropped unless the word ends in "ss" ("press" survives,
+# "raises" becomes "raise", "biceps" becomes "bicep"). A test asserts every key
+# is already in that form, so a hand-written plural cannot silently never match.
+#
+# That rule only fires on words longer than three characters, so short plurals
+# come through intact - "ups" and "abs" are never reduced to "up" and "ab".
+# Both spellings are therefore listed wherever a name ends in one.
+#
+# Entries whose name contains a MISLEADING muscle word are the important ones
+# here - "chest supported row" is a back exercise and "leg raise" is a core
+# exercise. The table is consulted before the token heuristics below precisely
+# so these resolve correctly.
+EXERCISE_MUSCLE_GROUPS: dict[str, str] = {
+    # --- Chest ---
+    "bench press": "Chest",
+    "chest bench press": "Chest",
+    "chest press": "Chest",
+    "flat bench press": "Chest",
+    "incline bench press": "Chest",
+    "incline press": "Chest",
+    "decline bench press": "Chest",
+    "decline press": "Chest",
+    "chest fly": "Chest",
+    "chest flie": "Chest",
+    "fly": "Chest",
+    "flie": "Chest",
+    "pec fly": "Chest",
+    "pec deck": "Chest",
+    "crossover": "Chest",
+    "cable crossover": "Chest",
+    "push up": "Chest",
+    "push ups": "Chest",
+    "pushup": "Chest",
+    "dip": "Chest",
+    "chest dip": "Chest",
+
+    # --- Back ---
+    "row": "Back",
+    "bent over row": "Back",
+    "barbell row": "Back",
+    "pendlay row": "Back",
+    "t bar row": "Back",
+    "chest supported row": "Back",
+    "inverted row": "Back",
+    "lat pulldown": "Back",
+    "pulldown": "Back",
+    "straight arm pulldown": "Back",
+    "pullover": "Back",
+    "pull up": "Back",
+    "pull ups": "Back",
+    "pullup": "Back",
+    "chin up": "Back",
+    "chin ups": "Back",
+    "chinup": "Back",
+    "deadlift": "Back",
+    "conventional deadlift": "Back",
+    "rack pull": "Back",
+    "shrug": "Back",
+    "good morning": "Back",
+    "back extension": "Back",
+    "hyperextension": "Back",
+
+    # --- Shoulders ---
+    "shoulder press": "Shoulders",
+    "overhead press": "Shoulders",
+    "military press": "Shoulders",
+    "arnold press": "Shoulders",
+    "push press": "Shoulders",
+    "lateral raise": "Shoulders",
+    "side raise": "Shoulders",
+    "side lateral raise": "Shoulders",
+    "front raise": "Shoulders",
+    "rear delt fly": "Shoulders",
+    "rear delt flie": "Shoulders",
+    "rear delt raise": "Shoulders",
+    "rear delt row": "Shoulders",
+    "reverse fly": "Shoulders",
+    "reverse flie": "Shoulders",
+    "reverse pec deck": "Shoulders",
+    "upright row": "Shoulders",
+    "face pull": "Shoulders",
+
+    # --- Biceps ---
+    "curl": "Biceps",
+    "bicep curl": "Biceps",
+    "hammer curl": "Biceps",
+    "preacher curl": "Biceps",
+    "concentration curl": "Biceps",
+    "incline curl": "Biceps",
+    "spider curl": "Biceps",
+    "drag curl": "Biceps",
+    "reverse curl": "Biceps",
+
+    # --- Triceps ---
+    "tricep extension": "Triceps",
+    "overhead tricep extension": "Triceps",
+    "overhead extension": "Triceps",
+    "tricep pushdown": "Triceps",
+    "pushdown": "Triceps",
+    "rope pushdown": "Triceps",
+    "tricep pressdown": "Triceps",
+    "pressdown": "Triceps",
+    "skullcrusher": "Triceps",
+    "skull crusher": "Triceps",
+    "close grip bench press": "Triceps",
+    "close grip press": "Triceps",
+    "tricep dip": "Triceps",
+    "bench dip": "Triceps",
+    "kickback": "Triceps",
+    "tricep kickback": "Triceps",
+
+    # --- Legs ---
+    "squat": "Legs",
+    "back squat": "Legs",
+    "front squat": "Legs",
+    "goblet squat": "Legs",
+    "hack squat": "Legs",
+    "split squat": "Legs",
+    "bulgarian split squat": "Legs",
+    "pistol squat": "Legs",
+    "leg press": "Legs",
+    "leg extension": "Legs",
+    "quad extension": "Legs",
+    "leg curl": "Legs",
+    "hamstring curl": "Legs",
+    "nordic curl": "Legs",
+    "romanian deadlift": "Legs",
+    "rdl": "Legs",
+    "stiff leg deadlift": "Legs",
+    "sumo deadlift": "Legs",
+    "lunge": "Legs",
+    "walking lunge": "Legs",
+    "reverse lunge": "Legs",
+    "step up": "Legs",
+    "step ups": "Legs",
+    "calf raise": "Legs",
+    "calf press": "Legs",
+
+    # --- Glutes ---
+    "hip thrust": "Glutes",
+    "glute bridge": "Glutes",
+    "hip bridge": "Glutes",
+    "glute kickback": "Glutes",
+    "hip abduction": "Glutes",
+    "abduction": "Glutes",
+    "hip extension": "Glutes",
+
+    # --- Core ---
+    "plank": "Core",
+    "side plank": "Core",
+    "crunch": "Core",
+    "crunche": "Core",
+    "cable crunch": "Core",
+    "cable crunche": "Core",
+    "sit up": "Core",
+    "sit ups": "Core",
+    "situp": "Core",
+    "leg raise": "Core",
+    "hanging leg raise": "Core",
+    "knee raise": "Core",
+    "russian twist": "Core",
+    "ab wheel": "Core",
+    "ab rollout": "Core",
+    "rollout": "Core",
+    "mountain climber": "Core",
+    "dead bug": "Core",
+    "hollow hold": "Core",
+    "woodchop": "Core",
+
+    # --- Forearms ---
+    "wrist curl": "Forearms",
+    "reverse wrist curl": "Forearms",
+    "farmer carry": "Forearms",
+    "farmer carrie": "Forearms",
+    "farmer walk": "Forearms",
+    "wrist roller": "Forearms",
+
+    # --- Full Body ---
+    "clean": "Full Body",
+    "power clean": "Full Body",
+    "hang clean": "Full Body",
+    "clean and jerk": "Full Body",
+    "snatch": "Full Body",
+    "thruster": "Full Body",
+    "burpee": "Full Body",
+    "kettlebell swing": "Full Body",
+    "swing": "Full Body",
+}
+
+# A muscle named inside the exercise name. Consulted only after both table
+# passes miss, so the misleading cases above ("chest supported row") never reach
+# it. Tokens too vague to place - "arm", "upper", "lower" - are absent on
+# purpose: no entry means no guess.
+MUSCLE_TOKENS: dict[str, str] = {
+    "chest": "Chest",
+    "pec": "Chest",
+    "back": "Back",
+    "lat": "Back",
+    "trap": "Back",
+    "rhomboid": "Back",
+    "shoulder": "Shoulders",
+    "delt": "Shoulders",
+    "bicep": "Biceps",
+    "tricep": "Triceps",
+    "leg": "Legs",
+    "quad": "Legs",
+    "hamstring": "Legs",
+    "ham": "Legs",
+    "calf": "Legs",
+    "calve": "Legs",
+    "glute": "Glutes",
+    "core": "Core",
+    "ab": "Core",
+    "abs": "Core",
+    "oblique": "Core",
+    "forearm": "Forearms",
+    "wrist": "Forearms",
+}
+
+# Last resort: the movement verb, for names the table has never seen and that
+# name no muscle ("Cable Rope Pushdown"). Only verbs with one plausible primary
+# mover appear; "press" and "raise" are ambiguous across chest, shoulders and
+# legs, so they are deliberately absent.
+MOVEMENT_TOKENS: dict[str, str] = {
+    "pulldown": "Back",
+    "row": "Back",
+    "deadlift": "Back",
+    "shrug": "Back",
+    "curl": "Biceps",
+    "pushdown": "Triceps",
+    "pressdown": "Triceps",
+    "skullcrusher": "Triceps",
+    "squat": "Legs",
+    "lunge": "Legs",
+    "thrust": "Glutes",
+    "plank": "Core",
+    "crunch": "Core",
+    "crunche": "Core",
+}
+
+
+def group_for_tokens(tokens: Sequence[str]) -> Optional[str]:
+    """Primary muscle group for already-normalized, singularized name tokens.
+
+    Four passes, most specific first:
+      1. The full name against the explicit table.
+      2. The name with equipment tokens removed, against the same table.
+      3. A muscle named in the name.
+      4. The movement verb.
+
+    Returns None when nothing matches, which is stored as NULL rather than a
+    guess. `pipeline.resolve_muscle_group` is the entry point that normalizes.
+    """
+    if not tokens:
+        return None
+
+    exact = EXERCISE_MUSCLE_GROUPS.get(" ".join(tokens))
+    if exact is not None:
+        return exact
+
+    stripped = [token for token in tokens if token not in EQUIPMENT_TOKENS]
+    if stripped and stripped != list(tokens):
+        reduced = EXERCISE_MUSCLE_GROUPS.get(" ".join(stripped))
+        if reduced is not None:
+            return reduced
+
+    # Rightmost muscle word wins: in "Cable Chest Fly" the qualifier sits left of
+    # the movement, and in a compound like "Leg Press Calf Raise" the later word
+    # is the one being trained.
+    for token in reversed(stripped or list(tokens)):
+        group = MUSCLE_TOKENS.get(token)
+        if group is not None:
+            return group
+
+    for token in reversed(stripped or list(tokens)):
+        group = MOVEMENT_TOKENS.get(token)
+        if group is not None:
+            return group
+
+    return None

--- a/pipeline.py
+++ b/pipeline.py
@@ -29,6 +29,8 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 from sqlalchemy.engine import Connection, Engine
 
+import muscle_groups
+
 try:  # Python 3.9+
     from zoneinfo import ZoneInfo
 except ImportError:  # pragma: no cover - Python < 3.9 is unsupported anyway
@@ -297,6 +299,16 @@ def normalize_tokens(name: str) -> list[str]:
 
 # Compared against singularized tokens, so the qualifier set is singularized too.
 _QUALIFIER_TOKENS_SINGULAR = frozenset(_singularize(t) for t in QUALIFIER_TOKENS)
+
+
+def resolve_muscle_group(name: str) -> Optional[str]:
+    """Primary muscle group for an exercise name, or None when unrecognized.
+
+    Table lookup only - see `muscle_groups` for why this is not asked of the
+    LLM. Normalization lives here so `muscle_groups` stays a leaf module with no
+    import back into this one.
+    """
+    return muscle_groups.group_for_tokens(normalize_tokens(name))
 
 
 def name_match_score(proposed: str, existing: str) -> float:
@@ -962,12 +974,20 @@ def get_or_create_exercise(
     if matched is not None:
         return known[matched], matched, False
 
+    # An explicit group from the caller wins; otherwise look the name up in the
+    # static table. Either may be None, which stores NULL and reports as
+    # "Unassigned" rather than a guess.
+    if not muscle_group:
+        muscle_group = resolve_muscle_group(proposed_name)
+
     row = conn.execute(
         text(
             """
             INSERT INTO exercises (name, muscle_group)
             VALUES (:name, :muscle_group)
-            ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+            ON CONFLICT (name) DO UPDATE
+                SET muscle_group = COALESCE(exercises.muscle_group,
+                                            EXCLUDED.muscle_group)
             RETURNING exercise_id
             """
         ),

--- a/tests/test_muscle_groups.py
+++ b/tests/test_muscle_groups.py
@@ -1,0 +1,218 @@
+"""Unit tests for the static muscle-group lookup.
+
+The table is the sole source of `exercises.muscle_group`, and that column is
+written once per exercise and then never revisited, so a wrong entry is a wrong
+label on every future chart and on the volume figures fed to the weekly report.
+Two kinds of test here: mechanical guards that the tables are well-formed, and
+resolution cases - especially the names whose muscle word contradicts the muscle
+actually trained.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import muscle_groups
+from muscle_groups import (
+    CANONICAL_GROUPS,
+    EXERCISE_MUSCLE_GROUPS,
+    MOVEMENT_TOKENS,
+    MUSCLE_TOKENS,
+)
+from pipeline import normalize_tokens, resolve_muscle_group
+
+
+# --------------------------------------------------------------------------
+# Table well-formedness
+# --------------------------------------------------------------------------
+
+
+class TestTablesAreWellFormed:
+    """Guards that catch a bad entry at commit time rather than in the data."""
+
+    @pytest.mark.parametrize("key", sorted(EXERCISE_MUSCLE_GROUPS))
+    def test_key_is_in_normalized_singular_form(self, key):
+        """A key the normalizer can never produce would silently never match.
+
+        Lookup happens on `normalize_tokens` output, so every key must already
+        be what that function emits - lowercase, punctuation-free, and
+        singularized by the crude rule that turns "raises" into "raise" but
+        leaves "press" alone.
+        """
+        assert " ".join(normalize_tokens(key)) == key
+
+    @pytest.mark.parametrize("table_name", ["EXERCISE_MUSCLE_GROUPS", "MUSCLE_TOKENS",
+                                            "MOVEMENT_TOKENS"])
+    def test_values_are_canonical_groups(self, table_name):
+        table = getattr(muscle_groups, table_name)
+        unknown = {value for value in table.values() if value not in CANONICAL_GROUPS}
+        assert unknown == set()
+
+    def test_token_tables_are_single_words(self):
+        """Both token tables are matched one token at a time."""
+        for table in (MUSCLE_TOKENS, MOVEMENT_TOKENS, muscle_groups.EQUIPMENT_TOKENS):
+            assert all(" " not in token for token in table)
+
+    def test_ambiguous_verbs_are_not_movement_tokens(self):
+        """"press" and "raise" span chest, shoulders and legs.
+
+        Either one as a fallback would mislabel roughly a third of the lifts it
+        caught, so they are left out and their names carried by the table.
+        """
+        assert "press" not in MOVEMENT_TOKENS
+        assert "raise" not in MOVEMENT_TOKENS
+
+
+# --------------------------------------------------------------------------
+# Resolution
+# --------------------------------------------------------------------------
+
+
+class TestResolvesKnownExercises:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Bench Press", "Chest"),
+            ("Chest Bench Press", "Chest"),
+            ("Lat Pulldown", "Back"),
+            ("Barbell Row", "Back"),
+            ("Shoulder Press", "Shoulders"),
+            ("Lateral Raise", "Shoulders"),
+            ("Preacher Curl", "Biceps"),
+            ("Skullcrusher", "Triceps"),
+            ("Leg Press", "Legs"),
+            ("Hip Thrust", "Glutes"),
+            ("Plank", "Core"),
+            ("Wrist Curl", "Forearms"),
+            ("Power Clean", "Full Body"),
+        ],
+    )
+    def test_table_hit(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            # Short plurals survive `_singularize` intact - it only strips a
+            # trailing "s" past three characters, so "ups" never becomes "up".
+            # These regressed once and are the reason both spellings are listed.
+            ("Push Ups", "Chest"),
+            ("Pull Ups", "Back"),
+            ("Chin Ups", "Back"),
+            ("Sit Ups", "Core"),
+            ("Step Ups", "Legs"),
+            ("Abs Crunch", "Core"),
+            ("Lateral Raises", "Shoulders"),
+            ("Barbell Rows", "Back"),
+            ("Bicep Curls", "Biceps"),
+            ("Crunches", "Core"),
+            ("Chest Flies", "Chest"),
+            ("Cable Flys", "Chest"),
+        ],
+    )
+    def test_plural_forms_resolve(self, name, expected):
+        """The singularizer is crude, so plurals are covered by real cases."""
+        assert resolve_muscle_group(name) == expected
+
+
+class TestEquipmentIsStripped:
+    """Equipment prefixes must not require their own table entry."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Dumbbell Bench Press", "Chest"),
+            ("Dumbell Bench Press", "Chest"),        # the common typo
+            ("Machine Chest Press", "Chest"),
+            ("Seated Cable Row", "Back"),
+            ("EZ Bar Preacher Curl", "Biceps"),
+            ("Lying Leg Curl", "Legs"),
+            ("Standing Calf Raise", "Legs"),
+            ("Seated Calf Raise", "Legs"),
+            ("Single Arm Dumbbell Row", "Back"),
+        ],
+    )
+    def test_strips_and_resolves(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    def test_variations_are_not_stripped(self):
+        """A variation changes which muscle leads, so it must survive.
+
+        `EQUIPMENT_TOKENS` is looser than `pipeline.QUALIFIER_TOKENS`, and this
+        is the line it must not cross: "romanian" and "close grip" move the lift
+        to a different primary mover.
+        """
+        assert resolve_muscle_group("Deadlift") == "Back"
+        assert resolve_muscle_group("Romanian Deadlift") == "Legs"
+        assert resolve_muscle_group("Bench Press") == "Chest"
+        assert resolve_muscle_group("Close Grip Bench Press") == "Triceps"
+
+
+class TestMisleadingMuscleWords:
+    """The reason the explicit table is consulted before the token heuristics.
+
+    Each of these names contains a muscle word that is not the muscle trained.
+    A pure token heuristic gets every one of them wrong.
+    """
+
+    @pytest.mark.parametrize(
+        "name,expected,wrong",
+        [
+            ("Chest Supported Row", "Back", "Chest"),
+            ("Leg Raise", "Core", "Legs"),
+            ("Hanging Leg Raise", "Core", "Legs"),
+            ("Leg Curl", "Legs", "Biceps"),      # "curl" would say Biceps
+            ("Rear Delt Row", "Shoulders", "Back"),
+            ("Glute Kickback", "Glutes", "Triceps"),
+        ],
+    )
+    def test_table_wins_over_tokens(self, name, expected, wrong):
+        resolved = resolve_muscle_group(name)
+        assert resolved == expected
+        assert resolved != wrong
+
+
+class TestTokenFallbacks:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Chest Cable Crossover", "Chest"),   # named muscle, novel movement
+            ("Tricep Rope Pushdown", "Triceps"),
+            ("Lat Prayer", "Back"),
+            ("Oblique Twist", "Core"),
+        ],
+    )
+    def test_muscle_token_fallback(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Meadows Row", "Back"),              # no muscle word, known verb
+            ("Jefferson Curl", "Biceps"),
+            ("Zercher Squat", "Legs"),
+        ],
+    )
+    def test_movement_token_fallback(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+
+class TestFailsClosed:
+    """Unrecognized names stay NULL rather than being guessed at.
+
+    `insights.volume_by_muscle_group` renders None as "Unassigned", so an
+    unknown movement is visibly unlabelled instead of quietly miscounted
+    against a muscle it never trained.
+    """
+
+    @pytest.mark.parametrize("name", ["Zercher Carry", "Some Machine Thing", "Wibble"])
+    def test_unknown_name_is_none(self, name):
+        assert resolve_muscle_group(name) is None
+
+    @pytest.mark.parametrize("name", ["", "   ", "!!!"])
+    def test_empty_name_is_none(self, name):
+        assert resolve_muscle_group(name) is None
+
+    def test_equipment_only_name_is_none(self):
+        """Nothing is left after stripping, and "dumbbell" names no muscle."""
+        assert resolve_muscle_group("Dumbbell") is None


### PR DESCRIPTION
## Summary
Introduces a static lookup table for resolving exercise names to their primary muscle groups, replacing dynamic resolution. This enables consistent, deterministic muscle group assignment that is written once per exercise and never revisited.

## Key Changes

- **New `muscle_groups.py` module**: Contains four lookup tables and a resolution function that performs four-pass matching:
  1. Full exercise name against explicit table
  2. Name with equipment tokens stripped
  3. Muscle tokens found in the name
  4. Movement verb fallback
  
  The explicit table is consulted first to correctly handle misleading cases like "Chest Supported Row" (back exercise) and "Leg Raise" (core exercise).

- **New `tests/test_muscle_groups.py`**: Comprehensive test suite covering:
  - Table well-formedness (keys are normalized, values are canonical)
  - Known exercise resolution
  - Plural form handling
  - Equipment token stripping
  - Misleading muscle word cases
  - Token fallbacks
  - Fail-closed behavior for unknown exercises

- **New `backfill_muscle_groups.py`**: One-off utility script to populate `muscle_group` for exercises created before the lookup existed. Only touches NULL rows, preserving any hand-corrected values.

- **Updated `pipeline.py`**: 
  - Imports `muscle_groups` module
  - Adds `resolve_muscle_group()` function that normalizes input and delegates to the lookup table
  - Modifies `get_or_create_exercise()` to use the lookup when no explicit group is provided

- **Updated `README.md`**: Documents the muscle group resolution strategy, including why a static table is preferred over LLM classification, the four-pass resolution algorithm, and the fail-closed design.

## Implementation Details

- **Primary mover only**: The `muscle_group` column is a single TEXT field, so exercises are attributed to exactly one group. Secondary movers are out of scope.

- **Equipment vs. variation tokens**: `EQUIPMENT_TOKENS` is intentionally looser than `QUALIFIER_TOKENS` — seated and standing calf raises share a muscle group but remain separate exercises. Genuine variations (incline, close grip, romanian) are excluded because they change the primary mover.

- **Fail-closed design**: Unknown names resolve to `None` (stored as NULL, displayed as "Unassigned") rather than guessing, matching the philosophy of the qualifier allowlist.

- **Ambiguous verbs excluded**: "press" and "raise" are deliberately absent from movement token fallback because they span multiple muscle groups and would mislabel ~33% of matches.

https://claude.ai/code/session_017EZ35VNyDTr7CmuqQu9D1p