### PR TITLE
Derive today's date from LOCAL_TIMEZONE, not the server clock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,10 @@ APP_PASSWORD=use_a_long_random_string
 CONFIDENCE_THRESHOLD=0.7
 # rapidfuzz score at/above which a proposed exercise name reuses an existing row.
 FUZZY_MATCH_THRESHOLD=85
-# Single fixed timezone for this single-user tool. IANA name.
+# Single fixed timezone for this single-user tool. IANA name. This is what
+# decides which calendar day - and so which week - a session belongs to, so on
+# a host whose clock is UTC (Vercel, Render) leaving it unset dates anything
+# logged late at night a day early. Set it to where you actually train.
 LOCAL_TIMEZONE=UTC
 # Assumed wall-clock hour when the journal text carries no time marker.
 DEFAULT_SESSION_HOUR=18

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ first request after a long gap can be slow.
 - Set `DATABASE_URL`, `GROQ_API_KEY`, `APP_USERNAME`, `APP_PASSWORD` and
   `LOCAL_TIMEZONE` in Project Settings → Environment Variables (`.env` is
   gitignored, so it is not deployed)
+- `LOCAL_TIMEZONE` is not optional in practice. Vercel's containers run on UTC,
+  and it is what decides which day — and therefore which week — a session is
+  filed under. Leave it unset and a workout logged late at night is dated a day
+  early; on a Sunday night that puts it in the previous week's volume
 - `vercel.json` pins `maxDuration` to 60s, which covers a Groq call plus inserts
 
 Use the Supabase **transaction pooler (port 6543)** rather than session mode

--- a/app.py
+++ b/app.py
@@ -313,7 +313,7 @@ async def healthz() -> JSONResponse:
 
 @app.get("/", response_class=HTMLResponse)
 async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
-    today = date.today().isoformat()
+    today = pipeline.local_today().isoformat()
     return _page(
         "Log a workout",
         f"""
@@ -397,7 +397,7 @@ async def progress(_user: str = Depends(require_auth)) -> HTMLResponse:
 
 @app.get("/weekly-report", response_class=HTMLResponse)
 async def weekly_report_form(_user: str = Depends(require_auth)) -> HTMLResponse:
-    current_week = insights.week_start_for(date.today())
+    current_week = insights.week_start_for(pipeline.local_today())
     return _page(
         "Weekly report",
         f"""

--- a/insights.py
+++ b/insights.py
@@ -803,7 +803,7 @@ def generate_weekly_report(
 ) -> dict[str, Any]:
     """Stage A, then Stage B, then upsert into weekly_reports."""
     if week_start is None:
-        week_start = week_start_for(date.today())
+        week_start = week_start_for(pipeline.local_today())
     week_start = week_start_for(week_start)
 
     since = week_start - timedelta(weeks=ANALYSIS_WEEKS)
@@ -976,7 +976,7 @@ def pain_summary(records: Iterable[SetRecord]) -> list[dict[str, Any]]:
 
 def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = None) -> dict[str, Any]:
     """Everything the progress page plots. No LLM anywhere in here."""
-    today = today or date.today()
+    today = today or pipeline.local_today()
     this_week = week_start_for(today)
     since = this_week - timedelta(weeks=weeks - 1)
     until = this_week + timedelta(days=7)

--- a/pipeline.py
+++ b/pipeline.py
@@ -429,6 +429,26 @@ def local_to_utc(local_dt: datetime, timezone_name: Optional[str] = None) -> dat
     return aware.astimezone(_tz.utc)
 
 
+def local_today(timezone_name: Optional[str] = None) -> date:
+    """Today's date in the configured local zone, not the server's.
+
+    Every host this deploys to runs its containers on UTC, so `date.today()`
+    there is the UTC date - which is still yesterday for part of every local day
+    east of Greenwich. Writes and reads already route through LOCAL_TIMEZONE
+    (`local_to_utc`, `_local_day_bounds`), so the day boundary has to as well:
+    otherwise a late-night session is dated a day early, and at a Sunday
+    boundary that files it under the previous week entirely.
+
+    Resolved at call time for the same reason as `local_to_utc`.
+    """
+    from datetime import timezone as _tz
+
+    if ZoneInfo is None:  # pragma: no cover
+        raise RuntimeError("zoneinfo unavailable; Python 3.9+ required")
+    tz = ZoneInfo(timezone_name or LOCAL_TIMEZONE)
+    return datetime.now(_tz.utc).astimezone(tz).date()
+
+
 def resolve_logged_at(
     logged_at_local: Optional[str],
     session_date: date,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -654,6 +654,68 @@ class TestLocalDayBounds:
         assert first_end == second_start
 
 
+class TestLocalToday:
+    """The day boundary must come from LOCAL_TIMEZONE, not the server clock.
+
+    Every deploy target runs its containers on UTC, so `date.today()` there is
+    the UTC date - a day early for part of every local day east of Greenwich.
+    """
+
+    @staticmethod
+    def _frozen(moment_utc: datetime):
+        class _Frozen(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return moment_utc.astimezone(tz) if tz else moment_utc
+
+        return _Frozen
+
+    def test_utc_zone_matches_the_utc_date(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today() == date(2026, 8, 21)
+
+    def test_late_evening_utc_is_already_tomorrow_in_karachi(self, monkeypatch):
+        """20:30 UTC is 01:30 the next day in Karachi - the local date wins."""
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today() == date(2026, 8, 22)
+
+    def test_a_sunday_night_session_is_not_filed_under_the_previous_week(self, monkeypatch):
+        """The failure this exists to prevent: a whole week's misplacement.
+
+        2026-08-23 is a Sunday. At 20:00 UTC it is already Monday in Karachi,
+        so the session belongs to the week starting 2026-08-24, not 2026-08-17.
+        """
+        import insights
+
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 23, 20, 0, tzinfo=timezone.utc))
+        )
+        assert insights.week_start_for(pipeline.local_today()) == date(2026, 8, 24)
+
+    def test_zone_is_read_at_call_time_not_bound_at_import(self, monkeypatch):
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        assert pipeline.local_today() == date(2026, 8, 21)
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        assert pipeline.local_today() == date(2026, 8, 22)
+
+    def test_explicit_zone_argument_overrides_the_setting(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today("Asia/Karachi") == date(2026, 8, 22)
+
+
 class TestReplaceIsOptIn:
     def test_process_entry_defaults_to_adding(self):
         import inspect


### PR DESCRIPTION
Four call sites asked the container what day it was via date.today(), while every write and read around them routed through LOCAL_TIMEZONE (local_to_utc, _local_day_bounds, load_set_records). Vercel and Render both run their containers on UTC, so on any deployment east of Greenwich those two disagreed for part of every day.

The visible effects: the "Session date" field on the log form pre-filled yesterday's date when logging late at night, and the progress dashboard's "this week" window lagged a day. At a Sunday-night boundary that is not an off-by-one on the label but a whole week's misplacement - the session gets filed under the previous week's volume.

Adds pipeline.local_today(), resolved at call time for the same reason as local_to_utc, and uses it in app.index, app.weekly_report_form, insights.generate_weekly_report and insights.build_dashboard.

seed_sample_data.py keeps date.today() - it is a developer script run on a machine whose clock is already local.

Also documents that LOCAL_TIMEZONE is not optional on a UTC host, since the failure it causes is silent.


Claude-Session: https://claude.ai/code/session_01VAJUvDJEV59uHU7P2wqK6U