### PR TITLE
Review every parsed row before it is saved, and file it by muscle group

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Notes app (unchanged)
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
+| `muscle_groups.py` | Static exercise-name -> primary muscle group tables and lookup |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
+| `backfill_muscle_groups.py` | One-off: fills `muscle_group` for exercises logged before the lookup existed |
 | `tests/` | Unit tests for the Stage A rules and the confidence / fuzzy-match logic |
 | `sample_entry.txt` | A messy journal entry in the real style, for trying the CLI |
 
@@ -218,6 +220,51 @@ Unknown words fail closed, into a separate row.
 
 Both names must have at least two tokens for the subset bonus, so "Curl" never
 absorbs "Leg Curl". Threshold is 85, tunable via `FUZZY_MATCH_THRESHOLD`.
+
+### Muscle groups come from a table, not the model
+
+`exercises.muscle_group` is written by `get_or_create_exercise` only on INSERT,
+so it is decided once per distinct movement and then never revisited — a few
+dozen decisions over the life of the tool, not one per set. That makes it a
+lookup, not a judgement, and `muscle_groups.py` holds the table.
+
+Asking the model instead would have cost nothing in tokens — the field would
+ride along in the extraction JSON that is already requested. The reason not to
+is `GROQ_REASONING_EFFORT=low`: gpt-oss shares one completion budget between its
+reasoning and its answer, so adding a *classification* subtask to an
+*extraction* task buys a `json_validate_failed` risk on long entries in exchange
+for an answer a `dict` already knows. Asking the user instead would tax every
+log for information the exercise name already carries.
+
+Resolution runs four passes, most specific first: the full name against the
+table, the name with equipment tokens stripped, a muscle named in the name, then
+the movement verb. The table is consulted first because the obvious heuristic is
+wrong on exactly the names that matter — `Chest Supported Row` is a back
+exercise, `Leg Raise` is a core exercise, and `Leg Curl` is not a biceps
+exercise. `press` and `raise` are deliberately absent from the verb fallback:
+they span chest, shoulders and legs, so a guess would mislabel about a third of
+what it caught.
+
+Unrecognized names resolve to `None`, stored as NULL and reported as
+"Unassigned" — the same fail-closed rule the qualifier allowlist uses. Nothing
+is ever guessed onto the axis the weekly report's volume figures are grouped by.
+
+**Primary mover only.** The column is a single `TEXT` and the chart sums over
+it. A bench press is chest, triceps and front delts; recording all three would
+make "volume by muscle group" stop summing to actual total volume.
+
+`EQUIPMENT_TOKENS` is looser than the identity-matching `QUALIFIER_TOKENS`
+above, on purpose: seated and standing calf raises are two exercises that must
+keep separate progress histories but share one muscle group. Stripping a token
+there never merges two exercises, it only lets them share a lookup key. Genuine
+variations — `incline`, `close grip`, `romanian` — stay out of it, because they
+change which muscle leads the lift.
+
+Exercises logged before any of this existed carry NULL. `python
+backfill_muscle_groups.py --dry-run` shows what the table would fill in;
+without the flag it writes them. It only ever touches NULL rows, so a
+hand-corrected group is never overwritten, and it lists the names it did not
+recognize — that list is what to add to `EXERCISE_MUSCLE_GROUPS`.
 
 ### Cheat reps are counted, not flagged
 
@@ -411,12 +458,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-201 tests, no network and no database required — they cover the Stage A rule
+545 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
-threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution, and JSON-mode retry behaviour. These are pure functions, so they are
-cheap to cover, and they are exactly the code where a silent bug produces a wrong
+threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
+resolution, and JSON-mode retry behaviour, and the muscle-group tables — both
+their resolution cases and mechanical guards that every key is in the normalized
+form lookup actually produces. These are pure functions, so they are cheap to
+cover, and they are exactly the code where a silent bug produces a wrong
 training recommendation that nobody notices.
 
 ## Not built (by design)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,36 @@ state between the two requests. The draft travels in the form itself, which is
 why the flow works unchanged on a serverless deploy where the two requests may
 not reach the same process.
 
+### Muscle group is suggested, then reviewed
+
+Nobody writes "chest" in a gym journal, and the extraction is never asked for a
+muscle group — so the column filled itself in silently from the static table and
+nothing ever showed you the answer. `exercises.muscle_group` is written once per
+distinct movement and then never revisited, and `insights.volume_by_muscle_group`
+buckets on it exactly as stored, so a wrong or blank one is a chart that quietly
+misreports for months.
+
+It is now suggested into the review form like any other value, and correctable
+there. The suggestion comes from what the exercise is **already filed under**
+first — matched the same fuzzy way the insert path matches names, so a reworded
+name still finds its own row — and falls back to the table. Stored wins because
+`get_or_create_exercise` never revises a stored group on its own: offering a
+table answer that disagreed with one would be offering an edit that saving
+ignores.
+
+Two things are marked in red: a name the table cannot place (left alone it
+becomes "Unassigned" in the volume chart), and a group outside the ten canonical
+ones (it would become its own bucket). Neither blocks the save — muscle group is
+a filing decision, not a fact about the set. The ten standard groups are offered
+as a pick list, which is a `<datalist>`, so it suggests without refusing
+anything you insist on.
+
+A group **you type** is treated differently from one the app suggested: it is
+the only thing that will re-file an exercise that already exists. That
+distinction is why edits are tracked per field rather than per row. Without it
+correcting a group on an exercise you had logged before would appear to work and
+change nothing.
+
 ### Confidence is computed, not asked for
 
 LLMs are badly calibrated at rating their own certainty, so the model is
@@ -526,11 +556,11 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-628 tests, no network and no database required — they cover the Stage A
+643 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution and JSON-mode retry behaviour, the muscle-group tables — both their
+resolution and JSON-mode retry behaviour, the muscle-group tables and how their answer is suggested and overridden — both their
 resolution cases and mechanical guards that every key is in the normalized form
 lookup actually produces — and the review screen's draft/edit/save round trip.
 These are pure functions, so they are cheap to cover, and they are exactly the

--- a/README.md
+++ b/README.md
@@ -456,8 +456,9 @@ so re-running it costs only another extraction.
 
 ## Charts
 
-`/progress` plots the logged data: weekly volume, estimated 1RM per exercise as
-small multiples, bodyweight, volume by muscle group, and a pain-flag view. Drawn
+`/progress` plots the logged data: weekly volume, estimated 1RM as small
+multiples sectioned by muscle group, bodyweight, volume by muscle group, and a
+pain-flag view. Drawn
 as inline SVG from a JSON blob, so there is no chart library, no external
 request, and nothing added to `requirements.txt`.
 
@@ -466,6 +467,16 @@ number on a chart and the same number in the report cannot drift apart.
 
 A few decisions that are easy to get wrong:
 
+- **e1RM is grouped by muscle, not averaged into it.** The exercises of one
+  muscle group sit together under a heading so "is my chest progressing" is one
+  glance rather than a hunt, but each keeps its own line. One averaged e1RM per
+  muscle group would read more easily and mean nothing: a 100kg bench press and
+  a 15kg cable fly have no useful mean, and the average would move when you
+  changed exercise selection rather than when you got stronger. Which exercises
+  appear is still decided by how much they are trained, so grouping never
+  reserves slots for a muscle you barely work. An exercise with no group on file
+  sections under **Unassigned**, last — which is also the nudge to go and set it
+  on the review screen.
 - **Each exercise carries a fitted trend line and its slope in kg/week.** The
   shape of a line does not give the rate: two lifts can both end higher while
   one is gaining three times as fast. The line drawn and the rate quoted beside
@@ -556,7 +567,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-643 tests, no network and no database required — they cover the Stage A
+655 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/README.md
+++ b/README.md
@@ -467,6 +467,18 @@ number on a chart and the same number in the report cannot drift apart.
 
 A few decisions that are easy to get wrong:
 
+- **Every card folds, and a card with nothing to say folds itself.** Bodyweight
+  with no readings, volume on a week you have not trained, pain flags on a clean
+  window — each collapses to its heading with the answer beside it ("none in
+  this window"), so folding never costs you what the card was telling you.
+  Anything with something to show starts open: you opened the page to look at
+  it. Muscle-group sections fold too, which is how you get one muscle on screen
+  at a time.
+  Built on `<details>`, the same element the table twins already use, so it
+  works without JavaScript — but a chart *drawn* inside a closed one has no
+  width to measure, and `clientWidth` falls back to a guess that would never
+  correct itself. Opening a section redraws what is inside it at the size it
+  actually got.
 - **e1RM is grouped by muscle, not averaged into it.** The exercises of one
   muscle group sit together under a heading so "is my chest progressing" is one
   glance rather than a hunt, but each keeps its own line. One averaged e1RM per
@@ -567,7 +579,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-655 tests, no network and no database required — they cover the Stage A
+666 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/app.py
+++ b/app.py
@@ -371,6 +371,20 @@ def _invalid_date_page() -> HTMLResponse:
     )
 
 
+def _known_groups() -> Optional[dict[str, Optional[str]]]:
+    """What each known exercise is already filed under, for the suggestion.
+
+    Best effort, like `_existing_counts`: without it the suggestion falls back
+    to the static table, which is a worse answer but not a wrong one.
+    """
+    try:
+        with get_engine().connect() as conn:
+            return pipeline.load_exercise_groups(conn)
+    except Exception:  # noqa: BLE001 - the save step will surface a real outage
+        logger.warning("event=known_groups_failed", exc_info=True)
+        return None
+
+
 def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
     """What is already logged on that date, for the review banner.
 
@@ -406,7 +420,7 @@ async def log_entry(
     if parsed_date is None:
         return _invalid_date_page()
 
-    draft = pipeline.build_draft(raw_text, parsed_date)
+    draft = pipeline.build_draft(raw_text, parsed_date, known_groups=_known_groups())
     draft.replace_existing = mode == "replace"
     logger.info(
         "event=entry_drafted date=%s mode=%s sets=%d bodyweight=%s flagged=%d blocked=%d error=%s",
@@ -447,7 +461,7 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
     """
     form = await request.form()
     try:
-        draft = review.draft_from_form(form)
+        draft = review.draft_from_form(form, known_groups=_known_groups())
     except ValueError:
         return _invalid_date_page()
 

--- a/backfill_muscle_groups.py
+++ b/backfill_muscle_groups.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fill in `exercises.muscle_group` for rows created before it was resolved.
+
+    python backfill_muscle_groups.py --dry-run   # show what would change
+    python backfill_muscle_groups.py             # apply
+
+Every exercise logged before the static lookup existed was inserted with a NULL
+muscle group, which `insights.volume_by_muscle_group` reports as "Unassigned" -
+so the whole training history collapses into one bar. This walks those rows
+through `pipeline.resolve_muscle_group` and writes back the ones it recognizes.
+
+Only NULL rows are touched. A group already stored - whether it came from the
+table, from `seed_sample_data.py`, or from a hand-written correction - is left
+exactly as it is, so re-running this can never overwrite a deliberate value.
+Names the table does not recognize stay NULL and are listed at the end, which is
+the signal for what to add to `muscle_groups.EXERCISE_MUSCLE_GROUPS`.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import text
+
+import pipeline
+
+
+def backfill(engine, dry_run: bool = False) -> tuple[int, list[str]]:
+    """Resolve NULL muscle groups. Returns (updated_count, unresolved_names)."""
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT exercise_id, name FROM exercises "
+                "WHERE muscle_group IS NULL ORDER BY name"
+            )
+        ).fetchall()
+
+        updated = 0
+        unresolved: list[str] = []
+        for exercise_id, name in rows:
+            group = pipeline.resolve_muscle_group(name)
+            if group is None:
+                unresolved.append(name)
+                continue
+
+            print(f"  {name}  ->  {group}")
+            if not dry_run:
+                conn.execute(
+                    text("UPDATE exercises SET muscle_group = :group "
+                         "WHERE exercise_id = :id AND muscle_group IS NULL"),
+                    {"group": group, "id": exercise_id},
+                )
+            updated += 1
+
+    return updated, unresolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the resolutions without writing them")
+    args = parser.parse_args()
+
+    updated, unresolved = backfill(pipeline.get_engine(), dry_run=args.dry_run)
+
+    verb = "Would update" if args.dry_run else "Updated"
+    print(f"\n{verb} {updated} exercise(s).")
+
+    if unresolved:
+        print(f"\n{len(unresolved)} name(s) the table does not recognize; these stay "
+              f"NULL and show as 'Unassigned':")
+        for name in unresolved:
+            print(f"  {name}")
+        print("\nAdd them to muscle_groups.EXERCISE_MUSCLE_GROUPS and re-run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/charts.py
+++ b/charts.py
@@ -23,6 +23,10 @@ import json
 from datetime import date, timedelta
 from typing import Any
 
+# insights does not import this module, so this stays a one-way dependency. Only
+# the shared label for an exercise with no muscle group on file comes from it.
+import insights
+
 # Tokens are declared for both the OS setting and an explicit theme stamp, so a
 # viewer's choice wins either way.
 PROGRESS_CSS = """
@@ -91,6 +95,10 @@ PROGRESS_CSS = """
 .plot svg { display: block; overflow: visible; }
 
 .smalls { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: .9rem; }
+.smalls .section { grid-column: 1 / -1; font-size: .8rem; font-weight: 600;
+  letter-spacing: .04em; text-transform: uppercase; color: var(--ink-2);
+  margin: .3rem 0 0; padding-bottom: .25rem; border-bottom: 1px solid var(--hairline); }
+.smalls .section:first-child { margin-top: 0; }
 .small h3 { font-size: .85rem; margin: 0 0 .1rem; font-weight: 600; }
 .small .sub { font-size: .75rem; margin: 0 0 .4rem; }
 
@@ -429,14 +437,22 @@ def _tile(label: str, value: str, delta: str = "", up_is_good: bool = False) -> 
     )
 
 
-def _table(headers: list[str], rows: list[list[str]], caption: str) -> str:
-    """The table twin. Every plotted value is reachable here without hovering."""
+def _table(
+    headers: list[str], rows: list[list[str]], caption: str, numeric_from: int = 1
+) -> str:
+    """The table twin. Every plotted value is reachable here without hovering.
+
+    `numeric_from` is the first right-aligned column. One label column is the
+    common case; a table that leads with more than one needs to say so, or its
+    text columns get flushed right against the numbers.
+    """
     head = "".join(
-        f'<th class="{"num" if i else ""}">{html.escape(h)}</th>' for i, h in enumerate(headers)
+        f'<th class="{"num" if i >= numeric_from else ""}">{html.escape(h)}</th>'
+        for i, h in enumerate(headers)
     )
     body = "".join(
         "<tr>" + "".join(
-            f'<td class="{"num" if i else ""}">{html.escape(str(c))}</td>'
+            f'<td class="{"num" if i >= numeric_from else ""}">{html.escape(str(c))}</td>'
             for i, c in enumerate(row)
         ) + "</tr>"
         for row in rows
@@ -497,8 +513,15 @@ def render_progress_body(data: dict[str, Any]) -> str:
                "Table view"),
     )
 
-    smalls, e1rm_rows = [], []
+    # The series arrive already ordered so one muscle group's exercises are
+    # adjacent, so a heading goes in wherever the group changes. Ordering stays
+    # in insights.py; this only draws the seam.
+    smalls, e1rm_rows, current_group = [], [], None
     for index, series in enumerate(data["exercise_e1rm"]):
+        group = series.get("muscle_group") or insights.UNASSIGNED_GROUP
+        if group != current_group:
+            smalls.append(f'<h3 class="section">{html.escape(group)}</h3>')
+            current_group = group
         first, last = series["points"][0][1], series["points"][-1][1]
         change = last - first
         slope = series.get("slope_per_week")
@@ -510,15 +533,19 @@ def render_progress_body(data: dict[str, Any]) -> str:
             f'<div class="plot" data-chart="e1rm:{index}"></div></div>'
         )
         for day, value in series["points"]:
-            e1rm_rows.append([series["exercise"], day, _fmt(value, 1)])
+            e1rm_rows.append([group, series["exercise"], day, _fmt(value, 1)])
 
     e1rm_card = _card(
-        "Estimated 1RM by exercise",
-        "Epley, from clean reps only. The grey line is the fitted trend; the rate "
-        "beside each name is its slope.",
+        "Estimated 1RM by muscle group",
+        "Epley, from clean reps only, grouped by the muscle each exercise is filed "
+        "under. Still one line per exercise \u2014 a bench press and a fly average to "
+        "nothing useful. The grey line is the fitted trend; the rate beside each "
+        "name is its slope.",
         f'<div class="smalls">{"".join(smalls)}</div>' if smalls
         else '<p class="empty">Needs at least two sessions of an exercise to show a trend.</p>',
-        _table(["Exercise", "Session", "e1RM (kg)"], e1rm_rows, "Table view") if e1rm_rows else "",
+        _table(["Muscle group", "Exercise", "Session", "e1RM (kg)"], e1rm_rows,
+               "Table view", numeric_from=3)
+        if e1rm_rows else "",
     )
 
     bodyweight_card = _card(

--- a/charts.py
+++ b/charts.py
@@ -94,11 +94,29 @@ PROGRESS_CSS = """
 .plot { width: 100%; }
 .plot svg { display: block; overflow: visible; }
 
-.smalls { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: .9rem; }
-.smalls .section { grid-column: 1 / -1; font-size: .8rem; font-weight: 600;
-  letter-spacing: .04em; text-transform: uppercase; color: var(--ink-2);
-  margin: .3rem 0 0; padding-bottom: .25rem; border-bottom: 1px solid var(--hairline); }
-.smalls .section:first-child { margin-top: 0; }
+/* auto-fill, not auto-fit: each muscle group now has its own grid, and auto-fit
+   would collapse the empty tracks so a group with one exercise drew a chart
+   three times the size of one in a group of three. */
+.smalls { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: .9rem; }
+.fold > summary { cursor: pointer; list-style: none; display: flex; align-items: baseline;
+  gap: .5rem; }
+.fold > summary::-webkit-details-marker { display: none; }
+/* The literal glyph, not a CSS hex escape. This block is a plain Python string,
+   so a backslash-escaped code point is read as a Python octal escape first and a
+   control character reaches the stylesheet instead of the arrow. */
+.fold > summary::before { content: "▾"; color: var(--ink-muted); font-size: .8rem;
+  line-height: 1; transition: transform .12s ease; }
+.fold:not([open]) > summary::before { transform: rotate(-90deg); }
+.fold > summary:focus-visible { outline: 2px solid var(--series-1); outline-offset: 2px;
+  border-radius: .3rem; }
+.fold > summary h2, .fold > summary h3 { margin: 0; }
+.fold > summary .note { font-size: .8rem; color: var(--ink-muted); }
+.fold:not([open]) > summary .note { color: var(--ink-2); }
+.group { margin-top: .3rem; }
+.group > summary { border-bottom: 1px solid var(--hairline); padding-bottom: .25rem;
+  margin-bottom: .6rem; }
+.section { font-size: .8rem; font-weight: 600; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--ink-2); }
 .small h3 { font-size: .85rem; margin: 0 0 .1rem; font-weight: 600; }
 .small .sub { font-size: .75rem; margin: 0 0 .4rem; }
 
@@ -375,8 +393,8 @@ PROGRESS_JS = """
     host.appendChild(svg);
   }
 
-  function draw() {
-    document.querySelectorAll('[data-chart]').forEach(function (host) {
+  function draw(root) {
+    (root || document).querySelectorAll('[data-chart]').forEach(function (host) {
       var kind = host.getAttribute('data-chart');
       if (kind === 'volume' && DATA.weekly_volume.length) {
         columns(host, DATA.weekly_volume, 'kg', weekRange);
@@ -393,10 +411,19 @@ PROGRESS_JS = """
   }
 
   draw();
+
+  // A host inside a closed <details> has no width, and clientWidth falls back to
+  // a guess that would never correct itself. Redraw what just opened, at the
+  // size it actually got. `toggle` does not bubble, hence the capture phase.
+  document.addEventListener('toggle', function (evt) {
+    if (evt.target.open) draw(evt.target);
+  }, true);
+
   var timer;
   window.addEventListener('resize', function () {
     clearTimeout(timer);
-    timer = setTimeout(draw, 150);   // re-render at true size, never scale text
+    // Only what is on screen: a closed section redraws when it opens.
+    timer = setTimeout(function () { draw(); }, 150);
   });
 })();
 """
@@ -463,10 +490,27 @@ def _table(
     )
 
 
-def _card(title: str, subtitle: str, plot: str, table: str = "") -> str:
+def _card(
+    title: str,
+    subtitle: str,
+    plot: str,
+    table: str = "",
+    note: str = "",
+    open_by_default: bool = True,
+) -> str:
+    """One collapsible card.
+
+    A card with nothing to report starts folded, and says so in `note` on its
+    own summary line — so folding it away never costs you the answer, which is
+    the whole reason "no pain flags" is worth showing at all.
+    """
+    mark = " open" if open_by_default else ""
+    hint = f'<span class="note">{html.escape(note)}</span>' if note else ""
     return (
-        f'<section class="card"><h2>{html.escape(title)}</h2>'
-        f'<p class="sub">{html.escape(subtitle)}</p>{plot}{table}</section>'
+        f'<section class="card"><details class="fold"{mark}>'
+        f"<summary><h2>{html.escape(title)}</h2>{hint}</summary>"
+        f'<p class="sub">{html.escape(subtitle)}</p>{plot}{table}'
+        f"</details></section>"
     )
 
 
@@ -520,7 +564,13 @@ def render_progress_body(data: dict[str, Any]) -> str:
     for index, series in enumerate(data["exercise_e1rm"]):
         group = series.get("muscle_group") or insights.UNASSIGNED_GROUP
         if group != current_group:
-            smalls.append(f'<h3 class="section">{html.escape(group)}</h3>')
+            if current_group is not None:
+                smalls.append("</div></details>")
+            smalls.append(
+                f'<details class="fold group" open>'
+                f'<summary><h3 class="section">{html.escape(group)}</h3></summary>'
+                f'<div class="smalls">'
+            )
             current_group = group
         first, last = series["points"][0][1], series["points"][-1][1]
         change = last - first
@@ -534,6 +584,8 @@ def render_progress_body(data: dict[str, Any]) -> str:
         )
         for day, value in series["points"]:
             e1rm_rows.append([group, series["exercise"], day, _fmt(value, 1)])
+    if current_group is not None:
+        smalls.append("</div></details>")
 
     e1rm_card = _card(
         "Estimated 1RM by muscle group",
@@ -541,7 +593,7 @@ def render_progress_body(data: dict[str, Any]) -> str:
         "under. Still one line per exercise \u2014 a bench press and a fly average to "
         "nothing useful. The grey line is the fitted trend; the rate beside each "
         "name is its slope.",
-        f'<div class="smalls">{"".join(smalls)}</div>' if smalls
+        "".join(smalls) if smalls
         else '<p class="empty">Needs at least two sessions of an exercise to show a trend.</p>',
         _table(["Muscle group", "Exercise", "Session", "e1RM (kg)"], e1rm_rows,
                "Table view", numeric_from=3)
@@ -556,6 +608,8 @@ def render_progress_body(data: dict[str, Any]) -> str:
              '("was 82.4kg this morning") and it lands here.</p>',
         _table(["Date", "Weight (kg)"], [[d, _fmt(v, 1)] for d, v in data["bodyweight"]],
                "Table view") if data["bodyweight"] else "",
+        note="" if data["bodyweight"] else "none logged",
+        open_by_default=bool(data["bodyweight"]),
     )
 
     muscle_card = _card(
@@ -566,6 +620,8 @@ def render_progress_body(data: dict[str, Any]) -> str:
         _table(["Muscle group", "Volume (kg)"],
                [[name, _fmt(value)] for name, value in data["muscle_volume"]],
                "Table view") if data["muscle_volume"] else "",
+        note="" if data["muscle_volume"] else "nothing logged this week",
+        open_by_default=bool(data["muscle_volume"]),
     )
 
     if data["pain"]:
@@ -589,10 +645,19 @@ def render_progress_body(data: dict[str, Any]) -> str:
     else:
         pain_body = '<p class="empty">No pain flags in this window.</p>'
 
+    # The all-clear is the one card worth folding on a good week: the answer is
+    # the summary line, and there is nothing underneath it to read.
+    serious = sum(1 for item in data["pain"] if item["status"] == "serious")
     pain_card = _card(
         "Pain flags",
         "Colour is never the only signal here - each row carries an icon and a word.",
         pain_body,
+        note=(
+            "none in this window" if not data["pain"]
+            else f"{len(data['pain'])} exercise(s)"
+                 + (f", {serious} needing attention" if serious else "")
+        ),
+        open_by_default=bool(data["pain"]),
     )
 
     return (

--- a/insights.py
+++ b/insights.py
@@ -224,10 +224,15 @@ def volume_by_exercise(records: Iterable[SetRecord]) -> dict[str, float]:
     return {name: round(value, 1) for name, value in sorted(totals.items())}
 
 
+# What an exercise with no muscle group on file is bucketed under. One constant
+# so the volume chart and the e1RM sections cannot label the same gap differently.
+UNASSIGNED_GROUP = "Unassigned"
+
+
 def volume_by_muscle_group(records: Iterable[SetRecord]) -> dict[str, float]:
     totals: dict[str, float] = defaultdict(float)
     for record in records:
-        totals[record.muscle_group or "Unassigned"] += set_volume(record)
+        totals[record.muscle_group or UNASSIGNED_GROUP] += set_volume(record)
     return {name: round(value, 1) for name, value in sorted(totals.items())}
 
 
@@ -949,6 +954,49 @@ def exercise_e1rm_series(
     return series[:limit]
 
 
+def exercise_e1rm_by_muscle_group(
+    records: Iterable[SetRecord], limit: int = 6, min_sessions: int = 2
+) -> list[tuple[str, str, list[tuple[date, float]]]]:
+    """`exercise_e1rm_series`, ordered so one muscle group's exercises sit together.
+
+    Returns (muscle_group, exercise, points).
+
+    Grouping here is presentation, not aggregation: the series stay per
+    exercise. One averaged e1RM line per muscle group would be easier to read
+    and would not mean anything — a 100kg bench press and a 15kg cable fly have
+    no useful mean, and the average would move when exercise selection changed
+    rather than when strength did. Sectioning the real series answers "is my
+    chest progressing" without inventing a number to answer it with.
+
+    Which exercises appear is decided before grouping, so the chart still shows
+    the most-trained lifts rather than reserving slots per group. Groups follow
+    the most-trained exercise in each, with Unassigned last so a gap in the
+    muscle-group table sinks instead of splitting the groups that do read.
+    """
+    records = list(records)
+    series = exercise_e1rm_series(records, limit=limit, min_sessions=min_sessions)
+    # Every row for an exercise carries the group from the same `exercises` row,
+    # so this is a lookup rather than a reconciliation.
+    group_for = {record.exercise_name: record.muscle_group for record in records}
+
+    def group_of(name: str) -> str:
+        return group_for.get(name) or UNASSIGNED_GROUP
+
+    first_seen: dict[str, int] = {}
+    for index, (name, _) in enumerate(series):
+        first_seen.setdefault(group_of(name), index)
+
+    ordered = sorted(
+        enumerate(series),
+        key=lambda pair: (
+            group_of(pair[1][0]) == UNASSIGNED_GROUP,
+            first_seen[group_of(pair[1][0])],
+            pair[0],
+        ),
+    )
+    return [(group_of(name), name, points) for _, (name, points) in ordered]
+
+
 def pain_summary(records: Iterable[SetRecord]) -> list[dict[str, Any]]:
     """Exercises carrying pain flags, worst streak first.
 
@@ -1017,6 +1065,7 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
         "exercise_e1rm": [
             {
                 "exercise": name,
+                "muscle_group": group,
                 "points": [[day.isoformat(), value] for day, value in points],
                 "slope_per_week": trend_slope_per_week(points),
                 "trend": (
@@ -1024,7 +1073,7 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
                     if trend_endpoints(points) else None
                 ),
             }
-            for name, points in exercise_e1rm_series(records)
+            for group, name, points in exercise_e1rm_by_muscle_group(records)
         ],
         "bodyweight": [[day.isoformat(), value] for day, value in bodyweight],
         "muscle_volume": sorted(

--- a/muscle_groups.py
+++ b/muscle_groups.py
@@ -1,0 +1,351 @@
+"""Static exercise-name -> primary muscle group resolution.
+
+Why static rather than asking the LLM or the user:
+  * `exercises.muscle_group` is a property of the exercise, not of a log entry.
+    `pipeline.get_or_create_exercise` writes it only on INSERT, so the value is
+    decided once per distinct movement and then never revisited - a few dozen
+    decisions over the life of the tool, not one per set.
+  * The answer is a lookup, not a judgement. A table is free, instant,
+    deterministic and unit-testable, which the same table asked of a model at
+    `reasoning_effort=low` is not.
+
+This module is a leaf: it deliberately imports nothing from `pipeline`, so the
+name-normalization helpers stay single-sourced there and there is no import
+cycle. Callers hand it already-normalized tokens; `pipeline.resolve_muscle_group`
+is the public entry point that does the normalizing.
+
+PRIMARY MOVER ONLY. `exercises.muscle_group` is a single TEXT column and the
+volume chart sums over it, so an exercise is attributed to exactly one group.
+A bench press is chest, triceps and front delts; recording all three would make
+"volume by muscle group" stop summing to actual total volume. Secondary movers
+are out of scope until the column becomes an array.
+
+Unknown names resolve to None, which is stored as NULL and reported as
+"Unassigned" by `insights.volume_by_muscle_group`. The tables are an allowlist:
+they fail closed rather than guessing, matching how `pipeline.QUALIFIER_TOKENS`
+treats unrecognized words.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+# Every value the resolver may return. `insights` renders None as "Unassigned";
+# it is not a group and so is not listed here.
+CANONICAL_GROUPS = (
+    "Chest",
+    "Back",
+    "Shoulders",
+    "Biceps",
+    "Triceps",
+    "Legs",
+    "Glutes",
+    "Core",
+    "Forearms",
+    "Full Body",
+)
+
+# Tokens dropped before the second lookup pass, so "Dumbbell Bench Press" and
+# "Bench Press" reach the same table entry without the table enumerating every
+# equipment permutation.
+#
+# This is a LOOSER list than `pipeline.QUALIFIER_TOKENS`, and deliberately so.
+# That set governs exercise IDENTITY, where "seated" vs "standing" must stay two
+# separate rows with separate progress histories. Muscle group is a coarser
+# question: seated and standing calf raises are different exercises that train
+# the same muscle. Stripping a token here therefore never merges two exercises,
+# it only lets them share one lookup key.
+#
+# Genuine movement variations stay OUT of this set. "incline", "decline",
+# "front", "close grip" and "romanian" change which muscle leads the lift, so
+# stripping them would produce a wrong group, not a coarser one.
+EQUIPMENT_TOKENS = frozenset(
+    {
+        "barbell", "dumbbell", "dumbell", "db", "bb", "machine", "cable",
+        "smith", "ez", "bar", "weighted", "bodyweight", "banded", "band",
+        "seated", "standing", "lying", "single", "one", "alternating", "alt",
+    }
+)
+
+# Explicit movement -> primary mover. Keys are normalized and singularized the
+# way `pipeline.normalize_tokens` produces them: lowercase, punctuation gone,
+# trailing plural "s" dropped unless the word ends in "ss" ("press" survives,
+# "raises" becomes "raise", "biceps" becomes "bicep"). A test asserts every key
+# is already in that form, so a hand-written plural cannot silently never match.
+#
+# That rule only fires on words longer than three characters, so short plurals
+# come through intact - "ups" and "abs" are never reduced to "up" and "ab".
+# Both spellings are therefore listed wherever a name ends in one.
+#
+# Entries whose name contains a MISLEADING muscle word are the important ones
+# here - "chest supported row" is a back exercise and "leg raise" is a core
+# exercise. The table is consulted before the token heuristics below precisely
+# so these resolve correctly.
+EXERCISE_MUSCLE_GROUPS: dict[str, str] = {
+    # --- Chest ---
+    "bench press": "Chest",
+    "chest bench press": "Chest",
+    "chest press": "Chest",
+    "flat bench press": "Chest",
+    "incline bench press": "Chest",
+    "incline press": "Chest",
+    "decline bench press": "Chest",
+    "decline press": "Chest",
+    "chest fly": "Chest",
+    "chest flie": "Chest",
+    "fly": "Chest",
+    "flie": "Chest",
+    "pec fly": "Chest",
+    "pec deck": "Chest",
+    "crossover": "Chest",
+    "cable crossover": "Chest",
+    "push up": "Chest",
+    "push ups": "Chest",
+    "pushup": "Chest",
+    "dip": "Chest",
+    "chest dip": "Chest",
+
+    # --- Back ---
+    "row": "Back",
+    "bent over row": "Back",
+    "barbell row": "Back",
+    "pendlay row": "Back",
+    "t bar row": "Back",
+    "chest supported row": "Back",
+    "inverted row": "Back",
+    "lat pulldown": "Back",
+    "pulldown": "Back",
+    "straight arm pulldown": "Back",
+    "pullover": "Back",
+    "pull up": "Back",
+    "pull ups": "Back",
+    "pullup": "Back",
+    "chin up": "Back",
+    "chin ups": "Back",
+    "chinup": "Back",
+    "deadlift": "Back",
+    "conventional deadlift": "Back",
+    "rack pull": "Back",
+    "shrug": "Back",
+    "good morning": "Back",
+    "back extension": "Back",
+    "hyperextension": "Back",
+
+    # --- Shoulders ---
+    "shoulder press": "Shoulders",
+    "overhead press": "Shoulders",
+    "military press": "Shoulders",
+    "arnold press": "Shoulders",
+    "push press": "Shoulders",
+    "lateral raise": "Shoulders",
+    "side raise": "Shoulders",
+    "side lateral raise": "Shoulders",
+    "front raise": "Shoulders",
+    "rear delt fly": "Shoulders",
+    "rear delt flie": "Shoulders",
+    "rear delt raise": "Shoulders",
+    "rear delt row": "Shoulders",
+    "reverse fly": "Shoulders",
+    "reverse flie": "Shoulders",
+    "reverse pec deck": "Shoulders",
+    "upright row": "Shoulders",
+    "face pull": "Shoulders",
+
+    # --- Biceps ---
+    "curl": "Biceps",
+    "bicep curl": "Biceps",
+    "hammer curl": "Biceps",
+    "preacher curl": "Biceps",
+    "concentration curl": "Biceps",
+    "incline curl": "Biceps",
+    "spider curl": "Biceps",
+    "drag curl": "Biceps",
+    "reverse curl": "Biceps",
+
+    # --- Triceps ---
+    "tricep extension": "Triceps",
+    "overhead tricep extension": "Triceps",
+    "overhead extension": "Triceps",
+    "tricep pushdown": "Triceps",
+    "pushdown": "Triceps",
+    "rope pushdown": "Triceps",
+    "tricep pressdown": "Triceps",
+    "pressdown": "Triceps",
+    "skullcrusher": "Triceps",
+    "skull crusher": "Triceps",
+    "close grip bench press": "Triceps",
+    "close grip press": "Triceps",
+    "tricep dip": "Triceps",
+    "bench dip": "Triceps",
+    "kickback": "Triceps",
+    "tricep kickback": "Triceps",
+
+    # --- Legs ---
+    "squat": "Legs",
+    "back squat": "Legs",
+    "front squat": "Legs",
+    "goblet squat": "Legs",
+    "hack squat": "Legs",
+    "split squat": "Legs",
+    "bulgarian split squat": "Legs",
+    "pistol squat": "Legs",
+    "leg press": "Legs",
+    "leg extension": "Legs",
+    "quad extension": "Legs",
+    "leg curl": "Legs",
+    "hamstring curl": "Legs",
+    "nordic curl": "Legs",
+    "romanian deadlift": "Legs",
+    "rdl": "Legs",
+    "stiff leg deadlift": "Legs",
+    "sumo deadlift": "Legs",
+    "lunge": "Legs",
+    "walking lunge": "Legs",
+    "reverse lunge": "Legs",
+    "step up": "Legs",
+    "step ups": "Legs",
+    "calf raise": "Legs",
+    "calf press": "Legs",
+
+    # --- Glutes ---
+    "hip thrust": "Glutes",
+    "glute bridge": "Glutes",
+    "hip bridge": "Glutes",
+    "glute kickback": "Glutes",
+    "hip abduction": "Glutes",
+    "abduction": "Glutes",
+    "hip extension": "Glutes",
+
+    # --- Core ---
+    "plank": "Core",
+    "side plank": "Core",
+    "crunch": "Core",
+    "crunche": "Core",
+    "cable crunch": "Core",
+    "cable crunche": "Core",
+    "sit up": "Core",
+    "sit ups": "Core",
+    "situp": "Core",
+    "leg raise": "Core",
+    "hanging leg raise": "Core",
+    "knee raise": "Core",
+    "russian twist": "Core",
+    "ab wheel": "Core",
+    "ab rollout": "Core",
+    "rollout": "Core",
+    "mountain climber": "Core",
+    "dead bug": "Core",
+    "hollow hold": "Core",
+    "woodchop": "Core",
+
+    # --- Forearms ---
+    "wrist curl": "Forearms",
+    "reverse wrist curl": "Forearms",
+    "farmer carry": "Forearms",
+    "farmer carrie": "Forearms",
+    "farmer walk": "Forearms",
+    "wrist roller": "Forearms",
+
+    # --- Full Body ---
+    "clean": "Full Body",
+    "power clean": "Full Body",
+    "hang clean": "Full Body",
+    "clean and jerk": "Full Body",
+    "snatch": "Full Body",
+    "thruster": "Full Body",
+    "burpee": "Full Body",
+    "kettlebell swing": "Full Body",
+    "swing": "Full Body",
+}
+
+# A muscle named inside the exercise name. Consulted only after both table
+# passes miss, so the misleading cases above ("chest supported row") never reach
+# it. Tokens too vague to place - "arm", "upper", "lower" - are absent on
+# purpose: no entry means no guess.
+MUSCLE_TOKENS: dict[str, str] = {
+    "chest": "Chest",
+    "pec": "Chest",
+    "back": "Back",
+    "lat": "Back",
+    "trap": "Back",
+    "rhomboid": "Back",
+    "shoulder": "Shoulders",
+    "delt": "Shoulders",
+    "bicep": "Biceps",
+    "tricep": "Triceps",
+    "leg": "Legs",
+    "quad": "Legs",
+    "hamstring": "Legs",
+    "ham": "Legs",
+    "calf": "Legs",
+    "calve": "Legs",
+    "glute": "Glutes",
+    "core": "Core",
+    "ab": "Core",
+    "abs": "Core",
+    "oblique": "Core",
+    "forearm": "Forearms",
+    "wrist": "Forearms",
+}
+
+# Last resort: the movement verb, for names the table has never seen and that
+# name no muscle ("Cable Rope Pushdown"). Only verbs with one plausible primary
+# mover appear; "press" and "raise" are ambiguous across chest, shoulders and
+# legs, so they are deliberately absent.
+MOVEMENT_TOKENS: dict[str, str] = {
+    "pulldown": "Back",
+    "row": "Back",
+    "deadlift": "Back",
+    "shrug": "Back",
+    "curl": "Biceps",
+    "pushdown": "Triceps",
+    "pressdown": "Triceps",
+    "skullcrusher": "Triceps",
+    "squat": "Legs",
+    "lunge": "Legs",
+    "thrust": "Glutes",
+    "plank": "Core",
+    "crunch": "Core",
+    "crunche": "Core",
+}
+
+
+def group_for_tokens(tokens: Sequence[str]) -> Optional[str]:
+    """Primary muscle group for already-normalized, singularized name tokens.
+
+    Four passes, most specific first:
+      1. The full name against the explicit table.
+      2. The name with equipment tokens removed, against the same table.
+      3. A muscle named in the name.
+      4. The movement verb.
+
+    Returns None when nothing matches, which is stored as NULL rather than a
+    guess. `pipeline.resolve_muscle_group` is the entry point that normalizes.
+    """
+    if not tokens:
+        return None
+
+    exact = EXERCISE_MUSCLE_GROUPS.get(" ".join(tokens))
+    if exact is not None:
+        return exact
+
+    stripped = [token for token in tokens if token not in EQUIPMENT_TOKENS]
+    if stripped and stripped != list(tokens):
+        reduced = EXERCISE_MUSCLE_GROUPS.get(" ".join(stripped))
+        if reduced is not None:
+            return reduced
+
+    # Rightmost muscle word wins: in "Cable Chest Fly" the qualifier sits left of
+    # the movement, and in a compound like "Leg Press Calf Raise" the later word
+    # is the one being trained.
+    for token in reversed(stripped or list(tokens)):
+        group = MUSCLE_TOKENS.get(token)
+        if group is not None:
+            return group
+
+    for token in reversed(stripped or list(tokens)):
+        group = MOVEMENT_TOKENS.get(token)
+        if group is not None:
+            return group
+
+    return None

--- a/pipeline.py
+++ b/pipeline.py
@@ -29,6 +29,8 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 from sqlalchemy.engine import Connection, Engine
 
+import muscle_groups
+
 try:  # Python 3.9+
     from zoneinfo import ZoneInfo
 except ImportError:  # pragma: no cover - Python < 3.9 is unsupported anyway
@@ -297,6 +299,16 @@ def normalize_tokens(name: str) -> list[str]:
 
 # Compared against singularized tokens, so the qualifier set is singularized too.
 _QUALIFIER_TOKENS_SINGULAR = frozenset(_singularize(t) for t in QUALIFIER_TOKENS)
+
+
+def resolve_muscle_group(name: str) -> Optional[str]:
+    """Primary muscle group for an exercise name, or None when unrecognized.
+
+    Table lookup only - see `muscle_groups` for why this is not asked of the
+    LLM. Normalization lives here so `muscle_groups` stays a leaf module with no
+    import back into this one.
+    """
+    return muscle_groups.group_for_tokens(normalize_tokens(name))
 
 
 def name_match_score(proposed: str, existing: str) -> float:
@@ -962,12 +974,20 @@ def get_or_create_exercise(
     if matched is not None:
         return known[matched], matched, False
 
+    # An explicit group from the caller wins; otherwise look the name up in the
+    # static table. Either may be None, which stores NULL and reports as
+    # "Unassigned" rather than a guess.
+    if not muscle_group:
+        muscle_group = resolve_muscle_group(proposed_name)
+
     row = conn.execute(
         text(
             """
             INSERT INTO exercises (name, muscle_group)
             VALUES (:name, :muscle_group)
-            ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+            ON CONFLICT (name) DO UPDATE
+                SET muscle_group = COALESCE(exercises.muscle_group,
+                                            EXCLUDED.muscle_group)
             RETURNING exercise_id
             """
         ),

--- a/pipeline.py
+++ b/pipeline.py
@@ -21,7 +21,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from rapidfuzz import fuzz
@@ -331,6 +331,10 @@ class DraftRow:
     issues: list[DraftIssue] = field(default_factory=list)
     include: bool = True
     edited: bool = False  # a person changed a value on the review screen
+    # Which columns they changed. Muscle group needs this: a value the user
+    # chose may overwrite what is on record for an exercise, a suggestion the
+    # app filled in must not.
+    edited_fields: frozenset[str] = frozenset()
     # Typed in on the review screen rather than read out of the entry. Such a row
     # has no source text behind it, so the grounding checks do not apply to it.
     added: bool = False
@@ -1186,12 +1190,34 @@ def _is_blank(values: dict[str, Any], defaults: dict[str, Any]) -> bool:
     )
 
 
+def suggest_muscle_group(
+    exercise_name: str,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
+) -> Optional[str]:
+    """The muscle group to offer for an exercise name, or None if nothing fits.
+
+    What is already on record wins over the table. `get_or_create_exercise`
+    never revises a stored group on its own, so offering a table answer that
+    disagrees with one would show the user a value that saving quietly ignores.
+    The name is fuzzy-matched the same way the insert path matches it, so a
+    reworded name still finds its own row.
+    """
+    if known_groups:
+        matched = find_matching_exercise(exercise_name, known_groups.keys())
+        if matched is not None and known_groups[matched]:
+            return known_groups[matched]
+    return resolve_muscle_group(exercise_name)
+
+
 def draft_set_row(
     values: dict[str, Any],
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
     added: bool = False,
+    edited_fields: frozenset[str] = frozenset(),
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
+    resuggest_muscle_group: bool = False,
 ) -> DraftRow:
     """Score one set and describe everything a person should look at before saving.
 
@@ -1201,7 +1227,11 @@ def draft_set_row(
     measuring nothing. Missing weights and reps are still worth pointing out.
     """
     row = DraftRow(
-        "workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited, added=added
+        "workout_set",
+        _pick(values, SET_COLUMNS, SET_DEFAULTS),
+        edited=edited,
+        added=added,
+        edited_fields=edited_fields,
     )
     if _is_blank(row.values, SET_DEFAULTS):
         # An empty slot the user has not filled in. Not a row, so it is neither
@@ -1228,6 +1258,20 @@ def draft_set_row(
         row.issues.append(
             DraftIssue("no rep count recorded — saved blank unless you fill it in", "reps")
         )
+
+    # Suggested rather than read: the extraction is never asked for a muscle
+    # group. A value already there is kept on the way in, so the rare one a model
+    # does volunteer still counts; on the way back from the review screen it is
+    # recomputed unless the user took the field over, because by then the value
+    # sitting in the box is this function's own last answer — and renaming the
+    # exercise has to re-answer it rather than leave the old name's group behind.
+    if "muscle_group" not in row.edited_fields:
+        current = None if resuggest_muscle_group else row.values.get("muscle_group")
+        row.values["muscle_group"] = current or suggest_muscle_group(
+            workout_set.exercise_name, known_groups
+        )
+    _flag_muscle_group(row)
+
     if added:
         return row
 
@@ -1246,6 +1290,34 @@ def draft_set_row(
             )
         )
     return row
+
+
+def _flag_muscle_group(row: DraftRow) -> None:
+    """Mark a muscle group that nothing can be done with downstream.
+
+    `insights.volume_by_muscle_group` buckets on this column exactly as stored,
+    so a blank one silently becomes "Unassigned" and a typo becomes its own
+    bucket. Neither is an error the database would catch, which is why both are
+    flagged here rather than left to be discovered in a chart.
+    """
+    group = (row.values.get("muscle_group") or "").strip()
+    if not group:
+        row.issues.append(
+            DraftIssue(
+                "no muscle group matched this name — volume by muscle group will "
+                "count it as Unassigned",
+                "muscle_group",
+            )
+        )
+    elif group not in muscle_groups.CANONICAL_GROUPS:
+        row.issues.append(
+            DraftIssue(
+                f"“{group}” is not one of the standard groups "
+                f"({', '.join(muscle_groups.CANONICAL_GROUPS)}) — it will be "
+                "counted as its own bucket",
+                "muscle_group",
+            )
+        )
 
 
 def draft_bodyweight_row(
@@ -1293,6 +1365,12 @@ def draft_bodyweight_row(
     return row
 
 
+def load_exercise_groups(conn: Connection) -> dict[str, Optional[str]]:
+    """Every known exercise name and the muscle group it is filed under."""
+    rows = conn.execute(text("SELECT name, muscle_group FROM exercises")).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
 def blank_set_row() -> DraftRow:
     """An empty slot for a set the extraction missed entirely."""
     return DraftRow("workout_set", dict(SET_DEFAULTS), added=True, blank=True)
@@ -1308,6 +1386,7 @@ def draft_from_payload(
     raw_text: str,
     session_date: date,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
     """Turn a raw extraction into editable rows, keeping the ones that failed.
 
@@ -1331,7 +1410,9 @@ def draft_from_payload(
                            {"raw": str(item)[:500]})
             )
             continue
-        draft.sets.append(draft_set_row(item, raw_text, confidence_threshold))
+        draft.sets.append(
+            draft_set_row(item, raw_text, confidence_threshold, known_groups=known_groups)
+        )
 
     raw_bodyweight = payload.get("bodyweight")
     if isinstance(raw_bodyweight, dict):
@@ -1350,8 +1431,14 @@ def build_draft(
     session_date: date,
     client: Any = None,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
-    """Extract one journal entry into a draft. Touches the model, not the database."""
+    """Extract one journal entry into a draft. Touches the model, not the database.
+
+    `known_groups` is what the `exercises` table already records, so the muscle
+    group offered for an exercise you have logged before is the one it is
+    actually filed under.
+    """
     raw_text = (raw_text or "").strip()
     if not raw_text:
         return EntryDraft(
@@ -1371,7 +1458,9 @@ def build_draft(
             review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
         )
 
-    return draft_from_payload(payload, raw_text, session_date, confidence_threshold)
+    return draft_from_payload(
+        payload, raw_text, session_date, confidence_threshold, known_groups
+    )
 
 
 # --------------------------------------------------------------------------
@@ -1405,14 +1494,29 @@ def get_or_create_exercise(
     proposed_name: str,
     muscle_group: Optional[str],
     known: dict[str, int],
+    chosen_group: bool = False,
 ) -> tuple[int, Optional[str], bool]:
     """Resolve an exercise name to an id, fuzzy-matching before inserting.
 
     Returns (exercise_id, matched_existing_name_or_None, created).
+
+    `chosen_group` says the muscle group came from a person on the review
+    screen rather than from the table. Only then is an existing exercise's group
+    revised: a suggestion must never quietly overwrite a filing decision that
+    has already been made, but a correction the user typed has to stick, or the
+    review screen would be offering an edit that does nothing.
     """
     matched = find_matching_exercise(proposed_name, known.keys())
     if matched is not None:
-        return known[matched], matched, False
+        exercise_id = known[matched]
+        if chosen_group:
+            conn.execute(
+                text("UPDATE exercises SET muscle_group = :muscle_group "
+                     "WHERE exercise_id = :exercise_id "
+                     "AND muscle_group IS DISTINCT FROM :muscle_group"),
+                {"muscle_group": muscle_group, "exercise_id": exercise_id},
+            )
+        return exercise_id, matched, False
 
     # An explicit group from the caller wins; otherwise look the name up in the
     # static table. Either may be None, which stores NULL and reports as
@@ -1587,7 +1691,8 @@ def commit_draft(
                 duplicate_of_recent=True,
             )
 
-    accepted_sets: list[tuple[WorkoutSet, float]] = []
+    # (model, confidence, the muscle group was chosen by the user not suggested)
+    accepted_sets: list[tuple[WorkoutSet, float, bool]] = []
     for row in draft.sets:
         if row.blank:
             continue
@@ -1612,7 +1717,11 @@ def commit_draft(
                            row.confidence, dict(row.values))
             )
             continue
-        accepted_sets.append((workout_set, 1.0 if row.edited or row.added else confidence))
+        accepted_sets.append((
+            workout_set,
+            1.0 if row.edited or row.added else confidence,
+            "muscle_group" in row.edited_fields,
+        ))
 
     accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
     if draft.bodyweight is not None and not draft.bodyweight.blank:
@@ -1644,9 +1753,10 @@ def commit_draft(
             result.replaced = delete_entries_for_date(conn, draft.session_date)
             logger.info("Replaced %s on %s", result.replaced, draft.session_date)
         known = load_exercise_names(conn)
-        for workout_set, confidence in accepted_sets:
+        for workout_set, confidence, chosen_group in accepted_sets:
             exercise_id, matched_name, created = get_or_create_exercise(
-                conn, workout_set.exercise_name, workout_set.muscle_group, known
+                conn, workout_set.exercise_name, workout_set.muscle_group, known,
+                chosen_group=chosen_group,
             )
             if created:
                 result.exercises_created.append(workout_set.exercise_name)

--- a/review.py
+++ b/review.py
@@ -23,6 +23,7 @@ import json
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
+import muscle_groups
 import pipeline
 from pipeline import CONFIDENCE_THRESHOLD, DraftRow, EntryDraft
 
@@ -134,18 +135,28 @@ def _origin_blob(row: DraftRow, columns: Sequence[str]) -> str:
 
 PLACEHOLDERS = {"logged_at_local": "HH:MM"}
 
+# Columns offered as a pick list. `<datalist>` suggests without restricting, so
+# a group the table does not know can still be typed in — it just gets flagged.
+DATALISTS = {"muscle_group": "muscle-groups"}
+
+MUSCLE_GROUP_OPTIONS = '<datalist id="muscle-groups">' + "".join(
+    f'<option value="{html.escape(group)}">' for group in muscle_groups.CANONICAL_GROUPS
+) + "</datalist>"
+
 
 def _text_field(prefix: str, column: str, label: str, css: str, mode: str, row: DraftRow) -> str:
     field_id = f"{prefix}.{column}"
     classes = "bad" if row.issues_for(column) else ""
     placeholder = PLACEHOLDERS.get(column, "")
+    listed = DATALISTS.get(column)
     return (
         f'<div class="field {css}">'
         f'<label for="{html.escape(field_id)}">{html.escape(label)}</label>'
         f'<input type="text" inputmode="{mode}" id="{html.escape(field_id)}" '
         f'name="{html.escape(field_id)}" class="{classes}" autocomplete="off" '
         f'placeholder="{html.escape(placeholder)}" '
-        f'value="{html.escape(display_value(row.values.get(column)))}">'
+        + (f'list="{html.escape(listed)}" ' if listed else "")
+        + f'value="{html.escape(display_value(row.values.get(column)))}">'
         f"</div>"
     )
 
@@ -371,11 +382,13 @@ def render_review_body(
 <h1>Check before saving</h1>
 <p class="muted">This is exactly what will be written to the database for
 {html.escape(draft.session_date.isoformat())}. Correct anything that is wrong,
-untick anything that should not be saved, then save. Nothing has been stored yet.</p>
+untick anything that should not be saved, then save. Nothing has been stored yet.
+Muscle group is suggested from the exercise name, not read from your entry &mdash;
+correcting one re-files that exercise for good.</p>
 {_banner(draft, existing)}
 {entry}
 <form method="post" action="/save">
-{hidden}
+{hidden}{MUSCLE_GROUP_OPTIONS}
 <h2>Sets ({sum(1 for row in draft.sets if not row.blank)})</h2>
 {cards}
 {bodyweight}
@@ -422,27 +435,33 @@ def _row_values(
     return values
 
 
-def _was_edited(form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]) -> bool:
-    """True when a submitted value differs from what the extraction proposed.
+def _edited_fields(
+    form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]
+) -> frozenset[str]:
+    """Which submitted values differ from what was put on the screen.
 
     Compared in submitted form — display strings and booleans — so a float that
-    round-tripped through the input does not read as a change.
+    round-tripped through the input does not read as a change. Per column rather
+    than per row because the muscle group needs it: one the user chose may
+    overwrite what an exercise is filed under, one the app suggested must not.
     """
     try:
         origin = json.loads(str(form.get(f"{prefix}.origin", "")))
     except (TypeError, ValueError):
-        return False
+        return frozenset()
     if not isinstance(origin, dict):
-        return False
-    return any(
-        origin.get(column) != (value if isinstance(value, bool) else display_value(value))
+        return frozenset()
+    return frozenset(
+        column
         for column, value in values.items()
+        if origin.get(column) != (value if isinstance(value, bool) else display_value(value))
     )
 
 
 def draft_from_form(
     form: Mapping[str, Any],
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
     """Rebuild a draft from a submitted review form, rescored against the edits.
 
@@ -468,12 +487,16 @@ def draft_from_form(
     for index in range(max(0, set_count)):
         prefix = f"s{index}"
         values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
+        changed = _edited_fields(form, prefix, values)
         row = pipeline.draft_set_row(
             values,
             raw_text,
             confidence_threshold,
-            edited=_was_edited(form, prefix, values),
+            edited=bool(changed),
             added=f"{prefix}.added" in form,
+            edited_fields=changed,
+            known_groups=known_groups,
+            resuggest_muscle_group=True,
         )
         row.include = f"{prefix}.include" in form
         draft.sets.append(row)
@@ -484,7 +507,7 @@ def draft_from_form(
             values,
             raw_text,
             confidence_threshold,
-            edited=_was_edited(form, "bw", values),
+            edited=bool(_edited_fields(form, "bw", values)),
             added="bw.added" in form,
         )
         row.include = "bw.include" in form

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -217,6 +217,65 @@ class TestRendering:
         assert "num" not in header
         assert '<th class="num">e1RM (kg)</th>' in body
 
+    @pytest.mark.parametrize("sheet", ["PROGRESS_CSS", "PROGRESS_JS"])
+    def test_no_stray_control_characters_reach_the_page(self, sheet):
+        """These blocks are plain Python strings, so a backslash-escaped CSS code
+        point is eaten as a Python octal escape and a control character lands in
+        the stylesheet in place of the glyph."""
+        text = getattr(charts, sheet)
+        assert [c for c in text if ord(c) < 32 and c not in "\n\t"] == []
+
+    def test_a_fold_marker_is_drawn(self):
+        assert 'summary::before' in charts.PROGRESS_CSS
+        assert '"▾"' in charts.PROGRESS_CSS
+
+    def test_cards_are_foldable(self):
+        body = charts.render_progress_body(self._data())
+        assert body.count('<details class="fold"') == 5
+
+    def test_a_card_with_something_to_show_starts_open(self):
+        body = charts.render_progress_body(self._data())
+        assert '<details class="fold" open><summary><h2>Weekly volume' in body
+
+    def test_an_all_clear_card_folds_and_says_so_on_its_summary(self):
+        """Folding it away must not cost the answer it was showing."""
+        data = self._data()
+        data["pain"] = []
+        body = charts.render_progress_body(data)
+        card = body.split("Pain flags")[1]
+        assert card.startswith("</h2><span class=\"note\">none in this window")
+        assert '<details class="fold"><summary><h2>Pain flags' in body
+
+    def test_a_card_with_flags_stays_open_and_counts_them(self):
+        body = charts.render_progress_body(self._data())
+        assert '<details class="fold" open><summary><h2>Pain flags' in body
+        assert "1 exercise(s)" in body
+
+    def test_a_serious_flag_is_called_out_on_the_summary(self):
+        data = self._data()
+        data["pain"][0]["status"] = "serious"
+        data["pain"][0]["streak"] = 3
+        assert "1 needing attention" in charts.render_progress_body(data)
+
+    def test_muscle_group_sections_are_foldable_and_start_open(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Row", "Back"))))
+        assert body.count('<details class="fold group" open>') == 2
+
+    def test_every_group_section_is_closed_off(self):
+        """An unclosed <details> would swallow the rest of the card."""
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Row", "Back"))))
+        assert body.count("<details") == body.count("</details>")
+        assert (body.count('<div class="smalls">')
+                == body.count('<details class="fold group"'))
+
+    def test_a_chart_redraws_when_its_section_opens(self):
+        """A host inside a closed <details> measures zero, and clientWidth falls
+        back to a guess that would never correct itself."""
+        assert "addEventListener('toggle'" in charts.PROGRESS_JS
+        assert "if (evt.target.open) draw(evt.target)" in charts.PROGRESS_JS
+
     def test_renders_the_expected_cards(self):
         body = charts.render_progress_body(self._data())
         for heading in ("Weekly volume", "Estimated 1RM by muscle group", "Bodyweight",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import date, timedelta
+from itertools import groupby
 
 import pytest
 
@@ -109,17 +110,66 @@ class TestPainSummary:
         assert pain_summary(records)[0]["exercise"] == "Lat Pulldown"
 
 
+class TestE1rmMuscleGrouping:
+    """The chart answers "is my chest progressing", so the exercises of one
+    muscle group have to sit together — but as their own series. See
+    `exercise_e1rm_by_muscle_group` for why they are not averaged into one."""
+
+    def _mixed(self):
+        days = [MONDAY, MONDAY + timedelta(days=2), MONDAY + timedelta(days=4)]
+        records = []
+        for day in days:
+            records += sets_for("Bench", day, 60, [10, 10], muscle="Chest")
+            records += sets_for("Row", day, 50, [10], muscle="Back")
+            records += sets_for("Fly", day, 15, [12], muscle="Chest")
+            records += sets_for("High to Low", day, 16, [12], muscle=None)
+        return records
+
+    def test_each_series_is_labelled_with_its_group(self):
+        grouped = insights.exercise_e1rm_by_muscle_group(self._mixed())
+        assert {name: group for group, name, _ in grouped} == {
+            "Bench": "Chest", "Fly": "Chest", "Row": "Back", "High to Low": "Unassigned"}
+
+    def test_a_group_appears_as_one_run_not_several(self):
+        groups = [group for group, _, _ in insights.exercise_e1rm_by_muscle_group(self._mixed())]
+        runs = [group for group, _ in groupby(groups)]
+        assert len(runs) == len(set(runs))
+
+    def test_an_exercise_with_no_group_falls_under_the_shared_label(self):
+        grouped = insights.exercise_e1rm_by_muscle_group(self._mixed())
+        assert ("Unassigned", "High to Low") in [(g, n) for g, n, _ in grouped]
+
+    def test_unassigned_sorts_last_so_it_does_not_split_the_rest(self):
+        groups = [group for group, _, _ in insights.exercise_e1rm_by_muscle_group(self._mixed())]
+        assert groups[-1] == insights.UNASSIGNED_GROUP
+
+    def test_the_series_themselves_are_unchanged_by_grouping(self):
+        records = self._mixed()
+        flat = dict(insights.exercise_e1rm_series(records))
+        grouped = {name: points for _, name, points in
+                   insights.exercise_e1rm_by_muscle_group(records)}
+        assert grouped == flat
+
+    def test_which_exercises_appear_is_still_decided_by_training_volume(self):
+        """Grouping must not start reserving slots per muscle group."""
+        records = self._mixed()
+        assert ([name for name, _ in insights.exercise_e1rm_series(records, limit=2)]
+                == sorted(name for _, name, _ in
+                          insights.exercise_e1rm_by_muscle_group(records, limit=2)))
+
+
 class TestRendering:
-    def _data(self, exercise="Bench Press"):
+    def _data(self, exercise="Bench Press", series=None):
         return {
             "week_start": MONDAY.isoformat(), "weeks": 12, "timezone": "Asia/Karachi",
             "kpis": {"volume_this_week": 7139.0, "volume_delta_pct": 1.0,
                      "sets_this_week": 15, "exercises_this_week": 5,
                      "bodyweight": 82.4, "bodyweight_delta": -0.7},
             "weekly_volume": [[MONDAY.isoformat(), 7139.0]],
-            "exercise_e1rm": [{"exercise": exercise,
-                               "points": [[MONDAY.isoformat(), 80.0],
-                                          [(MONDAY + timedelta(7)).isoformat(), 82.0]]}],
+            "exercise_e1rm": series or [
+                {"exercise": exercise, "muscle_group": "Chest",
+                 "points": [[MONDAY.isoformat(), 80.0],
+                            [(MONDAY + timedelta(7)).isoformat(), 82.0]]}],
             "bodyweight": [[MONDAY.isoformat(), 82.4]],
             "muscle_volume": [["Chest", 1269.0]],
             "pain": [{"exercise": exercise, "sessions_flagged": 1,
@@ -127,9 +177,49 @@ class TestRendering:
             "has_data": True,
         }
 
+    def _series(self, *pairs):
+        return [{"exercise": name, "muscle_group": group,
+                 "points": [[MONDAY.isoformat(), 80.0],
+                            [(MONDAY + timedelta(7)).isoformat(), 82.0]]}
+                for name, group in pairs]
+
+    def test_a_heading_is_drawn_for_each_muscle_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Row", "Back"))))
+        assert '<h3 class="section">Chest</h3>' in body
+        assert '<h3 class="section">Back</h3>' in body
+
+    def test_one_heading_covers_a_whole_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Fly", "Chest"))))
+        assert body.count('<h3 class="section">Chest</h3>') == 1
+
+    def test_a_missing_group_is_labelled_rather_than_left_blank(self):
+        body = charts.render_progress_body(self._data(series=self._series(("Bench", None))))
+        assert f'<h3 class="section">{insights.UNASSIGNED_GROUP}</h3>' in body
+
+    def test_a_group_name_is_escaped(self):
+        """It reaches the page from the review form, so it is user text."""
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "</h3><script>alert(1)</script>"))))
+        assert "<script>alert(1)</script>" not in body.split("</script>", 1)[1]
+
+    def test_the_table_view_names_the_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"))))
+        assert ">Muscle group</th>" in body
+
+    def test_only_the_e1rm_number_is_right_aligned(self):
+        """Three label columns lead this table, not one."""
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"))))
+        header = body.split(">Muscle group</th>")[0].rsplit("<th", 1)[1]
+        assert "num" not in header
+        assert '<th class="num">e1RM (kg)</th>' in body
+
     def test_renders_the_expected_cards(self):
         body = charts.render_progress_body(self._data())
-        for heading in ("Weekly volume", "Estimated 1RM by exercise", "Bodyweight",
+        for heading in ("Weekly volume", "Estimated 1RM by muscle group", "Bodyweight",
                         "Volume by muscle group", "Pain flags"):
             assert heading in body
 

--- a/tests/test_muscle_groups.py
+++ b/tests/test_muscle_groups.py
@@ -1,0 +1,218 @@
+"""Unit tests for the static muscle-group lookup.
+
+The table is the sole source of `exercises.muscle_group`, and that column is
+written once per exercise and then never revisited, so a wrong entry is a wrong
+label on every future chart and on the volume figures fed to the weekly report.
+Two kinds of test here: mechanical guards that the tables are well-formed, and
+resolution cases - especially the names whose muscle word contradicts the muscle
+actually trained.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import muscle_groups
+from muscle_groups import (
+    CANONICAL_GROUPS,
+    EXERCISE_MUSCLE_GROUPS,
+    MOVEMENT_TOKENS,
+    MUSCLE_TOKENS,
+)
+from pipeline import normalize_tokens, resolve_muscle_group
+
+
+# --------------------------------------------------------------------------
+# Table well-formedness
+# --------------------------------------------------------------------------
+
+
+class TestTablesAreWellFormed:
+    """Guards that catch a bad entry at commit time rather than in the data."""
+
+    @pytest.mark.parametrize("key", sorted(EXERCISE_MUSCLE_GROUPS))
+    def test_key_is_in_normalized_singular_form(self, key):
+        """A key the normalizer can never produce would silently never match.
+
+        Lookup happens on `normalize_tokens` output, so every key must already
+        be what that function emits - lowercase, punctuation-free, and
+        singularized by the crude rule that turns "raises" into "raise" but
+        leaves "press" alone.
+        """
+        assert " ".join(normalize_tokens(key)) == key
+
+    @pytest.mark.parametrize("table_name", ["EXERCISE_MUSCLE_GROUPS", "MUSCLE_TOKENS",
+                                            "MOVEMENT_TOKENS"])
+    def test_values_are_canonical_groups(self, table_name):
+        table = getattr(muscle_groups, table_name)
+        unknown = {value for value in table.values() if value not in CANONICAL_GROUPS}
+        assert unknown == set()
+
+    def test_token_tables_are_single_words(self):
+        """Both token tables are matched one token at a time."""
+        for table in (MUSCLE_TOKENS, MOVEMENT_TOKENS, muscle_groups.EQUIPMENT_TOKENS):
+            assert all(" " not in token for token in table)
+
+    def test_ambiguous_verbs_are_not_movement_tokens(self):
+        """"press" and "raise" span chest, shoulders and legs.
+
+        Either one as a fallback would mislabel roughly a third of the lifts it
+        caught, so they are left out and their names carried by the table.
+        """
+        assert "press" not in MOVEMENT_TOKENS
+        assert "raise" not in MOVEMENT_TOKENS
+
+
+# --------------------------------------------------------------------------
+# Resolution
+# --------------------------------------------------------------------------
+
+
+class TestResolvesKnownExercises:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Bench Press", "Chest"),
+            ("Chest Bench Press", "Chest"),
+            ("Lat Pulldown", "Back"),
+            ("Barbell Row", "Back"),
+            ("Shoulder Press", "Shoulders"),
+            ("Lateral Raise", "Shoulders"),
+            ("Preacher Curl", "Biceps"),
+            ("Skullcrusher", "Triceps"),
+            ("Leg Press", "Legs"),
+            ("Hip Thrust", "Glutes"),
+            ("Plank", "Core"),
+            ("Wrist Curl", "Forearms"),
+            ("Power Clean", "Full Body"),
+        ],
+    )
+    def test_table_hit(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            # Short plurals survive `_singularize` intact - it only strips a
+            # trailing "s" past three characters, so "ups" never becomes "up".
+            # These regressed once and are the reason both spellings are listed.
+            ("Push Ups", "Chest"),
+            ("Pull Ups", "Back"),
+            ("Chin Ups", "Back"),
+            ("Sit Ups", "Core"),
+            ("Step Ups", "Legs"),
+            ("Abs Crunch", "Core"),
+            ("Lateral Raises", "Shoulders"),
+            ("Barbell Rows", "Back"),
+            ("Bicep Curls", "Biceps"),
+            ("Crunches", "Core"),
+            ("Chest Flies", "Chest"),
+            ("Cable Flys", "Chest"),
+        ],
+    )
+    def test_plural_forms_resolve(self, name, expected):
+        """The singularizer is crude, so plurals are covered by real cases."""
+        assert resolve_muscle_group(name) == expected
+
+
+class TestEquipmentIsStripped:
+    """Equipment prefixes must not require their own table entry."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Dumbbell Bench Press", "Chest"),
+            ("Dumbell Bench Press", "Chest"),        # the common typo
+            ("Machine Chest Press", "Chest"),
+            ("Seated Cable Row", "Back"),
+            ("EZ Bar Preacher Curl", "Biceps"),
+            ("Lying Leg Curl", "Legs"),
+            ("Standing Calf Raise", "Legs"),
+            ("Seated Calf Raise", "Legs"),
+            ("Single Arm Dumbbell Row", "Back"),
+        ],
+    )
+    def test_strips_and_resolves(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    def test_variations_are_not_stripped(self):
+        """A variation changes which muscle leads, so it must survive.
+
+        `EQUIPMENT_TOKENS` is looser than `pipeline.QUALIFIER_TOKENS`, and this
+        is the line it must not cross: "romanian" and "close grip" move the lift
+        to a different primary mover.
+        """
+        assert resolve_muscle_group("Deadlift") == "Back"
+        assert resolve_muscle_group("Romanian Deadlift") == "Legs"
+        assert resolve_muscle_group("Bench Press") == "Chest"
+        assert resolve_muscle_group("Close Grip Bench Press") == "Triceps"
+
+
+class TestMisleadingMuscleWords:
+    """The reason the explicit table is consulted before the token heuristics.
+
+    Each of these names contains a muscle word that is not the muscle trained.
+    A pure token heuristic gets every one of them wrong.
+    """
+
+    @pytest.mark.parametrize(
+        "name,expected,wrong",
+        [
+            ("Chest Supported Row", "Back", "Chest"),
+            ("Leg Raise", "Core", "Legs"),
+            ("Hanging Leg Raise", "Core", "Legs"),
+            ("Leg Curl", "Legs", "Biceps"),      # "curl" would say Biceps
+            ("Rear Delt Row", "Shoulders", "Back"),
+            ("Glute Kickback", "Glutes", "Triceps"),
+        ],
+    )
+    def test_table_wins_over_tokens(self, name, expected, wrong):
+        resolved = resolve_muscle_group(name)
+        assert resolved == expected
+        assert resolved != wrong
+
+
+class TestTokenFallbacks:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Chest Cable Crossover", "Chest"),   # named muscle, novel movement
+            ("Tricep Rope Pushdown", "Triceps"),
+            ("Lat Prayer", "Back"),
+            ("Oblique Twist", "Core"),
+        ],
+    )
+    def test_muscle_token_fallback(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Meadows Row", "Back"),              # no muscle word, known verb
+            ("Jefferson Curl", "Biceps"),
+            ("Zercher Squat", "Legs"),
+        ],
+    )
+    def test_movement_token_fallback(self, name, expected):
+        assert resolve_muscle_group(name) == expected
+
+
+class TestFailsClosed:
+    """Unrecognized names stay NULL rather than being guessed at.
+
+    `insights.volume_by_muscle_group` renders None as "Unassigned", so an
+    unknown movement is visibly unlabelled instead of quietly miscounted
+    against a muscle it never trained.
+    """
+
+    @pytest.mark.parametrize("name", ["Zercher Carry", "Some Machine Thing", "Wibble"])
+    def test_unknown_name_is_none(self, name):
+        assert resolve_muscle_group(name) is None
+
+    @pytest.mark.parametrize("name", ["", "   ", "!!!"])
+    def test_empty_name_is_none(self, name):
+        assert resolve_muscle_group(name) is None
+
+    def test_equipment_only_name_is_none(self):
+        """Nothing is left after stripping, and "dumbbell" names no muscle."""
+        assert resolve_muscle_group("Dumbbell") is None

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -110,11 +110,11 @@ class TestDraftBuilding:
 class TestFlagging:
     def test_missing_weight_is_flagged_on_its_own_field(self):
         row = draft_for().sets[2]
-        assert [issue.field for issue in row.issues] == ["weight_kg"]
+        assert "weight_kg" in [issue.field for issue in row.issues]
 
     def test_missing_reps_is_flagged_on_its_own_field(self):
         row = draft_for().sets[1]
-        assert [issue.field for issue in row.issues] == ["reps"]
+        assert "reps" in [issue.field for issue in row.issues]
 
     def test_missing_information_does_not_block_the_save(self):
         """A set with no recorded weight is still a set that happened."""
@@ -166,6 +166,93 @@ class TestBlockingIssues:
     def test_a_blank_name_blocks_rather_than_inserting_an_empty_exercise(self):
         payload = {"sets": [{"exercise_name": "   ", "weight_kg": 20, "reps": 10}]}
         assert draft_for(payload).sets[0].blocking
+
+
+class TestMuscleGroupSuggestion:
+    """The entry never mentions a muscle group and the extraction is not asked
+    for one, so it is suggested — which makes it exactly the kind of value that
+    has to be visible and correctable rather than decided off-screen."""
+
+    def test_a_recognised_name_is_filled_in(self):
+        assert draft_for().sets[0].values["muscle_group"] == "Chest"
+
+    def test_a_recognised_name_is_not_flagged(self):
+        assert draft_for().sets[0].issues_for("muscle_group") == []
+
+    def test_a_name_the_table_does_not_know_is_flagged(self):
+        """Left alone it becomes "Unassigned" in the volume chart, silently."""
+        row = draft_for().sets[1]
+        assert row.values["muscle_group"] is None
+        assert "Unassigned" in row.issues_for("muscle_group")[0].message
+
+    def test_an_unknown_group_does_not_block_the_save(self):
+        assert draft_for().ready
+
+    def test_what_the_exercise_is_already_filed_under_wins(self):
+        """`get_or_create_exercise` never revises a stored group on its own, so
+        offering a table answer that disagreed would be offering a lie."""
+        known = {"Chest Bench Press": "Shoulders"}
+        row = pipeline.draft_set_row(PAYLOAD["sets"][0], RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Shoulders"
+
+    def test_a_stored_group_is_found_through_a_reworded_name(self):
+        known = {"Chest Bench Press": "Chest"}
+        row = pipeline.draft_set_row(
+            {"exercise_name": "Barbell Chest Bench Press", "weight_kg": 28, "reps": 11},
+            RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Chest"
+
+    def test_a_stored_blank_falls_through_to_the_table(self):
+        known = {"Chest Bench Press": None}
+        row = pipeline.draft_set_row(PAYLOAD["sets"][0], RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Chest"
+
+    def test_an_extracted_group_is_kept(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], muscle_group="Triceps")]}
+        assert draft_for(payload).sets[0].values["muscle_group"] == "Triceps"
+
+
+class TestMuscleGroupEditing:
+    def test_a_correction_is_taken(self):
+        form = submitted(draft_for())
+        form["s1.muscle_group"] = "Back"
+        row = review.draft_from_form(form).sets[1]
+        assert row.values["muscle_group"] == "Back" and row.issues_for("muscle_group") == []
+
+    def test_a_correction_is_recorded_as_chosen_by_the_user(self):
+        form = submitted(draft_for())
+        form["s1.muscle_group"] = "Back"
+        assert "muscle_group" in review.draft_from_form(form).sets[1].edited_fields
+
+    def test_a_suggestion_left_alone_is_not_chosen_by_the_user(self):
+        form = submitted(draft_for())
+        assert "muscle_group" not in review.draft_from_form(form).sets[0].edited_fields
+
+    def test_a_group_the_user_clears_is_not_suggested_again(self):
+        """Otherwise the box could never be emptied on purpose."""
+        form = submitted(draft_for())
+        form["s0.muscle_group"] = ""
+        row = review.draft_from_form(form).sets[0]
+        assert row.values["muscle_group"] is None
+        assert "muscle_group" in row.edited_fields
+
+    def test_renaming_the_exercise_reanswers_an_untouched_group(self):
+        """The old suggestion belongs to the old name."""
+        form = submitted(draft_for())
+        form["s0.exercise_name"] = "Preacher Curl"
+        assert review.draft_from_form(form).sets[0].values["muscle_group"] == "Biceps"
+
+    def test_a_non_standard_group_is_flagged_but_savable(self):
+        form = submitted(draft_for())
+        form["s0.muscle_group"] = "Pecs"
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].issues_for("muscle_group") and returned.ready
+
+    def test_the_standard_groups_are_offered_as_a_pick_list(self):
+        page = review.render_review_body(draft_for())
+        assert '<datalist id="muscle-groups">' in page
+        assert 'list="muscle-groups"' in page
+        assert '<option value="Glutes">' in page
 
 
 # --------------------------------------------------------------------------
@@ -282,7 +369,7 @@ class TestEditing:
     def test_correcting_a_field_clears_its_mark(self):
         form = submitted(draft_for())
         form["s1.reps"] = "9"
-        assert review.draft_from_form(form).sets[1].issues == []
+        assert review.draft_from_form(form).sets[1].issues_for("reps") == []
 
     def test_a_corrected_row_is_recorded_as_edited(self):
         form = submitted(draft_for())
@@ -396,6 +483,7 @@ class TestAddingRows:
         form["s3.reps"] = "10"
         row = review.draft_from_form(form).sets[3]
         assert row.issues == [] and row.confidence == 1.0
+        assert row.values["muscle_group"] == "Legs"
 
     def test_a_typed_row_still_says_what_is_missing(self):
         form = submitted(self.add(draft_for()))


### PR DESCRIPTION
Nothing the model extracts reaches the database until it has been shown, checked and confirmed. Everything else here follows from that.

Replaces #19, which was closed and so stopped tracking this branch at `d3bf20a` — it never picked up the last three commits.

## Nothing is saved before you have seen it

`POST /log` extracts and writes nothing. It renders every prospective database row as an editable form — the same columns the table has, filled with the values that would be stored — and only `POST /save` inserts.

Problems are marked in red in two tiers:

- **Blocking** — a value the database would reject (reps of `"eleven"`, cheat reps above reps, a blank name). The field is outlined, the fault is named, and the save is refused until it is fixed or the row is unticked. Bad input stays in the box rather than being dropped to null, because a field silently emptied is a mistake you never see.
- **Missing or weakly grounded** — no weight, no rep count, a name that does not match the span it was read from, a score under the threshold. Marked the same way but savable: a set with no recorded load is still a set that happened.

The submission is rescored from what was actually typed, not from the extraction, so correcting a field clears its mark and breaking one adds one. The round trip is exact: a form rendered and posted back untouched produces identical values, with no row falsely recorded as edited.

The threshold now marks rows in the web app instead of dropping them — you are looking at all of them anyway, and a set you can see and correct is worth more than one silently withheld. It still gates the CLI, which has nobody watching.

**Adding rows.** "Add a set" appends an empty slot for something the parser missed entirely; "Add bodyweight" does the same for a reading the entry never mentioned. An empty slot is not a row — skipped on save, never reported as left out — so adding one and changing your mind costs nothing. A slot you fill in is validated like any other row but not scored on grounding, since it was never read out of the entry.

## Muscle group is suggested, then reviewed

The extraction is never asked for a muscle group and nobody writes "chest" in a gym journal, so the column filled itself in silently and the form showed an empty box. It is written once per exercise and never revisited, and the volume chart buckets on it exactly as stored, so a wrong or blank one misreports for months without surfacing.

It is now suggested into the form and corrected there. The suggestion prefers what the exercise is already filed under — matched the same fuzzy way the insert path matches names — and falls back to the static table. Stored wins because `get_or_create_exercise` never revises a stored group on its own; offering a table answer that disagreed would be offering an edit that saving ignores.

A group **you type** re-files an exercise that already exists. That needed edits tracked per field rather than per row, so a suggestion can be told from a choice. Without it, correcting the group on an exercise logged before would have appeared to work and changed nothing.

## e1RM sectioned by muscle group, and cards that fold

The e1RM chart groups exercises by the muscle they are filed under, so "is my chest progressing" is one glance rather than a hunt. **Grouped, not aggregated** — one averaged e1RM line per muscle group would read more easily and mean nothing, since a 100 kg bench press and a 15 kg cable fly have no useful mean and the average would move when exercise selection changed rather than when strength did. Which exercises appear is still decided by how much each is trained.

Every progress card folds, as does every muscle group inside the e1RM card. A card with nothing to say folds itself and puts the answer on its own summary line ("Pain flags · none in this window"), so collapsing never costs what it was telling you.

## Design notes

- **No state between the two requests.** The draft round-trips in the form itself, so the flow works unchanged on a serverless deploy where `/log` and `/save` may not reach the same process. `vercel.json` bundles with `includeFiles: "*.py"`, so `review.py` needs no config change — confirmed by importing `app.py` by path from outside the project root, the way the loader does.
- **The duplicate guard moved to `/save`**, the step that writes. `/log` writes nothing, so re-running it costs only another extraction.
- **A row you edit or type in is stored at confidence 1.0.** The score measures how well an extraction is grounded in the source text; a human correction is better evidence than the heuristic, and a hand-entered row has no extraction to score.
- **`pipeline.process_entry` is unchanged for the CLI.** It is now a thin wrapper over `build_draft` and `commit_draft`, verified against the previous implementation on the same payloads — identical results, insert parameters included.

## Also in this branch

It carries the muscle-group table (#18), already merged to the repo's default branch but not to `main`, because the review screen builds on it rather than growing a second source of the same answer. That also resolves the README conflict between the two.

## Tests

666 tests, no network or database required. New coverage for the draft/edit/save round trip, blocking versus non-blocking flags, hand-entered rows, muscle-group suggestion and override, e1RM grouping, and the fold behaviour.

Bugs the tests caught while writing this:
- An empty slot round-tripped its cheat-reps box as the string `"0"`, so on the second pass it stopped reading as blank and demanded an exercise name.
- Renaming an exercise left the previous name's muscle group behind; the two directions need different rules.
- Adding a column to the e1RM table twin exposed that `_table` right-aligns every column after the first — correct for one-label-column tables, wrong for one leading with three.
- Per-group grids broke `auto-fit`, which collapses empty tracks, so a group with one exercise drew a chart three times the size of one in a group of three.
- The fold marker was a CSS hex escape inside a plain Python string, so Python read it as an octal escape and a control character reached the stylesheet instead of the arrow.

There is no CI in this repo, so the only automated check is the Vercel preview deploy — it proves the app builds and imports, not that the suite passes. The test counts above are from local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q45UQk8bucH5oZsbd3AzQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q45UQk8bucH5oZsbd3AzQF)_