### PR TITLE
Review every parsed row before it is saved, and file it by muscle group

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ generates a weekly progress report on top of them.
 You keep logging in your phone's Notes app exactly as you do now — typos,
 voice-to-text run-ons, times like "6:20ish", commentary like "almost died" —
 then paste the text into a small web form. The pipeline extracts the sets,
-validates them, scores how much it trusts each one, and inserts only what clears
-the bar. Everything else is listed for you to look at rather than quietly saved.
+validates them, scores how much it trusts each one, and shows you every row it
+is about to write — editable, with anything missing or invalid marked in red.
+Nothing reaches the database until you have looked at it and pressed save.
 
 Power BI connects straight to the Postgres tables. That side is out of scope
 here; the schema is just shaped for it.
@@ -16,15 +17,22 @@ here; the schema is just shaped for it.
 
 ```
 Notes app (unchanged)
-  -> paste into the mobile web form            app.py
+  -> paste into the mobile web form            app.py            POST /log
   -> Groq extraction, JSON mode, 1 retry       pipeline.extract_entities
-  -> Pydantic validation                       pipeline.validate_extraction
-  -> computed confidence heuristic             pipeline.compute_confidence
+  -> Pydantic validation + computed score      pipeline.build_draft
+  -> editable preview of every prospective row review.render_review_body
+       anything missing or invalid is red, and a row the database would
+       reject cannot be saved until it is fixed or unticked
+  -> you edit, untick, and press save          app.py            POST /save
+  -> rescored against what you actually typed  review.draft_from_form
   -> fuzzy match against existing exercises    pipeline.find_matching_exercise
-  -> below threshold? -> review list, not inserted
-  -> above threshold? -> parameterized INSERT into Postgres
+  -> parameterized INSERT into Postgres        pipeline.commit_draft
   -> Power BI reads Postgres directly (later, not part of this build)
 ```
+
+The CLI has no reviewer, so it keeps the older unattended behaviour: anything
+below the confidence threshold is reported rather than saved
+(`pipeline.process_entry`).
 
 ## Files
 
@@ -34,6 +42,7 @@ Notes app (unchanged)
 | `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
 | `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
+| `review.py` | The review screen: renders a draft as an editable form and reads the submission back |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
@@ -178,6 +187,41 @@ of waiting shrinks it. An ordinary failure retries immediately and keeps the
 full reservation: without JSON mode the model may wrap the object in prose, so
 the second attempt needs no less room than the first.
 
+### Nothing is saved before you have seen it
+
+The model is good at reading a run-on note and bad at knowing when it has
+misread one. The failure that matters is not a wrong number on screen — it is a
+wrong number in a chart four weeks later, with no way to tell which of thirty
+sets it came from.
+
+So `/log` extracts and writes nothing. It renders every prospective row as an
+editable form — the same columns the database has, filled with the values that
+would be stored — and only `/save` inserts. Two colours of problem are marked:
+
+- **Blocking** — a value the database would reject: a rep count of `"eleven"`,
+  more cheat reps than reps, a blank exercise name. The field is outlined in
+  red, the message says what is wrong, and the save is refused until it is fixed
+  or the row is unticked. Bad input is kept in the box rather than dropped to
+  null, because a field silently emptied is a mistake you never see.
+- **Missing or weakly grounded** — no weight, no rep count, a name that does not
+  match the text it was read from, a score below the threshold. Marked in the
+  same red, but savable: a set with no recorded load is still a set that
+  happened, and that is your call rather than the parser's.
+
+Each row shows the span of your entry it was read from, so a suspicious value
+can be checked without scrolling back. Every row also carries a Save tick;
+unticking one drops it.
+
+The submission is rescored from what you actually typed, not from the
+extraction — so correcting a field clears its mark, and breaking one adds a mark
+where there was none. The round trip is exact: a form rendered and posted back
+untouched produces the same values, with no row falsely recorded as edited.
+
+`review.py` owns both halves of that round trip and nothing else; it holds no
+state between the two requests. The draft travels in the form itself, which is
+why the flow works unchanged on a serverless deploy where the two requests may
+not reach the same process.
+
 ### Confidence is computed, not asked for
 
 LLMs are badly calibrated at rating their own certainty, so the model is
@@ -189,10 +233,18 @@ one from things that can actually be checked:
 - does the exercise name actually match the text span it was supposedly read
   from — the check that catches a name the model invented rather than read.
 
-Below `CONFIDENCE_THRESHOLD` (0.7) an entry goes to the review list and is not
-inserted. A set missing its weight or reps lands at 0.65 and so is always
-surfaced. That is deliberate: a set with no load recorded is not much use for
-progression, and a bodyweight exercise logged this way is worth a glance.
+Below `CONFIDENCE_THRESHOLD` (0.7) a row is marked in red on the review screen.
+A set missing its weight or reps lands at 0.65 and so is always surfaced. That is
+deliberate: a set with no load recorded is not much use for progression, and a
+bodyweight exercise logged this way is worth a glance.
+
+In the web app the threshold marks rows rather than dropping them — you are
+looking at all of them anyway, and a set you can see and correct is worth more
+than one silently withheld. It still gates the CLI, which has nobody watching.
+
+A row you edit is stored at confidence 1.0. The score measures how well an
+extraction is grounded in the source text; once you have corrected a field by
+hand, your correction is better evidence than any grounding heuristic.
 
 ### Exercise names are fuzzy-matched before a new row is created
 
@@ -291,11 +343,12 @@ Logging a second time against a date that already has rows asks which you meant:
 - **Replace** - discard everything already logged on that date and use this
   entry instead. For correcting a bad parse, not for adding.
 
-Replace is deliberately never the default, and never implicit. Two safeguards
-back it: the delete and the insert that follows commit in one transaction, so a
+Replace is deliberately never the default, and never implicit. Three safeguards
+back it: the review screen says how many rows the save will delete before you
+press it; the delete and the insert that follows commit in one transaction, so a
 failure mid-way cannot leave the day emptied with nothing put back; and it only
-runs when there is something to insert, so a failed extraction or an
-all-review entry leaves the existing day untouched.
+runs when there is something to insert, so a failed extraction or a draft with
+every row unticked leaves the existing day untouched.
 
 The delete window is a UTC range covering one *local* day, so it cannot reach
 into a neighbouring date - tested at an offset zone, not just UTC.
@@ -305,9 +358,10 @@ into a neighbouring date - tested at an offset zone, not just UTC.
 ### Duplicate submissions
 
 Render's free tier cold-starts in 30–50s after idle, which is exactly when you
-double-tap submit. Before extracting anything, `/log` checks whether the same raw
-text was inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns the
-earlier result instead of re-running the model and re-inserting.
+double-tap submit. The check sits on `/save`, the step that writes: it looks for
+the same raw text inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns
+the earlier result rather than inserting the entry twice. `/log` writes nothing,
+so re-running it costs only another extraction.
 
 ## Charts
 
@@ -411,13 +465,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-201 tests, no network and no database required — they cover the Stage A rule
+393 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
-threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution, and JSON-mode retry behaviour. These are pure functions, so they are
-cheap to cover, and they are exactly the code where a silent bug produces a wrong
-training recommendation that nobody notices.
+threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
+resolution and JSON-mode retry behaviour, and the review screen's draft/edit/save
+round trip. These are pure functions, so they are cheap to cover, and they are
+exactly the code where a silent bug produces a wrong training recommendation, or
+a saved row that does not match what was on screen, and nobody notices.
 
 ## Not built (by design)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Notes app (unchanged)
   -> editable preview of every prospective row review.render_review_body
        anything missing or invalid is red, and a row the database would
        reject cannot be saved until it is fixed or unticked
-  -> you edit, untick, and press save          app.py            POST /save
+  -> you edit, untick, add missed sets, save   app.py            POST /save
   -> rescored against what you actually typed  review.draft_from_form
   -> fuzzy match against existing exercises    pipeline.find_matching_exercise
   -> parameterized INSERT into Postgres        pipeline.commit_draft
@@ -42,7 +42,7 @@ below the confidence threshold is reported rather than saved
 | `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
 | `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
-| `review.py` | The review screen: renders a draft as an editable form and reads the submission back |
+| `review.py` | The review screen: renders a draft as an editable form, reads the submission back, and adds empty slots on request |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
@@ -212,6 +212,19 @@ Each row shows the span of your entry it was read from, so a suspicious value
 can be checked without scrolling back. Every row also carries a Save tick;
 unticking one drops it.
 
+**Add a set** appends an empty slot for something the parser missed entirely —
+a set you forgot to write down, or one lost in a run-on sentence. Adding is a
+round trip rather than a script: the form already carries the whole draft, so
+the server hands back the same state plus a slot, and the page stays
+JavaScript-free like the rest of the app. An empty slot is not a row: it is
+neither saved nor complained about, so there is no penalty for adding one and
+changing your mind. A slot you do fill in is validated like any other row, but
+not scored on grounding — it was never read out of the entry, so there is
+nothing to ground it in — and it is stored at confidence 1.0. The same applies
+to a bodyweight reading your entry never mentioned. If the extraction comes back
+with nothing at all, the add buttons are still there, so a failed parse is not a
+dead end.
+
 The submission is rescored from what you actually typed, not from the
 extraction — so correcting a field clears its mark, and breaking one adds a mark
 where there was none. The round trip is exact: a form rendered and posted back
@@ -242,9 +255,10 @@ In the web app the threshold marks rows rather than dropping them — you are
 looking at all of them anyway, and a set you can see and correct is worth more
 than one silently withheld. It still gates the CLI, which has nobody watching.
 
-A row you edit is stored at confidence 1.0. The score measures how well an
-extraction is grounded in the source text; once you have corrected a field by
-hand, your correction is better evidence than any grounding heuristic.
+A row you edit — or type in yourself — is stored at confidence 1.0. The score
+measures how well an extraction is grounded in the source text; once you have
+corrected a field by hand your correction is better evidence than any grounding
+heuristic, and for a hand-entered row there is no extraction to score at all.
 
 ### Exercise names are fuzzy-matched before a new row is created
 
@@ -465,7 +479,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-393 tests, no network and no database required — they cover the Stage A rule
+412 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/app.py
+++ b/app.py
@@ -438,7 +438,7 @@ async def log_entry(
 
 @app.post("/save", response_class=HTMLResponse)
 async def save_reviewed(request: Request, _user: str = Depends(require_auth)) -> HTMLResponse:
-    """Write the reviewed form. The only route that inserts.
+    """Write the reviewed form, or hand it back with one more empty slot.
 
     The rows are rescored from the submitted values rather than from the
     extraction, so a corrected field is judged on what the user actually typed.
@@ -450,6 +450,11 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
         draft = review.draft_from_form(form)
     except ValueError:
         return _invalid_date_page()
+
+    # "Add a set" posts the same form; it hands back the draft plus an empty slot
+    # rather than saving, so a half-corrected row is not judged in passing.
+    if review.add_row(draft, str(form.get("action", "save"))):
+        return _review_page(draft)
 
     if not draft.ready:
         logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)

--- a/app.py
+++ b/app.py
@@ -2,13 +2,20 @@
 
 Routes:
     GET  /               mobile-friendly entry form
-    POST /log            run the pipeline on a pasted journal entry
+    POST /log            parse a pasted journal entry into an editable review form
+    POST /save           write the reviewed rows to the database
     GET  /weekly-report  report page with a "Generate weekly report" button
     POST /weekly-report  run Stage A + Stage B and upsert the report
     GET  /healthz        unauthenticated liveness probe
 
+Saving is deliberately two steps. POST /log only extracts; it renders every
+prospective database row for editing, with anything missing or invalid marked in
+red. Nothing is written until POST /save, and what it writes is the reviewed
+form, not the raw extraction.
+
 All extraction/validation/insert logic is imported from pipeline.py; all report
-logic from insights.py. Nothing is reimplemented here.
+logic from insights.py; the review form from review.py. Nothing is
+reimplemented here.
 """
 
 from __future__ import annotations
@@ -45,11 +52,12 @@ try:
     import charts  # noqa: E402 - must follow the sys.path bootstrap above
     import insights  # noqa: E402
     import pipeline  # noqa: E402
+    import review  # noqa: E402
 except Exception:  # noqa: BLE001 - report anything that stops the app booting
     import traceback
 
     _STARTUP_ERROR = traceback.format_exc()
-    charts = insights = pipeline = None  # type: ignore[assignment]
+    charts = insights = pipeline = review = None  # type: ignore[assignment]
 
 logging.basicConfig(
     level=pipeline.env("LOG_LEVEL", "INFO").upper() if pipeline else "INFO",
@@ -277,6 +285,13 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
         )
         parts.append(f'<div class="card muted"><strong>Fuzzy-matched names</strong><ul>{rows}</ul></div>')
 
+    skipped = result.skipped_sets + result.skipped_bodyweight
+    if skipped:
+        parts.append(
+            f'<div class="card muted">You unticked {skipped} row(s) on the review '
+            "screen, so they were not saved.</div>"
+        )
+
     if result.review_items:
         rows = []
         for item in result.review_items:
@@ -292,11 +307,12 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
                 f"{html.escape(item.reason)}</li>"
             )
         parts.append(
-            '<div class="card warn"><strong>Needs manual review '
-            f"({len(result.review_items)}) &mdash; not inserted</strong><ul>{''.join(rows)}</ul></div>"
+            '<div class="card err"><strong>Could not be saved '
+            f"({len(result.review_items)})</strong> &mdash; these parts of the entry "
+            f"could not be turned into editable rows.<ul>{''.join(rows)}</ul></div>"
         )
-    elif not result.error and not result.duplicate_of_recent:
-        parts.append('<div class="card muted">Nothing needed review.</div>')
+    elif not result.error and not result.duplicate_of_recent and not skipped:
+        parts.append('<div class="card muted">Everything you ticked was saved.</div>')
 
     return "".join(parts)
 
@@ -329,14 +345,52 @@ async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
     <option value="add" selected>Add to them &mdash; a second session, or more sets</option>
     <option value="replace">Replace them &mdash; discard that day and use this instead</option>
   </select>
-  <button type="submit">Parse &amp; save</button>
+  <button type="submit">Parse &amp; review</button>
 </form>
-<p class="muted">Sets below the confidence threshold
-({pipeline.CONFIDENCE_THRESHOLD:.0%}) are listed for review instead of being saved.
-Bodyweight mentions in the same entry are picked up automatically.
-<strong>Replace</strong> deletes everything already logged on that date, so use it to
-correct a bad entry &mdash; not to add an evening session.</p>
+<p class="muted">Parsing shows you every row it is about to write, with anything
+missing or invalid marked in red. Nothing is saved until you have looked at it
+and pressed save. Bodyweight mentions in the same entry are picked up
+automatically. <strong>Replace</strong> deletes everything already logged on that
+date, so use it to correct a bad entry &mdash; not to add an evening session.</p>
 """,
+    )
+
+
+def _parse_session_date(value: str) -> Optional[date]:
+    try:
+        return datetime.strptime((value or "").strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _invalid_date_page() -> HTMLResponse:
+    return _page(
+        "Invalid date",
+        '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
+        '<p><a href="/">Back</a></p>',
+    )
+
+
+def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
+    """What is already logged on that date, for the review banner.
+
+    Best effort: this only decorates the page, so a database that is briefly
+    unreachable should not cost the user the extraction they just paid for.
+    """
+    try:
+        return pipeline.count_entries_for_date(get_engine(), session_date)
+    except Exception:  # noqa: BLE001 - the save step will surface a real outage
+        logger.warning("event=existing_counts_failed date=%s", session_date, exc_info=True)
+        return None
+
+
+def _review_page(draft: pipeline.EntryDraft) -> HTMLResponse:
+    return _page(
+        "Check before saving",
+        review.render_review_body(
+            draft, _existing_counts(draft.session_date), pipeline.CONFIDENCE_THRESHOLD
+        ),
+        extra_css=review.REVIEW_CSS,
     )
 
 
@@ -347,36 +401,77 @@ async def log_entry(
     mode: str = Form("add"),
     _user: str = Depends(require_auth),
 ) -> HTMLResponse:
-    try:
-        parsed_date = datetime.strptime(session_date.strip(), "%Y-%m-%d").date()
-    except ValueError:
+    """Extract only. Nothing reaches the database until POST /save."""
+    parsed_date = _parse_session_date(session_date)
+    if parsed_date is None:
+        return _invalid_date_page()
+
+    draft = pipeline.build_draft(raw_text, parsed_date)
+    draft.replace_existing = mode == "replace"
+    logger.info(
+        "event=entry_drafted date=%s mode=%s sets=%d bodyweight=%s flagged=%d blocked=%d error=%s",
+        parsed_date,
+        mode,
+        len(draft.sets),
+        draft.bodyweight is not None,
+        draft.flagged_count,
+        draft.blocked_count,
+        bool(draft.error),
+    )
+
+    if draft.error:
+        notes = "".join(
+            f'<div class="card muted">{html.escape(item.reason)}</div>'
+            for item in draft.review_items
+        )
         return _page(
-            "Invalid date",
-            '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
+            "Could not parse",
+            f'<h1>Could not parse that entry</h1>'
+            f'<div class="card err">{html.escape(draft.error)}</div>{notes}'
+            '<p class="muted">Nothing was saved. Go back and try again — the entry '
+            "is unchanged.</p>"
             '<p><a href="/">Back</a></p>',
         )
 
-    result = pipeline.process_entry(
-        raw_text,
-        parsed_date,
-        engine=get_engine(),
-        check_duplicates=True,
-        replace_existing=(mode == "replace"),
-    )
+    return _review_page(draft)
+
+
+@app.post("/save", response_class=HTMLResponse)
+async def save_reviewed(request: Request, _user: str = Depends(require_auth)) -> HTMLResponse:
+    """Write the reviewed form. The only route that inserts.
+
+    The rows are rescored from the submitted values rather than from the
+    extraction, so a corrected field is judged on what the user actually typed.
+    A row the database would still reject sends the whole form back for another
+    pass instead of being quietly dropped.
+    """
+    form = await request.form()
+    try:
+        draft = review.draft_from_form(form)
+    except ValueError:
+        return _invalid_date_page()
+
+    if not draft.ready:
+        logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)
+        return _review_page(draft)
+
+    result = pipeline.commit_draft(draft, engine=get_engine(), check_duplicates=True)
     logger.info(
-        "event=log_processed date=%s mode=%s inserted_sets=%d inserted_bodyweight=%d "
-        "review=%d duplicate=%s replaced=%s",
-        parsed_date,
-        mode,
+        "event=entry_saved date=%s replace=%s inserted_sets=%d inserted_bodyweight=%d "
+        "skipped=%d review=%d duplicate=%s replaced=%s",
+        draft.session_date,
+        draft.replace_existing,
         result.inserted_sets,
         result.inserted_bodyweight,
+        result.skipped_sets + result.skipped_bodyweight,
         len(result.review_items),
         result.duplicate_of_recent,
         result.replaced,
     )
     return _page(
-        "Result",
-        f'<h1>Result</h1>{_render_result(result, parsed_date)}<p><a href="/">Log another</a></p>',
+        "Saved",
+        f'<h1>Saved</h1>{_render_result(result, draft.session_date)}'
+        '<p><a href="/">Log another</a></p>',
     )
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -262,10 +262,142 @@ class PipelineResult:
     duplicate_of_recent: bool = False
     replaced: Optional[dict[str, int]] = None
     error: Optional[str] = None
+    # Rows the user unticked on the review screen. Distinct from review_items,
+    # which are rows the pipeline itself held back.
+    skipped_sets: int = 0
+    skipped_bodyweight: int = 0
 
     @property
     def total_inserted(self) -> int:
         return self.inserted_sets + self.inserted_bodyweight
+
+
+# --------------------------------------------------------------------------
+# Editable draft — what the review screen shows before anything is written
+# --------------------------------------------------------------------------
+
+# The editable columns of each row, in the order the review screen lays them
+# out. `raw_span` is carried but never edited: it is the evidence the row was
+# read from, and rewriting it would rewrite the audit trail.
+SET_COLUMNS: tuple[str, ...] = (
+    "exercise_name",
+    "weight_kg",
+    "reps",
+    "cheat_reps",
+    "set_number",
+    "logged_at_local",
+    "muscle_group",
+    "is_warmup",
+    "is_dropset",
+    "pain_flag",
+    "notes",
+    "raw_span",
+)
+
+BODYWEIGHT_COLUMNS: tuple[str, ...] = (
+    "weight_kg",
+    "body_fat_pct",
+    "logged_at_local",
+    "notes",
+    "raw_span",
+)
+
+
+@dataclass
+class DraftIssue:
+    """Something wrong with a drafted row, addressed to the person reviewing it.
+
+    `blocking` separates the two kinds the review screen treats differently:
+    a blocking issue is one the database would reject, so the row cannot be
+    saved until it is fixed; a non-blocking one is missing or weakly grounded
+    information, which is flagged but savable — a set with no recorded weight
+    is still a set that happened.
+    """
+
+    message: str
+    field: Optional[str] = None  # column it belongs to; None = the whole row
+    blocking: bool = False
+
+
+@dataclass
+class DraftRow:
+    """One prospective database row, as extracted and possibly since edited."""
+
+    kind: str  # "workout_set" | "bodyweight"
+    values: dict[str, Any] = field(default_factory=dict)
+    confidence: Optional[float] = None
+    issues: list[DraftIssue] = field(default_factory=list)
+    include: bool = True
+    edited: bool = False  # a person changed a value on the review screen
+    # The exact wording `process_entry` used before the review screen existed,
+    # kept so the CLI and the unattended path still report failures the same way.
+    validation_error: Optional[str] = None
+
+    @property
+    def blocking(self) -> bool:
+        return any(issue.blocking for issue in self.issues)
+
+    @property
+    def flagged(self) -> bool:
+        return bool(self.issues)
+
+    def issues_for(self, column: str) -> list[DraftIssue]:
+        return [issue for issue in self.issues if issue.field == column]
+
+    @property
+    def row_issues(self) -> list[DraftIssue]:
+        """Issues that belong to no single column."""
+        return [issue for issue in self.issues if issue.field is None]
+
+    def legacy_reason(self, confidence_threshold: float) -> str:
+        """Why an unattended run would have held this row back."""
+        if self.validation_error:
+            return self.validation_error
+        return (
+            f"confidence {self.confidence or 0.0:.2f} below "
+            f"threshold {confidence_threshold:.2f}"
+        )
+
+
+@dataclass
+class EntryDraft:
+    """Everything one journal entry would write, before any of it is written."""
+
+    raw_text: str
+    session_date: date
+    sets: list[DraftRow] = field(default_factory=list)
+    bodyweight: Optional[DraftRow] = None
+    # Fragments of the extraction that are not editable rows at all — a `sets`
+    # key that came back as a string, say. Nothing can be done with these on the
+    # review screen, so they pass straight through to the result.
+    review_items: list[ReviewItem] = field(default_factory=list)
+    error: Optional[str] = None
+    replace_existing: bool = False
+
+    @property
+    def rows(self) -> list[DraftRow]:
+        return self.sets + ([self.bodyweight] if self.bodyweight is not None else [])
+
+    @property
+    def included(self) -> list[DraftRow]:
+        return [row for row in self.rows if row.include]
+
+    @property
+    def flagged_count(self) -> int:
+        return sum(1 for row in self.rows if row.flagged)
+
+    @property
+    def blocked_count(self) -> int:
+        return sum(1 for row in self.included if row.blocking)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.rows
+
+    @property
+    def ready(self) -> bool:
+        """True when saving would not be rejected by the database."""
+        return self.error is None and self.blocked_count == 0
 
 
 # --------------------------------------------------------------------------
@@ -821,6 +953,44 @@ def get_groq_client() -> Any:
     return Groq(api_key=api_key)
 
 
+def score_set(
+    item: dict[str, Any],
+    raw_text: str,
+) -> tuple[Optional[WorkoutSet], float, Optional[ValidationError]]:
+    """Validate and score one raw set object.
+
+    The single place a set is turned into a model and given a confidence, so the
+    review screen, the CLI dry run and the insert path can never disagree about
+    what is wrong with a row. Returns (model, confidence, error); exactly one of
+    model and error is None.
+    """
+    try:
+        workout_set = WorkoutSet.model_validate(item)
+    except ValidationError as exc:
+        return None, compute_confidence(None, None, None, None, raw_text, validation_ok=False), exc
+
+    confidence = compute_confidence(
+        workout_set.exercise_name,
+        workout_set.weight_kg,
+        workout_set.reps,
+        workout_set.raw_span,
+        raw_text,
+    )
+    return workout_set, confidence, None
+
+
+def score_bodyweight(
+    item: dict[str, Any],
+    raw_text: str,
+) -> tuple[Optional[BodyweightEntry], float, Optional[ValidationError]]:
+    """`score_set`, for the bodyweight reading."""
+    try:
+        entry = BodyweightEntry.model_validate(item)
+    except ValidationError as exc:
+        return None, 0.0, exc
+    return entry, compute_bodyweight_confidence(entry, raw_text), None
+
+
 def validate_extraction(
     payload: dict[str, Any],
     raw_text: str,
@@ -841,39 +1011,29 @@ def validate_extraction(
             review.append(ReviewItem("workout_set", f"set {index} was not an object", 0.0,
                                      {"raw": str(item)[:500]}))
             continue
-        try:
-            workout_set = WorkoutSet.model_validate(item)
-        except ValidationError as exc:
+        workout_set, confidence, exc = score_set(item, raw_text)
+        if exc is not None:
             review.append(
                 ReviewItem(
                     "workout_set",
                     f"failed validation: {_short_errors(exc)}",
-                    compute_confidence(None, None, None, None, raw_text, validation_ok=False),
+                    confidence,
                     item,
                 )
             )
             continue
-
-        confidence = compute_confidence(
-            workout_set.exercise_name,
-            workout_set.weight_kg,
-            workout_set.reps,
-            workout_set.raw_span,
-            raw_text,
-        )
         scored_sets.append((workout_set, confidence))
 
     scored_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
     raw_bodyweight = payload.get("bodyweight")
     if isinstance(raw_bodyweight, dict):
-        try:
-            entry = BodyweightEntry.model_validate(raw_bodyweight)
-        except ValidationError as exc:
+        entry, bodyweight_confidence, exc = score_bodyweight(raw_bodyweight, raw_text)
+        if exc is not None:
             review.append(
                 ReviewItem("bodyweight", f"failed validation: {_short_errors(exc)}", 0.0, raw_bodyweight)
             )
         else:
-            scored_bodyweight = (entry, compute_bodyweight_confidence(entry, raw_text))
+            scored_bodyweight = (entry, bodyweight_confidence)
     elif raw_bodyweight not in (None, ""):
         review.append(
             ReviewItem("bodyweight", "'bodyweight' was neither null nor an object", 0.0,
@@ -920,6 +1080,227 @@ def compute_bodyweight_confidence(entry: BodyweightEntry, raw_text: str) -> floa
 def _short_errors(exc: ValidationError) -> str:
     parts = [f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()[:3]]
     return "; ".join(parts)
+
+
+# --------------------------------------------------------------------------
+# Draft building (extraction -> editable rows, still nothing written)
+# --------------------------------------------------------------------------
+
+
+def _clean_message(message: str) -> str:
+    """Pydantic prefixes custom validator failures; the prefix means nothing here."""
+    return re.sub(r"^(Value|Assertion) error, ", "", message).strip()
+
+
+def _named_column(message: str, columns: Sequence[str]) -> Optional[str]:
+    """The column a whole-model validation message is about, if it names one.
+
+    Pydantic reports a `model_validator` failure against no field at all, which
+    would leave the form saying a row is unsaveable without marking anything on
+    it. These messages are ours, so the column they name is reliable.
+    """
+    lowered = message.lower()
+    # Longest first, so "cheat_reps exceeds reps" points at cheat_reps, the
+    # column that is actually out of range, rather than the one it is compared to.
+    matches = sorted((c for c in columns if c in lowered), key=len, reverse=True)
+    return matches[0] if matches else None
+
+
+def _field_issues(exc: ValidationError, columns: Sequence[str]) -> list[DraftIssue]:
+    """Turn a validation failure into per-column issues the form can highlight."""
+    issues: list[DraftIssue] = []
+    for error in exc.errors():
+        message = _clean_message(error["msg"])
+        location = str(error["loc"][0]) if error["loc"] else None
+        column = location if location in columns else _named_column(message, columns)
+        issues.append(DraftIssue(message, column, blocking=True))
+    return issues
+
+
+def _column_defaults(model: type[BaseModel], columns: Sequence[str]) -> dict[str, Any]:
+    """What each column falls back to when the extraction leaves it out.
+
+    Read off the models rather than restated, so the review screen shows the
+    value the database would actually store — `cheat_reps` absent means 0, not
+    null, and null is what the column rejects.
+    """
+    defaults: dict[str, Any] = {}
+    for column in columns:
+        info = model.model_fields.get(column)
+        defaults[column] = (
+            None if info is None or info.is_required()
+            else info.get_default(call_default_factory=True)
+        )
+    return defaults
+
+
+SET_DEFAULTS = _column_defaults(WorkoutSet, SET_COLUMNS)
+BODYWEIGHT_DEFAULTS = _column_defaults(BodyweightEntry, BODYWEIGHT_COLUMNS)
+
+
+def _pick(
+    values: dict[str, Any], columns: Sequence[str], defaults: dict[str, Any]
+) -> dict[str, Any]:
+    """Keep only the editable columns, filling omissions with the column default.
+
+    A missing key and an explicit null are treated alike: models routinely emit
+    one or the other for a flag they had nothing to say about, and neither means
+    "store null in a NOT NULL column".
+    """
+    picked: dict[str, Any] = {}
+    for column in columns:
+        value = values.get(column)
+        picked[column] = defaults[column] if value is None else value
+    return picked
+
+
+def draft_set_row(
+    values: dict[str, Any],
+    raw_text: str,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    edited: bool = False,
+) -> DraftRow:
+    """Score one set and describe everything a person should look at before saving."""
+    row = DraftRow("workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited)
+    workout_set, confidence, exc = score_set(row.values, raw_text)
+    row.confidence = confidence
+
+    if exc is not None:
+        row.validation_error = f"failed validation: {_short_errors(exc)}"
+        row.issues = _field_issues(exc, SET_COLUMNS)
+        return row
+
+    # Show the coerced values, so what the screen displays is what gets stored.
+    row.values = _pick(workout_set.model_dump(), SET_COLUMNS, SET_DEFAULTS)
+
+    if workout_set.weight_kg is None:
+        row.issues.append(
+            DraftIssue("no weight found in your entry — saved blank unless you fill it in",
+                       "weight_kg")
+        )
+    if workout_set.reps is None:
+        row.issues.append(
+            DraftIssue("no rep count found in your entry — saved blank unless you fill it in",
+                       "reps")
+        )
+    if _grounding_similarity(workout_set.exercise_name, workout_set.raw_span or raw_text) < 0.5:
+        row.issues.append(
+            DraftIssue("this name does not closely match the text it was read from",
+                       "exercise_name")
+        )
+
+    # Only worth saying when nothing more specific already explains the score.
+    if confidence < confidence_threshold and not row.issues and not edited:
+        row.issues.append(
+            DraftIssue(
+                f"confidence {confidence:.2f}, below the {confidence_threshold:.2f} "
+                "threshold — check it against your entry"
+            )
+        )
+    return row
+
+
+def draft_bodyweight_row(
+    values: dict[str, Any],
+    raw_text: str,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    edited: bool = False,
+) -> DraftRow:
+    """`draft_set_row`, for the bodyweight reading."""
+    row = DraftRow("bodyweight", _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS), edited=edited)
+    entry, confidence, exc = score_bodyweight(row.values, raw_text)
+    row.confidence = confidence
+
+    if exc is not None:
+        row.validation_error = f"failed validation: {_short_errors(exc)}"
+        row.issues = _field_issues(exc, BODYWEIGHT_COLUMNS)
+        return row
+
+    row.values = _pick(entry.model_dump(), BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS)
+    haystack = _normalize_numeric_text(entry.raw_span or raw_text)
+    if not _number_appears_in(float(entry.weight_kg), haystack):
+        row.issues.append(
+            DraftIssue("this number does not appear in your entry", "weight_kg")
+        )
+    if confidence < confidence_threshold and not row.issues and not edited:
+        row.issues.append(
+            DraftIssue(
+                f"confidence {confidence:.2f}, below the {confidence_threshold:.2f} "
+                "threshold — check it against your entry"
+            )
+        )
+    return row
+
+
+def draft_from_payload(
+    payload: dict[str, Any],
+    raw_text: str,
+    session_date: date,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Turn a raw extraction into editable rows, keeping the ones that failed.
+
+    `validate_extraction` drops invalid sets into a review list; here they are
+    kept as rows, because a set the model got half right is exactly the one a
+    person wants to correct rather than retype.
+    """
+    draft = EntryDraft(raw_text=raw_text, session_date=session_date)
+
+    raw_sets = payload.get("sets") or []
+    if not isinstance(raw_sets, list):
+        draft.review_items.append(
+            ReviewItem("extraction", "'sets' was not a list", None, {"sets": str(raw_sets)[:500]})
+        )
+        raw_sets = []
+
+    for index, item in enumerate(raw_sets):
+        if not isinstance(item, dict):
+            draft.review_items.append(
+                ReviewItem("workout_set", f"set {index} was not an object", 0.0,
+                           {"raw": str(item)[:500]})
+            )
+            continue
+        draft.sets.append(draft_set_row(item, raw_text, confidence_threshold))
+
+    raw_bodyweight = payload.get("bodyweight")
+    if isinstance(raw_bodyweight, dict):
+        draft.bodyweight = draft_bodyweight_row(raw_bodyweight, raw_text, confidence_threshold)
+    elif raw_bodyweight not in (None, ""):
+        draft.review_items.append(
+            ReviewItem("bodyweight", "'bodyweight' was neither null nor an object", 0.0,
+                       {"raw": str(raw_bodyweight)[:500]})
+        )
+
+    return draft
+
+
+def build_draft(
+    raw_text: str,
+    session_date: date,
+    client: Any = None,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Extract one journal entry into a draft. Touches the model, not the database."""
+    raw_text = (raw_text or "").strip()
+    if not raw_text:
+        return EntryDraft(
+            raw_text=raw_text,
+            session_date=session_date,
+            error="Empty entry — nothing to parse.",
+        )
+
+    try:
+        payload = extract_entities(raw_text, session_date, client=client)
+    except ExtractionError as exc:
+        logger.error("Extraction failed: %s", exc)
+        return EntryDraft(
+            raw_text=raw_text,
+            session_date=session_date,
+            error="Extraction failed after one retry — entry not inserted.",
+            review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
+        )
+
+    return draft_from_payload(payload, raw_text, session_date, confidence_threshold)
 
 
 # --------------------------------------------------------------------------
@@ -1086,6 +1467,144 @@ def find_recent_submission(
 # --------------------------------------------------------------------------
 
 
+def commit_draft(
+    draft: EntryDraft,
+    engine: Optional[Engine] = None,
+    check_duplicates: bool = False,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    review_excluded: bool = False,
+) -> PipelineResult:
+    """Write the ticked rows of a draft. The only function that inserts.
+
+    A row that reaches here has either been looked at on the review screen or
+    cleared the threshold unattended, so the threshold is not applied again —
+    `include` is the decision. `review_excluded` makes the rows left out come
+    back as review items, which is what the unattended path reports.
+
+    Confidence is recomputed from the values as they stand. A row a person
+    edited is stored at 1.0: the score measures how well an extraction is
+    grounded in the source text, and a human correction is better evidence
+    than any grounding heuristic.
+    """
+    if engine is None:
+        engine = get_engine()
+
+    result = PipelineResult(review_items=list(draft.review_items))
+    if draft.error:
+        result.error = draft.error
+        return result
+
+    if check_duplicates:
+        prior = find_recent_submission(engine, draft.raw_text)
+        if prior is not None:
+            logger.info("Duplicate submission suppressed (%s)", prior)
+            return PipelineResult(
+                inserted_sets=prior["inserted_sets"],
+                inserted_bodyweight=prior["inserted_bodyweight"],
+                duplicate_of_recent=True,
+            )
+
+    accepted_sets: list[tuple[WorkoutSet, float]] = []
+    for row in draft.sets:
+        if not row.include:
+            result.skipped_sets += 1
+            if review_excluded:
+                result.review_items.append(
+                    ReviewItem(
+                        "workout_set",
+                        row.legacy_reason(confidence_threshold),
+                        row.confidence,
+                        dict(row.values),
+                    )
+                )
+            continue
+        workout_set, confidence, exc = score_set(row.values, draft.raw_text)
+        if exc is not None:
+            # Callers check `draft.ready` first, so this is a guard rather than a
+            # path: a row the database would reject is never silently dropped.
+            result.review_items.append(
+                ReviewItem("workout_set", f"failed validation: {_short_errors(exc)}",
+                           row.confidence, dict(row.values))
+            )
+            continue
+        accepted_sets.append((workout_set, 1.0 if row.edited else confidence))
+
+    accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
+    if draft.bodyweight is not None:
+        row = draft.bodyweight
+        if not row.include:
+            result.skipped_bodyweight += 1
+            if review_excluded:
+                result.review_items.append(
+                    ReviewItem("bodyweight", row.legacy_reason(confidence_threshold),
+                               row.confidence, dict(row.values))
+                )
+        else:
+            entry, confidence, exc = score_bodyweight(row.values, draft.raw_text)
+            if exc is not None:
+                result.review_items.append(
+                    ReviewItem("bodyweight", f"failed validation: {_short_errors(exc)}",
+                               row.confidence, dict(row.values))
+                )
+            else:
+                accepted_bodyweight = (entry, 1.0 if row.edited else confidence)
+
+    if not accepted_sets and accepted_bodyweight is None:
+        return result
+
+    with engine.begin() as conn:
+        if draft.replace_existing:
+            # Only reached when there is something to put back - the early
+            # return above means a failed extraction never empties the day.
+            result.replaced = delete_entries_for_date(conn, draft.session_date)
+            logger.info("Replaced %s on %s", result.replaced, draft.session_date)
+        known = load_exercise_names(conn)
+        for workout_set, confidence in accepted_sets:
+            exercise_id, matched_name, created = get_or_create_exercise(
+                conn, workout_set.exercise_name, workout_set.muscle_group, known
+            )
+            if created:
+                result.exercises_created.append(workout_set.exercise_name)
+            elif matched_name and matched_name != workout_set.exercise_name:
+                result.exercises_matched.append((workout_set.exercise_name, matched_name))
+
+            conn.execute(
+                _INSERT_WORKOUT_SET,
+                {
+                    "exercise_id": exercise_id,
+                    "logged_at": resolve_logged_at(workout_set.logged_at_local, draft.session_date),
+                    "weight_kg": workout_set.weight_kg,
+                    "reps": workout_set.reps,
+                    "cheat_reps": workout_set.cheat_reps,
+                    "set_number": workout_set.set_number,
+                    "is_warmup": workout_set.is_warmup,
+                    "is_dropset": workout_set.is_dropset,
+                    "pain_flag": workout_set.pain_flag,
+                    "notes": workout_set.notes,
+                    "raw_source": draft.raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_sets += 1
+
+        if accepted_bodyweight is not None:
+            entry, confidence = accepted_bodyweight
+            conn.execute(
+                _INSERT_BODYWEIGHT,
+                {
+                    "logged_at": resolve_logged_at(entry.logged_at_local, draft.session_date),
+                    "weight_kg": entry.weight_kg,
+                    "body_fat_pct": entry.body_fat_pct,
+                    "notes": entry.notes,
+                    "raw_source": draft.raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_bodyweight += 1
+
+    return result
+
+
 def process_entry(
     raw_text: str,
     session_date: date,
@@ -1095,10 +1614,12 @@ def process_entry(
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     replace_existing: bool = False,
 ) -> PipelineResult:
-    """Run the full pipeline for one journal entry.
+    """Extract and insert one journal entry with nobody watching.
 
-    Called by both the CLI and the web app. `check_duplicates` is enabled by the
-    web app, where a double-tapped submit is a real risk.
+    The CLI path: no review screen, so the confidence threshold does the
+    deciding and anything under it is reported rather than saved. The web app
+    goes through `build_draft` and `commit_draft` instead, and lets the person
+    who wrote the entry make that call.
     """
     raw_text = (raw_text or "").strip()
     if not raw_text:
@@ -1117,98 +1638,18 @@ def process_entry(
                 duplicate_of_recent=True,
             )
 
-    try:
-        payload = extract_entities(raw_text, session_date, client=client)
-    except ExtractionError as exc:
-        logger.error("Extraction failed: %s", exc)
-        return PipelineResult(
-            error="Extraction failed after one retry — entry not inserted.",
-            review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
-        )
+    draft = build_draft(raw_text, session_date, client=client,
+                        confidence_threshold=confidence_threshold)
+    if draft.error:
+        return PipelineResult(error=draft.error, review_items=list(draft.review_items))
 
-    scored_sets, scored_bodyweight, review = validate_extraction(payload, raw_text)
-    result = PipelineResult(review_items=list(review))
+    draft.replace_existing = replace_existing
+    for row in draft.rows:
+        row.include = not row.blocking and (row.confidence or 0.0) >= confidence_threshold
 
-    accepted_sets = []
-    for workout_set, confidence in scored_sets:
-        if confidence < confidence_threshold:
-            result.review_items.append(
-                ReviewItem(
-                    "workout_set",
-                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
-                    confidence,
-                    workout_set.model_dump(),
-                )
-            )
-        else:
-            accepted_sets.append((workout_set, confidence))
-
-    accepted_bodyweight = None
-    if scored_bodyweight is not None:
-        entry, confidence = scored_bodyweight
-        if confidence < confidence_threshold:
-            result.review_items.append(
-                ReviewItem(
-                    "bodyweight",
-                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
-                    confidence,
-                    entry.model_dump(),
-                )
-            )
-        else:
-            accepted_bodyweight = (entry, confidence)
-
-    if not accepted_sets and accepted_bodyweight is None:
-        return result
-
-    with engine.begin() as conn:
-        if replace_existing:
-            # Only reached when there is something to put back - the early
-            # return above means a failed extraction never empties the day.
-            result.replaced = delete_entries_for_date(conn, session_date)
-            logger.info("Replaced %s on %s", result.replaced, session_date)
-        known = load_exercise_names(conn)
-        for workout_set, confidence in accepted_sets:
-            exercise_id, matched_name, created = get_or_create_exercise(
-                conn, workout_set.exercise_name, workout_set.muscle_group, known
-            )
-            if created:
-                result.exercises_created.append(workout_set.exercise_name)
-            elif matched_name and matched_name != workout_set.exercise_name:
-                result.exercises_matched.append((workout_set.exercise_name, matched_name))
-
-            conn.execute(
-                _INSERT_WORKOUT_SET,
-                {
-                    "exercise_id": exercise_id,
-                    "logged_at": resolve_logged_at(workout_set.logged_at_local, session_date),
-                    "weight_kg": workout_set.weight_kg,
-                    "reps": workout_set.reps,
-                    "cheat_reps": workout_set.cheat_reps,
-                    "set_number": workout_set.set_number,
-                    "is_warmup": workout_set.is_warmup,
-                    "is_dropset": workout_set.is_dropset,
-                    "pain_flag": workout_set.pain_flag,
-                    "notes": workout_set.notes,
-                    "raw_source": raw_text,
-                    "extraction_confidence": confidence,
-                },
-            )
-            result.inserted_sets += 1
-
-        if accepted_bodyweight is not None:
-            entry, confidence = accepted_bodyweight
-            conn.execute(
-                _INSERT_BODYWEIGHT,
-                {
-                    "logged_at": resolve_logged_at(entry.logged_at_local, session_date),
-                    "weight_kg": entry.weight_kg,
-                    "body_fat_pct": entry.body_fat_pct,
-                    "notes": entry.notes,
-                    "raw_source": raw_text,
-                    "extraction_confidence": confidence,
-                },
-            )
-            result.inserted_bodyweight += 1
-
-    return result
+    return commit_draft(
+        draft,
+        engine=engine,
+        confidence_threshold=confidence_threshold,
+        review_excluded=True,
+    )

--- a/pipeline.py
+++ b/pipeline.py
@@ -329,6 +329,12 @@ class DraftRow:
     issues: list[DraftIssue] = field(default_factory=list)
     include: bool = True
     edited: bool = False  # a person changed a value on the review screen
+    # Typed in on the review screen rather than read out of the entry. Such a row
+    # has no source text behind it, so the grounding checks do not apply to it.
+    added: bool = False
+    # An added row nobody has filled in yet: not a row at all, so it is neither
+    # saved nor complained about.
+    blank: bool = False
     # The exact wording `process_entry` used before the review screen existed,
     # kept so the CLI and the unattended path still report failures the same way.
     validation_error: Optional[str] = None
@@ -380,7 +386,7 @@ class EntryDraft:
 
     @property
     def included(self) -> list[DraftRow]:
-        return [row for row in self.rows if row.include]
+        return [row for row in self.rows if row.include and not row.blank]
 
     @property
     def flagged_count(self) -> int:
@@ -1154,16 +1160,45 @@ def _pick(
     return picked
 
 
+def _is_blank(values: dict[str, Any], defaults: dict[str, Any]) -> bool:
+    """True when nothing has been entered — every column still holds its default.
+
+    Compared as text as well as by value, because anything that has been through
+    a form arrives as a string: an untouched cheat-rep box submits "0", not 0,
+    and an empty slot that failed this check would fail validation on its blank
+    exercise name instead of being ignored.
+    """
+    return all(
+        value == defaults[column] or str(value).strip() == str(defaults[column])
+        for column, value in values.items()
+    )
+
+
 def draft_set_row(
     values: dict[str, Any],
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
+    added: bool = False,
 ) -> DraftRow:
-    """Score one set and describe everything a person should look at before saving."""
-    row = DraftRow("workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited)
+    """Score one set and describe everything a person should look at before saving.
+
+    `added` marks a row typed in on the review screen rather than read out of the
+    entry. There is no source text behind such a row, so the grounding checks —
+    which ask how well a reading is supported by what was written — would be
+    measuring nothing. Missing weights and reps are still worth pointing out.
+    """
+    row = DraftRow(
+        "workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited, added=added
+    )
+    if _is_blank(row.values, SET_DEFAULTS):
+        # An empty slot the user has not filled in. Not a row, so it is neither
+        # saved nor complained about.
+        row.blank = True
+        return row
+
     workout_set, confidence, exc = score_set(row.values, raw_text)
-    row.confidence = confidence
+    row.confidence = 1.0 if added else confidence
 
     if exc is not None:
         row.validation_error = f"failed validation: {_short_errors(exc)}"
@@ -1175,14 +1210,15 @@ def draft_set_row(
 
     if workout_set.weight_kg is None:
         row.issues.append(
-            DraftIssue("no weight found in your entry — saved blank unless you fill it in",
-                       "weight_kg")
+            DraftIssue("no weight recorded — saved blank unless you fill it in", "weight_kg")
         )
     if workout_set.reps is None:
         row.issues.append(
-            DraftIssue("no rep count found in your entry — saved blank unless you fill it in",
-                       "reps")
+            DraftIssue("no rep count recorded — saved blank unless you fill it in", "reps")
         )
+    if added:
+        return row
+
     if _grounding_similarity(workout_set.exercise_name, workout_set.raw_span or raw_text) < 0.5:
         row.issues.append(
             DraftIssue("this name does not closely match the text it was read from",
@@ -1205,11 +1241,21 @@ def draft_bodyweight_row(
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
+    added: bool = False,
 ) -> DraftRow:
     """`draft_set_row`, for the bodyweight reading."""
-    row = DraftRow("bodyweight", _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS), edited=edited)
+    row = DraftRow(
+        "bodyweight",
+        _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS),
+        edited=edited,
+        added=added,
+    )
+    if _is_blank(row.values, BODYWEIGHT_DEFAULTS):
+        row.blank = True
+        return row
+
     entry, confidence, exc = score_bodyweight(row.values, raw_text)
-    row.confidence = confidence
+    row.confidence = 1.0 if added else confidence
 
     if exc is not None:
         row.validation_error = f"failed validation: {_short_errors(exc)}"
@@ -1217,6 +1263,9 @@ def draft_bodyweight_row(
         return row
 
     row.values = _pick(entry.model_dump(), BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS)
+    if added:
+        return row
+
     haystack = _normalize_numeric_text(entry.raw_span or raw_text)
     if not _number_appears_in(float(entry.weight_kg), haystack):
         row.issues.append(
@@ -1230,6 +1279,16 @@ def draft_bodyweight_row(
             )
         )
     return row
+
+
+def blank_set_row() -> DraftRow:
+    """An empty slot for a set the extraction missed entirely."""
+    return DraftRow("workout_set", dict(SET_DEFAULTS), added=True, blank=True)
+
+
+def blank_bodyweight_row() -> DraftRow:
+    """An empty slot for a bodyweight reading the entry never mentioned."""
+    return DraftRow("bodyweight", dict(BODYWEIGHT_DEFAULTS), added=True, blank=True)
 
 
 def draft_from_payload(
@@ -1482,9 +1541,13 @@ def commit_draft(
     back as review items, which is what the unattended path reports.
 
     Confidence is recomputed from the values as they stand. A row a person
-    edited is stored at 1.0: the score measures how well an extraction is
-    grounded in the source text, and a human correction is better evidence
-    than any grounding heuristic.
+    edited or typed in themselves is stored at 1.0: the score measures how well
+    an extraction is grounded in the source text, and a human correction is
+    better evidence than any grounding heuristic — for a hand-entered row there
+    is no extraction to score at all.
+
+    Blank slots are skipped in silence. They are offers to add a row that nobody
+    took up, so they are neither saved nor reported as left out.
     """
     if engine is None:
         engine = get_engine()
@@ -1506,6 +1569,8 @@ def commit_draft(
 
     accepted_sets: list[tuple[WorkoutSet, float]] = []
     for row in draft.sets:
+        if row.blank:
+            continue
         if not row.include:
             result.skipped_sets += 1
             if review_excluded:
@@ -1527,10 +1592,10 @@ def commit_draft(
                            row.confidence, dict(row.values))
             )
             continue
-        accepted_sets.append((workout_set, 1.0 if row.edited else confidence))
+        accepted_sets.append((workout_set, 1.0 if row.edited or row.added else confidence))
 
     accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
-    if draft.bodyweight is not None:
+    if draft.bodyweight is not None and not draft.bodyweight.blank:
         row = draft.bodyweight
         if not row.include:
             result.skipped_bodyweight += 1
@@ -1547,7 +1612,7 @@ def commit_draft(
                                row.confidence, dict(row.values))
                 )
             else:
-                accepted_bodyweight = (entry, 1.0 if row.edited else confidence)
+                accepted_bodyweight = (entry, 1.0 if row.edited or row.added else confidence)
 
     if not accepted_sets and accepted_bodyweight is None:
         return result

--- a/review.py
+++ b/review.py
@@ -60,6 +60,7 @@ body { max-width: 60rem; }
          padding: .6rem .8rem .8rem; margin: .7rem 0; }
 .draft.flagged { border-left-color: #dc2626; }
 .draft.dropped { opacity: .55; }
+.draft.blank { border-style: dashed; }
 .draft-head { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
               margin-bottom: .5rem; }
 .draft-head .name { font-weight: 600; }
@@ -68,6 +69,7 @@ body { max-width: 60rem; }
 .save-toggle input { width: 1.05rem; height: 1.05rem; margin: 0; accent-color: #2563eb; }
 .chip { font-size: .78rem; padding: .1rem .45rem; border-radius: 1rem;
         border: 1px solid #8886; opacity: .85; }
+.chip.chip-bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
 .chip.bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
 .chip.edited { border-color: #2563eb; color: #2563eb; opacity: 1; }
 .draft-grid { display: grid; gap: .5rem .6rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -94,7 +96,8 @@ body { max-width: 60rem; }
 .evidence { margin: .5rem 0 0; font-size: .82rem; opacity: .65; }
 .actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-top: 1.2rem; }
 .actions button { margin-top: 0; width: auto; padding: .7rem 1.4rem; }
-.actions button[disabled] { background: #8886; cursor: not-allowed; }
+.actions button.secondary { background: transparent; color: inherit; border: 1px solid #8886; }
+.actions button.secondary:active { background: #8882; }
 details.entry summary { cursor: pointer; font-weight: 600; }
 details.entry pre { margin: .6rem 0 0; font-size: .9rem; opacity: .85; }
 """
@@ -169,9 +172,11 @@ def _row_card(
         # "confidence 0.00" on a row that never validated says nothing useful.
         chips.append('<span class="chip bad">cannot be saved yet</span>')
     elif row.confidence is not None:
-        bad = " bad" if row.confidence < confidence_threshold else ""
+        bad = " chip-bad" if row.confidence < confidence_threshold else ""
         chips.append(f'<span class="chip{bad}">confidence {row.confidence:.2f}</span>')
-    if row.edited:
+    if row.added:
+        chips.append('<span class="chip edited">typed in by you</span>')
+    elif row.edited:
         chips.append('<span class="chip edited">edited</span>')
 
     grid = "".join(
@@ -198,14 +203,27 @@ def _row_card(
     if span:
         evidence = f'<p class="evidence">Read from: &ldquo;{html.escape(span)}&rdquo;</p>'
 
+    if row.blank:
+        problems = (
+            '<p class="evidence">Fill this in to add something the parser missed. '
+            "Left empty, it is ignored.</p>"
+        )
+
     hidden = (
         f'<input type="hidden" name="{html.escape(prefix)}.raw_span" '
         f'value="{html.escape(display_value(row.values.get("raw_span")))}">'
         f'<input type="hidden" name="{html.escape(prefix)}.origin" '
         f'value="{html.escape(_origin_blob(row, columns))}">'
+        + (f'<input type="hidden" name="{html.escape(prefix)}.added" value="1">'
+           if row.added else "")
     )
 
-    classes = "draft" + (" flagged" if row.flagged else "") + ("" if row.include else " dropped")
+    classes = (
+        "draft"
+        + (" flagged" if row.flagged else "")
+        + (" blank" if row.blank else "")
+        + ("" if row.include else " dropped")
+    )
     return (
         f'<div class="{classes}">'
         f'<div class="draft-head">'
@@ -216,6 +234,29 @@ def _row_card(
         f"{flags}{problems}{evidence}{hidden}"
         f"</div>"
     )
+
+
+def _add_buttons(draft: EntryDraft, standalone: bool = True) -> str:
+    """Submit buttons that re-render the form with one more empty slot.
+
+    Adding a row is a round trip rather than a script: the form already carries
+    the whole draft, so the server can hand back the same state plus a slot, and
+    the page stays JavaScript-free like the rest of the app.
+
+    Save comes first in the markup on the full form, because pressing Enter in a
+    text field submits via the first button — and that should save, not add.
+    """
+    buttons = [
+        '<button type="submit" class="secondary" name="action" value="add_set">'
+        "Add a set</button>"
+    ]
+    if draft.bodyweight is None:
+        buttons.append(
+            '<button type="submit" class="secondary" name="action" value="add_bodyweight">'
+            "Add bodyweight</button>"
+        )
+    joined = "".join(buttons)
+    return f'<div class="actions">{joined}</div>' if standalone else joined
 
 
 def _banner(draft: EntryDraft, existing: Optional[Mapping[str, int]]) -> str:
@@ -287,19 +328,21 @@ def render_review_body(
     )
 
     if draft.is_empty:
+        # A dead end otherwise: the parser found nothing, but the workout still
+        # happened, so the same add buttons are offered without any rows above them.
         return (
             "<h1>Nothing to save</h1>"
             '<div class="card err">No sets or bodyweight readings came back from '
-            "that entry.</div>"
+            "that entry. You can still enter them by hand.</div>"
             f"{_banner(draft, existing)}{entry}"
-            '<p><a href="/">Back</a></p>'
+            f'<form method="post" action="/save">{hidden}{_add_buttons(draft)}</form>'
         )
 
     cards = "".join(
         _row_card(
             row,
             f"s{index}",
-            f"Set {index + 1}",
+            "New set" if row.blank else f"Set {index + 1}",
             SET_FIELDS,
             pipeline.SET_COLUMNS,
             SET_CHECKBOXES,
@@ -313,7 +356,7 @@ def render_review_body(
         bodyweight = "<h2>Bodyweight</h2>" + _row_card(
             draft.bodyweight,
             "bw",
-            "Bodyweight",
+            "New bodyweight reading" if draft.bodyweight.blank else "Bodyweight",
             BODYWEIGHT_FIELDS,
             pipeline.BODYWEIGHT_COLUMNS,
             (),
@@ -322,7 +365,7 @@ def render_review_body(
 
     # The button label stays static: the page carries no JavaScript, so a count
     # baked in at render time would go stale the moment a box is unticked.
-    total = len(draft.rows)
+    total = len(draft.included)
 
     return f"""
 <h1>Check before saving</h1>
@@ -333,14 +376,16 @@ untick anything that should not be saved, then save. Nothing has been stored yet
 {entry}
 <form method="post" action="/save">
 {hidden}
-<h2>Sets ({len(draft.sets)})</h2>
+<h2>Sets ({sum(1 for row in draft.sets if not row.blank)})</h2>
 {cards}
 {bodyweight}
 <div class="actions">
-  <button type="submit">Save to database</button>
+  <button type="submit" name="action" value="save">Save to database</button>
+  {_add_buttons(draft, standalone=False)}
   <a href="/">Discard and start over</a>
 </div>
-<p class="muted">{total} row(s) drafted. Only the ticked ones are saved.</p>
+<p class="muted">{total} row(s) drafted. Only the ticked ones are saved; an empty
+slot is ignored.</p>
 </form>
 """
 
@@ -424,7 +469,11 @@ def draft_from_form(
         prefix = f"s{index}"
         values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
         row = pipeline.draft_set_row(
-            values, raw_text, confidence_threshold, edited=_was_edited(form, prefix, values)
+            values,
+            raw_text,
+            confidence_threshold,
+            edited=_was_edited(form, prefix, values),
+            added=f"{prefix}.added" in form,
         )
         row.include = f"{prefix}.include" in form
         draft.sets.append(row)
@@ -432,9 +481,28 @@ def draft_from_form(
     if str(form.get("has_bodyweight", "")).strip():
         values = _row_values(form, "bw", pipeline.BODYWEIGHT_COLUMNS, ())
         row = pipeline.draft_bodyweight_row(
-            values, raw_text, confidence_threshold, edited=_was_edited(form, "bw", values)
+            values,
+            raw_text,
+            confidence_threshold,
+            edited=_was_edited(form, "bw", values),
+            added="bw.added" in form,
         )
         row.include = "bw.include" in form
         draft.bodyweight = row
 
     return draft
+
+
+def add_row(draft: EntryDraft, action: str) -> bool:
+    """Give the draft one more empty slot. True when `action` asked for one.
+
+    Adding never validates or saves — the user may well be part way through
+    fixing something else on the same form.
+    """
+    if action == "add_set":
+        draft.sets.append(pipeline.blank_set_row())
+        return True
+    if action == "add_bodyweight" and draft.bodyweight is None:
+        draft.bodyweight = pipeline.blank_bodyweight_row()
+        return True
+    return False

--- a/review.py
+++ b/review.py
@@ -1,0 +1,440 @@
+"""The review screen: what the extraction produced, before any of it is saved.
+
+The web app never inserts straight from an extraction. It builds a draft
+(`pipeline.build_draft`), renders it here as an editable form showing every
+prospective database row, and only writes what comes back from that form
+(`pipeline.commit_draft`). Anything missing, ungrounded or outright invalid is
+marked in red, so a bad reading is corrected in place rather than discovered
+weeks later in a chart.
+
+This module owns the two halves of that round trip:
+    render_review_body()  draft  -> HTML form
+    draft_from_form()     posted -> draft, rescored against the edited values
+
+Nothing here talks to the database or the model. Every dynamic value is escaped
+before it reaches the page: exercise names come from LLM output, so escaping is
+a correctness concern here, not a formality.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence
+
+import pipeline
+from pipeline import CONFIDENCE_THRESHOLD, DraftRow, EntryDraft
+
+# Column -> (label, css class, input mode). The order is the order the fields
+# are laid out in; the grid classes decide how many columns each one spans.
+SET_FIELDS: Sequence[tuple[str, str, str, str]] = (
+    ("exercise_name", "Exercise", "n2 w2", "text"),
+    ("weight_kg", "Weight (kg)", "", "decimal"),
+    ("reps", "Reps", "", "numeric"),
+    ("cheat_reps", "Cheat reps", "", "numeric"),
+    ("set_number", "Set #", "", "numeric"),
+    ("logged_at_local", "Time", "", "text"),
+    ("muscle_group", "Muscle group", "w2", "text"),
+    ("notes", "Notes", "n2 w3", "text"),
+)
+
+BODYWEIGHT_FIELDS: Sequence[tuple[str, str, str, str]] = (
+    ("weight_kg", "Weight (kg)", "", "decimal"),
+    ("body_fat_pct", "Body fat %", "", "decimal"),
+    ("logged_at_local", "Time", "", "text"),
+    ("notes", "Notes", "n2 w3", "text"),
+)
+
+SET_CHECKBOXES: Sequence[tuple[str, str]] = (
+    ("is_warmup", "Warm-up"),
+    ("is_dropset", "Drop set"),
+    ("pain_flag", "Pain"),
+)
+
+REVIEW_CSS = """
+/* The review grid needs more room than the entry form, which is sized for a
+   phone held in one hand. Overrides the base rule by coming later in the sheet. */
+body { max-width: 60rem; }
+.draft { border: 1px solid #8884; border-left: 4px solid #8884; border-radius: .6rem;
+         padding: .6rem .8rem .8rem; margin: .7rem 0; }
+.draft.flagged { border-left-color: #dc2626; }
+.draft.dropped { opacity: .55; }
+.draft-head { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
+              margin-bottom: .5rem; }
+.draft-head .name { font-weight: 600; }
+.save-toggle { display: inline-flex; align-items: center; gap: .35rem; font-weight: 600;
+               margin: 0; white-space: nowrap; }
+.save-toggle input { width: 1.05rem; height: 1.05rem; margin: 0; accent-color: #2563eb; }
+.chip { font-size: .78rem; padding: .1rem .45rem; border-radius: 1rem;
+        border: 1px solid #8886; opacity: .85; }
+.chip.bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
+.chip.edited { border-color: #2563eb; color: #2563eb; opacity: 1; }
+.draft-grid { display: grid; gap: .5rem .6rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.field { min-width: 0; }
+.field.n2 { grid-column: span 2; }
+.field label { font-size: .78rem; font-weight: 600; opacity: .8; margin: 0 0 .15rem; }
+.field input[type=text] { width: 100%; font-size: 1rem; padding: .45rem .5rem;
+        border-radius: .4rem; border: 1px solid #8884; font-family: inherit;
+        background: transparent; color: inherit; }
+.field input.bad { border-color: #dc2626; background: rgba(220, 38, 38, .1); }
+.field input:focus { outline: 2px solid #2563eb; outline-offset: -1px; }
+@media (min-width: 34rem) {
+  .draft-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .field.n2 { grid-column: span 1; }
+  .field.w2 { grid-column: span 2; }
+  .field.w3 { grid-column: span 3; }
+}
+.flags { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: .55rem; }
+.flags label { display: inline-flex; align-items: center; gap: .35rem; font-weight: 400;
+               font-size: .9rem; margin: 0; }
+.flags input { width: 1rem; height: 1rem; margin: 0; }
+.problems { margin: .55rem 0 0; padding-left: 1.1rem; color: #dc2626; font-size: .88rem; }
+.problems li { margin: .15rem 0; }
+.evidence { margin: .5rem 0 0; font-size: .82rem; opacity: .65; }
+.actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-top: 1.2rem; }
+.actions button { margin-top: 0; width: auto; padding: .7rem 1.4rem; }
+.actions button[disabled] { background: #8886; cursor: not-allowed; }
+details.entry summary { cursor: pointer; font-weight: 600; }
+details.entry pre { margin: .6rem 0 0; font-size: .9rem; opacity: .85; }
+"""
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+def display_value(value: Any) -> str:
+    """A field value as it should appear in a text input.
+
+    `%g` on floats so a weight the model returned as 28.0 shows as "28" — the
+    round trip has to look like what the user wrote, or every row reads as edited.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "yes" if value else ""
+    if isinstance(value, float):
+        return f"{value:g}"
+    return str(value)
+
+
+def _origin_blob(row: DraftRow, columns: Sequence[str]) -> str:
+    """The values as extracted, in submitted form, so edits can be detected later."""
+    snapshot: dict[str, Any] = {}
+    for column in columns:
+        value = row.values.get(column)
+        snapshot[column] = value if isinstance(value, bool) else display_value(value)
+    return json.dumps(snapshot, separators=(",", ":"), sort_keys=True)
+
+
+PLACEHOLDERS = {"logged_at_local": "HH:MM"}
+
+
+def _text_field(prefix: str, column: str, label: str, css: str, mode: str, row: DraftRow) -> str:
+    field_id = f"{prefix}.{column}"
+    classes = "bad" if row.issues_for(column) else ""
+    placeholder = PLACEHOLDERS.get(column, "")
+    return (
+        f'<div class="field {css}">'
+        f'<label for="{html.escape(field_id)}">{html.escape(label)}</label>'
+        f'<input type="text" inputmode="{mode}" id="{html.escape(field_id)}" '
+        f'name="{html.escape(field_id)}" class="{classes}" autocomplete="off" '
+        f'placeholder="{html.escape(placeholder)}" '
+        f'value="{html.escape(display_value(row.values.get(column)))}">'
+        f"</div>"
+    )
+
+
+def _checkbox(name: str, label: str, checked: bool, css: str = "") -> str:
+    mark = " checked" if checked else ""
+    return (
+        f'<label class="{css}"><input type="checkbox" name="{html.escape(name)}"'
+        f"{mark}> {html.escape(label)}</label>"
+    )
+
+
+def _row_card(
+    row: DraftRow,
+    prefix: str,
+    title: str,
+    fields: Sequence[tuple[str, str, str, str]],
+    columns: Sequence[str],
+    checkboxes: Sequence[tuple[str, str]] = (),
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> str:
+    chips = []
+    if row.validation_error:
+        # "confidence 0.00" on a row that never validated says nothing useful.
+        chips.append('<span class="chip bad">cannot be saved yet</span>')
+    elif row.confidence is not None:
+        bad = " bad" if row.confidence < confidence_threshold else ""
+        chips.append(f'<span class="chip{bad}">confidence {row.confidence:.2f}</span>')
+    if row.edited:
+        chips.append('<span class="chip edited">edited</span>')
+
+    grid = "".join(
+        _text_field(prefix, column, label, css, mode, row)
+        for column, label, css, mode in fields
+    )
+
+    flags = ""
+    if checkboxes:
+        flags = '<div class="flags">' + "".join(
+            _checkbox(f"{prefix}.{column}", label, bool(row.values.get(column)))
+            for column, label in checkboxes
+        ) + "</div>"
+
+    problems = ""
+    messages = [issue.message for issue in row.issues]
+    if messages:
+        problems = '<ul class="problems">' + "".join(
+            f"<li>{html.escape(message)}</li>" for message in messages
+        ) + "</ul>"
+
+    evidence = ""
+    span = (row.values.get("raw_span") or "").strip()
+    if span:
+        evidence = f'<p class="evidence">Read from: &ldquo;{html.escape(span)}&rdquo;</p>'
+
+    hidden = (
+        f'<input type="hidden" name="{html.escape(prefix)}.raw_span" '
+        f'value="{html.escape(display_value(row.values.get("raw_span")))}">'
+        f'<input type="hidden" name="{html.escape(prefix)}.origin" '
+        f'value="{html.escape(_origin_blob(row, columns))}">'
+    )
+
+    classes = "draft" + (" flagged" if row.flagged else "") + ("" if row.include else " dropped")
+    return (
+        f'<div class="{classes}">'
+        f'<div class="draft-head">'
+        f'{_checkbox(f"{prefix}.include", "Save", row.include, css="save-toggle")}'
+        f'<span class="name">{html.escape(title)}</span>{"".join(chips)}'
+        f"</div>"
+        f'<div class="draft-grid">{grid}</div>'
+        f"{flags}{problems}{evidence}{hidden}"
+        f"</div>"
+    )
+
+
+def _banner(draft: EntryDraft, existing: Optional[Mapping[str, int]]) -> str:
+    parts: list[str] = []
+
+    flagged, blocked = draft.flagged_count, draft.blocked_count
+    if flagged:
+        detail = (
+            f" {blocked} of them cannot be saved until the red fields are fixed "
+            "or the row is unticked."
+            if blocked
+            else " Nothing stops you saving them — check them against your entry first."
+        )
+        parts.append(
+            f'<div class="card err"><strong>{flagged} row(s) marked in red.</strong>'
+            f"{html.escape(detail)}</div>"
+        )
+
+    if draft.replace_existing:
+        if existing and (existing["sets"] or existing["bodyweight"]):
+            parts.append(
+                '<div class="card warn"><strong>Replace mode.</strong> Saving first '
+                f"deletes the {existing['sets']} set(s) and {existing['bodyweight']} "
+                "bodyweight entry/entries already logged on "
+                f"{html.escape(draft.session_date.isoformat())}.</div>"
+            )
+        else:
+            parts.append(
+                '<div class="card warn"><strong>Replace mode.</strong> Nothing is '
+                f"logged on {html.escape(draft.session_date.isoformat())} yet, so "
+                "there is nothing to replace.</div>"
+            )
+    elif existing and (existing["sets"] or existing["bodyweight"]):
+        parts.append(
+            f'<div class="card muted">{existing["sets"]} set(s) are already logged on '
+            f"{html.escape(draft.session_date.isoformat())}. These will be added to them.</div>"
+        )
+
+    for item in draft.review_items:
+        parts.append(
+            '<div class="card err"><strong>Could not be read as a row.</strong> '
+            f"{html.escape(item.reason)} &mdash; this part of the entry cannot be "
+            "edited here and will not be saved.</div>"
+        )
+
+    return "".join(parts)
+
+
+def render_review_body(
+    draft: EntryDraft,
+    existing: Optional[Mapping[str, int]] = None,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> str:
+    """The review form: every prospective row, editable, before anything is written."""
+    hidden = (
+        f'<input type="hidden" name="raw_text" value="{html.escape(draft.raw_text)}">'
+        f'<input type="hidden" name="session_date" '
+        f'value="{html.escape(draft.session_date.isoformat())}">'
+        f'<input type="hidden" name="mode" '
+        f'value="{"replace" if draft.replace_existing else "add"}">'
+        f'<input type="hidden" name="set_count" value="{len(draft.sets)}">'
+        f'<input type="hidden" name="has_bodyweight" '
+        f'value="{"1" if draft.bodyweight is not None else ""}">'
+    )
+
+    entry = (
+        '<details class="card entry"><summary>Your entry</summary>'
+        f"<pre>{html.escape(draft.raw_text)}</pre></details>"
+    )
+
+    if draft.is_empty:
+        return (
+            "<h1>Nothing to save</h1>"
+            '<div class="card err">No sets or bodyweight readings came back from '
+            "that entry.</div>"
+            f"{_banner(draft, existing)}{entry}"
+            '<p><a href="/">Back</a></p>'
+        )
+
+    cards = "".join(
+        _row_card(
+            row,
+            f"s{index}",
+            f"Set {index + 1}",
+            SET_FIELDS,
+            pipeline.SET_COLUMNS,
+            SET_CHECKBOXES,
+            confidence_threshold,
+        )
+        for index, row in enumerate(draft.sets)
+    )
+
+    bodyweight = ""
+    if draft.bodyweight is not None:
+        bodyweight = "<h2>Bodyweight</h2>" + _row_card(
+            draft.bodyweight,
+            "bw",
+            "Bodyweight",
+            BODYWEIGHT_FIELDS,
+            pipeline.BODYWEIGHT_COLUMNS,
+            (),
+            confidence_threshold,
+        )
+
+    # The button label stays static: the page carries no JavaScript, so a count
+    # baked in at render time would go stale the moment a box is unticked.
+    total = len(draft.rows)
+
+    return f"""
+<h1>Check before saving</h1>
+<p class="muted">This is exactly what will be written to the database for
+{html.escape(draft.session_date.isoformat())}. Correct anything that is wrong,
+untick anything that should not be saved, then save. Nothing has been stored yet.</p>
+{_banner(draft, existing)}
+{entry}
+<form method="post" action="/save">
+{hidden}
+<h2>Sets ({len(draft.sets)})</h2>
+{cards}
+{bodyweight}
+<div class="actions">
+  <button type="submit">Save to database</button>
+  <a href="/">Discard and start over</a>
+</div>
+<p class="muted">{total} row(s) drafted. Only the ticked ones are saved.</p>
+</form>
+"""
+
+
+# --------------------------------------------------------------------------
+# Reading the form back
+# --------------------------------------------------------------------------
+
+
+def _coerce(value: str) -> Optional[str]:
+    """Form strings back into field values, leaving bad input for the model to reject.
+
+    Nothing is repaired here: "twelve" in the reps box stays "twelve" so Pydantic
+    can fail on it and the field comes back red, rather than being silently
+    dropped to null. A blank box becomes None, which `pipeline._pick` resolves to
+    that column's default.
+    """
+    return (value or "").strip() or None
+
+
+def _row_values(
+    form: Mapping[str, Any],
+    prefix: str,
+    columns: Sequence[str],
+    checkboxes: Sequence[str],
+) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for column in columns:
+        if column in checkboxes:
+            # An unticked checkbox is simply absent from the submission.
+            values[column] = f"{prefix}.{column}" in form
+        else:
+            values[column] = _coerce(str(form.get(f"{prefix}.{column}", "")))
+    return values
+
+
+def _was_edited(form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]) -> bool:
+    """True when a submitted value differs from what the extraction proposed.
+
+    Compared in submitted form — display strings and booleans — so a float that
+    round-tripped through the input does not read as a change.
+    """
+    try:
+        origin = json.loads(str(form.get(f"{prefix}.origin", "")))
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(origin, dict):
+        return False
+    return any(
+        origin.get(column) != (value if isinstance(value, bool) else display_value(value))
+        for column, value in values.items()
+    )
+
+
+def draft_from_form(
+    form: Mapping[str, Any],
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Rebuild a draft from a submitted review form, rescored against the edits.
+
+    Every row is validated again from scratch, so a field the user fixed loses
+    its red mark and a field they broke gains one. Raises ValueError if the
+    round-tripped session date is unusable.
+    """
+    raw_text = str(form.get("raw_text", "")).strip()
+    session_date = datetime.strptime(str(form.get("session_date", "")).strip(), "%Y-%m-%d").date()
+
+    try:
+        set_count = int(str(form.get("set_count", "0")).strip() or 0)
+    except ValueError:
+        set_count = 0
+
+    draft = EntryDraft(
+        raw_text=raw_text,
+        session_date=session_date,
+        replace_existing=str(form.get("mode", "add")) == "replace",
+    )
+
+    checkbox_columns = [column for column, _ in SET_CHECKBOXES]
+    for index in range(max(0, set_count)):
+        prefix = f"s{index}"
+        values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
+        row = pipeline.draft_set_row(
+            values, raw_text, confidence_threshold, edited=_was_edited(form, prefix, values)
+        )
+        row.include = f"{prefix}.include" in form
+        draft.sets.append(row)
+
+    if str(form.get("has_bodyweight", "")).strip():
+        values = _row_values(form, "bw", pipeline.BODYWEIGHT_COLUMNS, ())
+        row = pipeline.draft_bodyweight_row(
+            values, raw_text, confidence_threshold, edited=_was_edited(form, "bw", values)
+        )
+        row.include = "bw.include" in form
+        draft.bodyweight = row
+
+    return draft

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -188,7 +188,7 @@ class TestRendering:
         assert 'name="s0.reps" class=""' in page
 
     def test_the_issue_is_spelled_out_next_to_the_row(self):
-        assert "no rep count found" in review.render_review_body(draft_for())
+        assert "no rep count recorded" in review.render_review_body(draft_for())
 
     def test_a_row_that_cannot_be_saved_says_so_instead_of_showing_a_zero_score(self):
         payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
@@ -220,9 +220,19 @@ class TestRendering:
         page = review.render_review_body(draft, {"sets": 12, "bodyweight": 1})
         assert "deletes the 12 set(s)" in page
 
-    def test_an_empty_draft_offers_no_form(self):
+    def test_an_empty_draft_still_offers_a_way_in(self):
+        """The parser finding nothing does not mean the workout did not happen."""
         page = review.render_review_body(draft_for({"sets": [], "bodyweight": None}))
-        assert "Nothing to save" in page and "<form" not in page
+        assert "Nothing to save" in page and 'value="add_set"' in page
+
+    def test_save_is_the_first_button_so_enter_does_not_add_a_row(self):
+        page = review.render_review_body(draft_for())
+        assert page.index('value="save"') < page.index('value="add_set"')
+
+    def test_bodyweight_can_only_be_added_when_there_is_none(self):
+        assert 'value="add_bodyweight"' not in review.render_review_body(draft_for())
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        assert 'value="add_bodyweight"' in review.render_review_body(without)
 
 
 # --------------------------------------------------------------------------
@@ -335,6 +345,89 @@ class TestEditing:
         corrected = review.draft_from_form(form)
         again = review.draft_from_form(submitted(corrected))
         assert [row.values for row in again.sets] == [row.values for row in corrected.sets]
+
+
+class TestAddingRows:
+    """A set the parser missed entirely is typed in on the same form. Adding is a
+    round trip rather than a script, so the state has to survive the extra hop."""
+
+    def add(self, draft, action="add_set"):
+        returned = review.draft_from_form(submitted(draft))
+        assert review.add_row(returned, action)
+        return returned
+
+    def test_an_empty_slot_is_appended(self):
+        assert len(self.add(draft_for()).sets) == 4
+
+    def test_an_unknown_action_adds_nothing(self):
+        draft = draft_for()
+        assert not review.add_row(draft, "save") and len(draft.sets) == 3
+
+    def test_bodyweight_is_not_added_twice(self):
+        draft = draft_for()
+        assert not review.add_row(draft, "add_bodyweight")
+
+    def test_an_empty_slot_is_not_a_row(self):
+        draft = self.add(draft_for())
+        assert draft.sets[3].blank and len(draft.included) == 4
+
+    def test_an_empty_slot_does_not_block_the_save(self):
+        """A blank exercise name would otherwise fail validation on sight."""
+        draft = self.add(draft_for())
+        assert draft.ready and draft.flagged_count == 2
+
+    def test_an_empty_slot_survives_the_round_trip_still_empty(self):
+        draft = review.draft_from_form(submitted(self.add(draft_for())))
+        assert len(draft.sets) == 4 and draft.sets[3].blank
+
+    def test_filling_a_slot_in_makes_it_a_row(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        form["s3.weight_kg"] = "15"
+        form["s3.reps"] = "12"
+        row = review.draft_from_form(form).sets[3]
+        assert not row.blank and row.added and row.values["exercise_name"] == "Face Pull"
+
+    def test_a_typed_row_is_not_judged_on_grounding(self):
+        """It was never read out of the entry, so there is nothing to ground it in."""
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Bulgarian Split Squat"
+        form["s3.weight_kg"] = "20"
+        form["s3.reps"] = "10"
+        row = review.draft_from_form(form).sets[3]
+        assert row.issues == [] and row.confidence == 1.0
+
+    def test_a_typed_row_still_says_what_is_missing(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        assert review.draft_from_form(form).sets[3].issues_for("weight_kg")
+
+    def test_a_typed_row_is_still_validated(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        form["s3.reps"] = "twelve"
+        returned = review.draft_from_form(form)
+        assert not returned.ready and returned.sets[3].issues_for("reps")
+
+    def test_a_typed_bodyweight_reading_survives(self):
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        form = submitted(self.add(without, "add_bodyweight"))
+        form["bw.weight_kg"] = "81.2"
+        row = review.draft_from_form(form).bodyweight
+        assert row.added and not row.blank and row.values["weight_kg"] == 81.2
+
+    def test_a_typed_bodyweight_reading_is_not_judged_on_grounding(self):
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        form = submitted(self.add(without, "add_bodyweight"))
+        form["bw.weight_kg"] = "81.2"
+        assert review.draft_from_form(form).bodyweight.issues == []
+
+    def test_an_empty_slot_reads_as_an_invitation_not_a_fault(self):
+        page = review.render_review_body(self.add(draft_for()))
+        assert "New set" in page and "cannot be saved yet" not in page
+
+    def test_an_empty_slot_is_not_counted_as_a_set(self):
+        assert "<h2>Sets (3)</h2>" in review.render_review_body(self.add(draft_for()))
 
 
 # --------------------------------------------------------------------------
@@ -460,6 +553,27 @@ class TestCommitting:
         draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
         result, _ = commit(draft)
         assert len(result.review_items) == 1
+
+    def test_an_empty_slot_is_neither_saved_nor_reported(self):
+        draft = draft_for()
+        draft.sets.append(pipeline.blank_set_row())
+        result, engine = commit(draft)
+        assert len(engine.inserted) == 4
+        assert result.skipped_sets == 0 and result.review_items == []
+
+    def test_an_empty_bodyweight_slot_is_ignored(self):
+        draft = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        draft.bodyweight = pipeline.blank_bodyweight_row()
+        result, _ = commit(draft)
+        assert result.inserted_bodyweight == 0 and result.skipped_bodyweight == 0
+
+    def test_a_typed_row_is_written(self):
+        draft = draft_for()
+        draft.sets.append(pipeline.draft_set_row(
+            {"exercise_name": "Face Pull", "weight_kg": 15, "reps": 12}, RAW_ENTRY, added=True))
+        result, engine = commit(draft)
+        assert result.inserted_sets == 4
+        assert engine.inserted[3]["extraction_confidence"] == 1.0
 
     def test_an_extraction_failure_writes_nothing(self):
         draft = pipeline.EntryDraft(RAW_ENTRY, SESSION, error="Extraction failed")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,488 @@
+"""Tests for the review screen: draft, edit, save.
+
+Nothing reaches the database from the web app without passing through here, so
+these cover the two ways that guarantee could fail quietly. One is the round
+trip: a row rendered into the form and posted straight back must come out
+identical, or an untouched entry silently changes on save. The other is the red
+marking: a row the database would reject has to block the save and say which
+field is wrong, otherwise the screen tells the user their entry is fine while
+dropping half of it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from html.parser import HTMLParser
+
+import pytest
+
+import pipeline
+import review
+from pipeline import CONFIDENCE_THRESHOLD
+
+SESSION = date(2026, 8, 22)
+
+RAW_ENTRY = (
+    "Chest bench press 28kg 11 reps almost died. Cable pulls 28kg. "
+    "External rotation 15 reps each side. Tricep pushdown. Was 82.4kg this morning."
+)
+
+PAYLOAD = {
+    "sets": [
+        {"exercise_name": "Chest Bench Press", "weight_kg": 28, "reps": 11,
+         "notes": "almost died", "raw_span": "Chest bench press 28kg 11 reps almost died"},
+        {"exercise_name": "Cable Pulls", "weight_kg": 28, "raw_span": "Cable pulls 28kg"},
+        {"exercise_name": "External Rotation", "reps": 15,
+         "raw_span": "External rotation 15 reps each side"},
+    ],
+    "bodyweight": {"weight_kg": 82.4, "raw_span": "Was 82.4kg this morning"},
+}
+
+
+def draft_for(payload=None, raw_text=RAW_ENTRY) -> pipeline.EntryDraft:
+    return pipeline.draft_from_payload(payload or PAYLOAD, raw_text, SESSION)
+
+
+class FormScraper(HTMLParser):
+    """Read a rendered review form back as the browser would submit it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: dict[str, str] = {}
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag != "input" or "name" not in attributes:
+            return
+        if attributes.get("type") == "checkbox":
+            # An unticked box is simply absent from the submission.
+            if "checked" in attributes:
+                self.data[attributes["name"]] = "on"
+        else:
+            self.data[attributes["name"]] = attributes.get("value", "")
+
+
+def submitted(draft: pipeline.EntryDraft) -> dict[str, str]:
+    scraper = FormScraper()
+    scraper.feed(review.render_review_body(draft))
+    return scraper.data
+
+
+# --------------------------------------------------------------------------
+# Building the draft
+# --------------------------------------------------------------------------
+
+
+class TestDraftBuilding:
+    def test_every_extracted_set_becomes_a_row(self):
+        assert len(draft_for().sets) == 3
+
+    def test_bodyweight_becomes_its_own_row(self):
+        assert draft_for().bodyweight.values["weight_kg"] == 82.4
+
+    def test_a_clean_row_is_not_flagged(self):
+        assert draft_for().sets[0].issues == []
+
+    def test_omitted_columns_fall_back_to_the_model_default(self):
+        """A missing cheat_reps means zero, not null — the column is NOT NULL."""
+        row = draft_for().sets[0]
+        assert row.values["cheat_reps"] == 0
+        assert row.values["is_warmup"] is False
+
+    def test_an_explicit_null_is_treated_as_omitted(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], cheat_reps=None, pain_flag=None)]}
+        row = draft_for(payload).sets[0]
+        assert row.values["cheat_reps"] == 0 and row.values["pain_flag"] is False
+
+    def test_values_are_coerced_to_what_will_be_stored(self):
+        assert draft_for().sets[0].values["weight_kg"] == 28.0
+
+    def test_nothing_extracted_is_reported_as_empty(self):
+        assert draft_for({"sets": [], "bodyweight": None}).is_empty
+
+    def test_a_fragment_that_is_not_a_row_stays_out_of_the_form(self):
+        """It cannot be edited, so it is reported rather than rendered."""
+        draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
+        assert draft.sets == []
+        assert "was not an object" in draft.review_items[0].reason
+
+
+class TestFlagging:
+    def test_missing_weight_is_flagged_on_its_own_field(self):
+        row = draft_for().sets[2]
+        assert [issue.field for issue in row.issues] == ["weight_kg"]
+
+    def test_missing_reps_is_flagged_on_its_own_field(self):
+        row = draft_for().sets[1]
+        assert [issue.field for issue in row.issues] == ["reps"]
+
+    def test_missing_information_does_not_block_the_save(self):
+        """A set with no recorded weight is still a set that happened."""
+        draft = draft_for()
+        assert draft.flagged_count == 2
+        assert draft.blocked_count == 0 and draft.ready
+
+    def test_a_name_the_model_invented_is_flagged(self):
+        payload = {"sets": [{"exercise_name": "Bulgarian Split Squat", "weight_kg": 20,
+                             "reps": 10, "raw_span": "Cable pulls 28kg"}]}
+        assert draft_for(payload).sets[0].issues_for("exercise_name")
+
+    def test_a_low_score_with_no_specific_cause_is_still_explained(self):
+        """Nothing is missing here — the name is only loosely supported by the
+        text and there is no span to check it against."""
+        payload = {"sets": [{"exercise_name": "Overhead Press", "weight_kg": 40, "reps": 8}]}
+        row = draft_for(payload).sets[0]
+        assert row.confidence < CONFIDENCE_THRESHOLD
+        assert [issue.field for issue in row.issues] == [None]
+
+    def test_a_bodyweight_number_not_in_the_entry_is_flagged(self):
+        payload = {"sets": [], "bodyweight": {"weight_kg": 91.0, "raw_span": "Was 82.4kg"}}
+        assert draft_for(payload).bodyweight.issues_for("weight_kg")
+
+
+class TestBlockingIssues:
+    def test_an_invalid_value_blocks_the_save(self):
+        payload = {"sets": [{"exercise_name": "Bench", "weight_kg": 28, "reps": "eleven"}]}
+        draft = draft_for(payload)
+        assert draft.sets[0].blocking and not draft.ready
+
+    def test_the_blocked_field_is_named(self):
+        payload = {"sets": [{"exercise_name": "Bench", "weight_kg": 28, "reps": "eleven"}]}
+        assert draft_for(payload).sets[0].issues_for("reps")
+
+    def test_a_whole_row_check_is_pinned_to_the_column_it_names(self):
+        """Pydantic reports a model validator against no field at all."""
+        payload = {"sets": [{"exercise_name": "Leg Press", "weight_kg": 100, "reps": 8,
+                             "cheat_reps": 12}]}
+        row = draft_for(payload).sets[0]
+        assert [issue.field for issue in row.issues] == ["cheat_reps"]
+
+    def test_an_unticked_row_cannot_block_the_save(self):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
+        draft = draft_for(payload)
+        draft.sets[0].include = False
+        assert draft.ready
+
+    def test_a_blank_name_blocks_rather_than_inserting_an_empty_exercise(self):
+        payload = {"sets": [{"exercise_name": "   ", "weight_kg": 20, "reps": 10}]}
+        assert draft_for(payload).sets[0].blocking
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+class TestRendering:
+    def test_every_editable_column_gets_a_field(self):
+        page = review.render_review_body(draft_for())
+        for column in pipeline.SET_COLUMNS:
+            assert f'name="s0.{column}"' in page
+
+    def test_a_flagged_field_is_marked(self):
+        page = review.render_review_body(draft_for())
+        assert 'name="s1.reps" class="bad"' in page
+
+    def test_a_clean_field_is_not_marked(self):
+        page = review.render_review_body(draft_for())
+        assert 'name="s0.reps" class=""' in page
+
+    def test_the_issue_is_spelled_out_next_to_the_row(self):
+        assert "no rep count found" in review.render_review_body(draft_for())
+
+    def test_a_row_that_cannot_be_saved_says_so_instead_of_showing_a_zero_score(self):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
+        page = review.render_review_body(draft_for(payload))
+        assert "cannot be saved yet" in page and "confidence 0.00" not in page
+
+    def test_exercise_names_are_escaped(self):
+        """Names come straight from model output and land in an attribute."""
+        payload = {"sets": [{"exercise_name": '"><script>alert(1)</script>',
+                             "weight_kg": 20, "reps": 10}]}
+        page = review.render_review_body(draft_for(payload))
+        assert "<script>" not in page and "&lt;script&gt;" in page
+
+    def test_the_entry_text_is_escaped_in_the_hidden_field(self):
+        page = review.render_review_body(draft_for(raw_text='bench "20kg" <b>'))
+        assert "<b>" not in page and "&lt;b&gt;" in page
+
+    def test_the_original_entry_is_carried_forward_for_the_save(self):
+        assert submitted(draft_for())["raw_text"] == RAW_ENTRY
+
+    def test_replace_mode_survives_the_review_step(self):
+        draft = draft_for()
+        draft.replace_existing = True
+        assert submitted(draft)["mode"] == "replace"
+
+    def test_replace_mode_says_what_it_will_delete(self):
+        draft = draft_for()
+        draft.replace_existing = True
+        page = review.render_review_body(draft, {"sets": 12, "bodyweight": 1})
+        assert "deletes the 12 set(s)" in page
+
+    def test_an_empty_draft_offers_no_form(self):
+        page = review.render_review_body(draft_for({"sets": [], "bodyweight": None}))
+        assert "Nothing to save" in page and "<form" not in page
+
+
+# --------------------------------------------------------------------------
+# Reading the form back
+# --------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_an_untouched_submission_reproduces_the_draft(self):
+        original = draft_for()
+        returned = review.draft_from_form(submitted(original))
+        assert [row.values for row in returned.sets] == [row.values for row in original.sets]
+
+    def test_an_untouched_submission_is_not_reported_as_edited(self):
+        """Otherwise every row would be stored as human-confirmed."""
+        returned = review.draft_from_form(submitted(draft_for()))
+        assert not any(row.edited for row in returned.rows)
+
+    def test_an_untouched_submission_keeps_its_scores(self):
+        original = draft_for()
+        returned = review.draft_from_form(submitted(original))
+        assert [row.confidence for row in returned.sets] == [row.confidence for row in original.sets]
+
+    def test_the_session_date_survives(self):
+        assert review.draft_from_form(submitted(draft_for())).session_date == SESSION
+
+    def test_an_unusable_session_date_is_refused(self):
+        form = submitted(draft_for())
+        form["session_date"] = "22/08/2026"
+        with pytest.raises(ValueError):
+            review.draft_from_form(form)
+
+    def test_the_bodyweight_row_survives(self):
+        assert review.draft_from_form(submitted(draft_for())).bodyweight is not None
+
+    def test_no_bodyweight_stays_no_bodyweight(self):
+        draft = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        assert review.draft_from_form(submitted(draft)).bodyweight is None
+
+
+class TestEditing:
+    def test_a_corrected_field_is_taken(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        assert review.draft_from_form(form).sets[1].values["reps"] == 9
+
+    def test_correcting_a_field_clears_its_mark(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        assert review.draft_from_form(form).sets[1].issues == []
+
+    def test_a_corrected_row_is_recorded_as_edited(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        returned = review.draft_from_form(form)
+        assert returned.sets[1].edited and not returned.sets[0].edited
+
+    def test_a_toggled_flag_counts_as_an_edit(self):
+        form = submitted(draft_for())
+        form["s0.pain_flag"] = "on"
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["pain_flag"] is True and returned.sets[0].edited
+
+    def test_clearing_a_flag_counts_as_an_edit(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], is_warmup=True)]}
+        form = submitted(draft_for(payload))
+        del form["s0.is_warmup"]
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["is_warmup"] is False and returned.sets[0].edited
+
+    def test_unticking_a_row_leaves_it_out(self):
+        form = submitted(draft_for())
+        del form["s1.include"]
+        returned = review.draft_from_form(form)
+        assert not returned.sets[1].include and len(returned.included) == 3
+
+    def test_unticking_the_bodyweight_row_leaves_it_out(self):
+        form = submitted(draft_for())
+        del form["bw.include"]
+        assert not review.draft_from_form(form).bodyweight.include
+
+    def test_breaking_a_field_blocks_the_save(self):
+        form = submitted(draft_for())
+        form["s0.reps"] = "eleven"
+        returned = review.draft_from_form(form)
+        assert not returned.ready and returned.sets[0].issues_for("reps")
+
+    def test_bad_input_is_kept_so_it_can_be_corrected(self):
+        """Dropping it to null would hide the mistake and save the row anyway."""
+        form = submitted(draft_for())
+        form["s0.reps"] = "eleven"
+        page = review.render_review_body(review.draft_from_form(form))
+        assert 'value="eleven"' in page
+
+    def test_clearing_a_field_empties_it_rather_than_failing(self):
+        form = submitted(draft_for())
+        form["s0.weight_kg"] = "  "
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["weight_kg"] is None and returned.ready
+
+    def test_a_cleared_cheat_rep_count_becomes_zero(self):
+        form = submitted(draft_for())
+        form["s0.cheat_reps"] = ""
+        assert review.draft_from_form(form).sets[0].values["cheat_reps"] == 0
+
+    def test_a_second_pass_over_a_corrected_form_is_stable(self):
+        """The re-rendered page has to submit back to the same values."""
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        corrected = review.draft_from_form(form)
+        again = review.draft_from_form(submitted(corrected))
+        assert [row.values for row in again.sets] == [row.values for row in corrected.sets]
+
+
+# --------------------------------------------------------------------------
+# Saving
+# --------------------------------------------------------------------------
+
+
+class FakeConnection:
+    def __init__(self, log: list) -> None:
+        self.log = log
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        self.log.append(params or {})
+
+        class Result:
+            @staticmethod
+            def fetchall():
+                return []
+
+            @staticmethod
+            def fetchone():
+                return (1,)
+
+            @staticmethod
+            def scalar_one():
+                return 0
+
+        return Result()
+
+
+class FakeEngine:
+    """Enough of an Engine for commit_draft; every statement is recorded."""
+
+    def __init__(self) -> None:
+        self.log: list = []
+
+    def begin(self):
+        return FakeConnection(self.log)
+
+    def connect(self):
+        return FakeConnection(self.log)
+
+    @property
+    def inserted(self) -> list:
+        return [params for params in self.log if "extraction_confidence" in params]
+
+
+def commit(draft, engine=None, **kwargs):
+    engine = engine or FakeEngine()
+    result = pipeline.commit_draft(draft, engine=engine, **kwargs)
+    return result, engine
+
+
+class TestCommitting:
+    def test_ticked_rows_are_written(self):
+        result, engine = commit(draft_for())
+        assert result.inserted_sets == 3 and result.inserted_bodyweight == 1
+        assert len(engine.inserted) == 4
+
+    def test_unticked_rows_are_not_written(self):
+        draft = draft_for()
+        draft.sets[1].include = False
+        result, _ = commit(draft)
+        assert result.inserted_sets == 2 and result.skipped_sets == 1
+
+    def test_an_unticked_bodyweight_row_is_counted_separately(self):
+        draft = draft_for()
+        draft.bodyweight.include = False
+        result, _ = commit(draft)
+        assert result.inserted_bodyweight == 0 and result.skipped_bodyweight == 1
+
+    def test_a_low_score_no_longer_holds_a_row_back(self):
+        """The threshold gates the unattended path; here a person decided."""
+        draft = draft_for()
+        assert draft.sets[1].confidence < CONFIDENCE_THRESHOLD
+        result, _ = commit(draft)
+        assert result.inserted_sets == 3 and result.review_items == []
+
+    def test_an_edited_row_is_stored_as_human_confirmed(self):
+        draft = draft_for()
+        draft.sets[1].edited = True
+        _, engine = commit(draft)
+        assert engine.inserted[1]["extraction_confidence"] == 1.0
+
+    def test_an_untouched_row_keeps_its_computed_score(self):
+        draft = draft_for()
+        _, engine = commit(draft)
+        assert engine.inserted[1]["extraction_confidence"] == draft.sets[1].confidence
+
+    def test_the_original_entry_is_stored_against_every_row(self):
+        _, engine = commit(draft_for())
+        assert all(params["raw_source"] == RAW_ENTRY for params in engine.inserted)
+
+    def test_a_row_the_database_would_reject_is_reported_not_dropped(self):
+        """A guard: the route checks `ready` first, so this should be unreachable."""
+        draft = draft_for({"sets": [{"exercise_name": "Bench", "reps": "eleven"}]})
+        result, engine = commit(draft)
+        assert engine.inserted == [] and len(result.review_items) == 1
+
+    def test_nothing_ticked_writes_nothing(self):
+        draft = draft_for()
+        for row in draft.rows:
+            row.include = False
+        result, engine = commit(draft)
+        assert engine.log == [] and result.total_inserted == 0
+
+    def test_replace_only_deletes_when_something_replaces_it(self):
+        """An all-unticked draft must never empty the day."""
+        draft = draft_for()
+        draft.replace_existing = True
+        for row in draft.rows:
+            row.include = False
+        result, engine = commit(draft)
+        assert engine.log == [] and result.replaced is None
+
+    def test_fragments_that_were_never_rows_carry_through_to_the_result(self):
+        draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
+        result, _ = commit(draft)
+        assert len(result.review_items) == 1
+
+    def test_an_extraction_failure_writes_nothing(self):
+        draft = pipeline.EntryDraft(RAW_ENTRY, SESSION, error="Extraction failed")
+        result, engine = commit(draft)
+        assert engine.log == [] and result.error == "Extraction failed"
+
+
+class TestUnattendedPathIsUnchanged:
+    """`process_entry` is the CLI's route and has no reviewer, so the threshold
+    still decides there."""
+
+    def test_a_low_score_is_held_back_for_review(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: PAYLOAD)
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
+        engine = FakeEngine()
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=engine)
+        assert result.inserted_sets == 1
+        assert len(result.review_items) == 2
+        assert all("below threshold" in item.reason for item in result.review_items)
+
+    def test_an_invalid_row_is_reported_the_same_way_as_before(self, monkeypatch):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}], "bodyweight": None}
+        monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: payload)
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=FakeEngine())
+        assert result.review_items[0].reason.startswith("failed validation:")


### PR DESCRIPTION
Nothing the model extracts reaches the database until it has been shown, checked and confirmed. Everything else here follows from that.

## Nothing is saved before you have seen it

`POST /log` extracts and writes nothing. It renders every prospective database row as an editable form — the same columns the table has, filled with the values that would be stored — and only `POST /save` inserts.

Problems are marked in red in two tiers:

- **Blocking** — a value the database would reject (reps of `"eleven"`, cheat reps above reps, a blank name). The field is outlined, the fault is named, and the save is refused until it is fixed or the row is unticked. Bad input stays in the box rather than being dropped to null, because a field silently emptied is a mistake you never see.
- **Missing or weakly grounded** — no weight, no rep count, a name that does not match the span it was read from, a score under the threshold. Marked the same way but savable: a set with no recorded load is still a set that happened.

The submission is rescored from what was actually typed, not from the extraction, so correcting a field clears its mark and breaking one adds one. The round trip is exact: a form rendered and posted back untouched produces identical values, with no row falsely recorded as edited.

The threshold now marks rows in the web app instead of dropping them — you are looking at all of them anyway, and a set you can see and correct is worth more than one silently withheld. It still gates the CLI, which has nobody watching.

**Adding rows.** "Add a set" appends an empty slot for something the parser missed entirely; "Add bodyweight" does the same for a reading the entry never mentioned. An empty slot is not a row — skipped on save, never reported as left out — so adding one and changing your mind costs nothing. A slot you fill in is validated like any other row but not scored on grounding, since it was never read out of the entry.

## Muscle group is suggested, then reviewed

The extraction is never asked for a muscle group and nobody writes "chest" in a gym journal, so the column filled itself in silently and the form showed an empty box. It is written once per exercise and never revisited, and the volume chart buckets on it exactly as stored, so a wrong or blank one misreports for months without surfacing.

It is now suggested into the form and corrected there. The suggestion prefers what the exercise is already filed under — matched the same fuzzy way the insert path matches names — and falls back to the static table. Stored wins because `get_or_create_exercise` never revises a stored group on its own; offering a table answer that disagreed would be offering an edit that saving ignores.

A group **you type** re-files an exercise that already exists. That needed edits tracked per field rather than per row, so a suggestion can be told from a choice. Without it, correcting the group on an exercise logged before would have appeared to work and changed nothing.

## e1RM sectioned by muscle group, and cards that fold

The e1RM chart grouped exercises by the muscle they are filed under, so "is my chest progressing" is one glance rather than a hunt. **Grouped, not aggregated** — one averaged e1RM line per muscle group would read more easily and mean nothing, since a 100 kg bench press and a 15 kg cable fly have no useful mean and the average would move when exercise selection changed rather than when strength did. Which exercises appear is still decided by how much each is trained.

Every progress card folds, as does every muscle group inside the e1RM card. A card with nothing to say folds itself and puts the answer on its own summary line ("Pain flags · none in this window"), so collapsing never costs what it was telling you.

## Design notes

- **No state between the two requests.** The draft round-trips in the form itself, so the flow works unchanged on a serverless deploy where `/log` and `/save` may not reach the same process. `vercel.json` bundles with `includeFiles: "*.py"`, so `review.py` needs no config change — confirmed by importing `app.py` by path from outside the project root, the way the loader does.
- **The duplicate guard moved to `/save`**, the step that writes. `/log` writes nothing, so re-running it costs only another extraction.
- **A row you edit or type in is stored at confidence 1.0.** The score measures how well an extraction is grounded in the source text; a human correction is better evidence than the heuristic, and a hand-entered row has no extraction to score.
- **`pipeline.process_entry` is unchanged for the CLI.** It is now a thin wrapper over `build_draft` and `commit_draft`, verified against the previous implementation on the same payloads — identical results, insert parameters included.

## Also in this branch

It carries the muscle-group table (#18), already merged to the repo's default branch but not to `main`, because the review screen builds on it rather than growing a second source of the same answer. That also resolves the README conflict between the two.

## Tests

666 tests, no network or database required. New coverage for the draft/edit/save round trip, blocking versus non-blocking flags, hand-entered rows, muscle-group suggestion and override, e1RM grouping, and the fold behaviour.

Bugs the tests caught while writing this:
- An empty slot round-tripped its cheat-reps box as the string `"0"`, so on the second pass it stopped reading as blank and demanded an exercise name.
- Renaming an exercise left the previous name's muscle group behind; the two directions need different rules.
- Adding a column to the e1RM table twin exposed that `_table` right-aligns every column after the first — correct for one-label-column tables, wrong for one leading with three.
- Per-group grids broke `auto-fit`, which collapses empty tracks, so a group with one exercise drew a chart three times the size of one in a group of three.
- The fold marker was a CSS hex escape inside a plain Python string, so Python read it as an octal escape and a control character reached the stylesheet instead of the arrow.

There is no CI in this repo, so the only automated check is the Vercel preview deploy — it proves the app builds and imports, not that the suite passes. The test counts above are from local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q45UQk8bucH5oZsbd3AzQF