### PR TITLE
Restore the five commits that never reached main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ DEFAULT_SESSION_HOUR=18
 # Window for the /log duplicate-submission guard, in minutes.
 DUPLICATE_WINDOW_MINUTES=5
 
+# --- Exercise name flagging -----------------------------------------------
+# A newly created exercise name scoring in [NEAR_MISS_FLOOR, FUZZY_MATCH_THRESHOLD)
+# against an existing one is amber-flagged as a probable typo - too far to merge
+# automatically, close enough that a misspelling is the likely explanation.
+NEAR_MISS_FLOOR=70
+# Grounding similarity below which a SAVED name is flagged as poorly supported
+# by the text it was read from. Confidence already rejects anything under 0.5,
+# so in practice this flags the 0.5-0.8 band that would otherwise pass unseen.
+WEAK_GROUNDING_SIMILARITY=0.8
+
 # --- Weekly report tuning -------------------------------------------------
 # Pain safeguard. MUST stay true unless you are deliberately turning it off.
 PAIN_SAFEGUARD_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ generates a weekly progress report on top of them.
 You keep logging in your phone's Notes app exactly as you do now — typos,
 voice-to-text run-ons, times like "6:20ish", commentary like "almost died" —
 then paste the text into a small web form. The pipeline extracts the sets,
-validates them, scores how much it trusts each one, and inserts only what clears
-the bar. Everything else is listed for you to look at rather than quietly saved.
+validates them, scores how much it trusts each one, and shows you every row it
+is about to write — editable, with anything missing or invalid marked in red.
+Nothing reaches the database until you have looked at it and pressed save.
 
 Power BI connects straight to the Postgres tables. That side is out of scope
 here; the schema is just shaped for it.
@@ -16,15 +17,22 @@ here; the schema is just shaped for it.
 
 ```
 Notes app (unchanged)
-  -> paste into the mobile web form            app.py
+  -> paste into the mobile web form            app.py            POST /log
   -> Groq extraction, JSON mode, 1 retry       pipeline.extract_entities
-  -> Pydantic validation                       pipeline.validate_extraction
-  -> computed confidence heuristic             pipeline.compute_confidence
+  -> Pydantic validation + computed score      pipeline.build_draft
+  -> editable preview of every prospective row review.render_review_body
+       anything missing or invalid is red, and a row the database would
+       reject cannot be saved until it is fixed or unticked
+  -> you edit, untick, and press save          app.py            POST /save
+  -> rescored against what you actually typed  review.draft_from_form
   -> fuzzy match against existing exercises    pipeline.find_matching_exercise
-  -> below threshold? -> review list, not inserted
-  -> above threshold? -> parameterized INSERT into Postgres
+  -> parameterized INSERT into Postgres        pipeline.commit_draft
   -> Power BI reads Postgres directly (later, not part of this build)
 ```
+
+The CLI has no reviewer, so it keeps the older unattended behaviour: anything
+below the confidence threshold is reported rather than saved
+(`pipeline.process_entry`).
 
 ## Files
 
@@ -34,6 +42,7 @@ Notes app (unchanged)
 | `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
 | `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
+| `review.py` | The review screen: renders a draft as an editable form and reads the submission back |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
@@ -178,6 +187,41 @@ of waiting shrinks it. An ordinary failure retries immediately and keeps the
 full reservation: without JSON mode the model may wrap the object in prose, so
 the second attempt needs no less room than the first.
 
+### Nothing is saved before you have seen it
+
+The model is good at reading a run-on note and bad at knowing when it has
+misread one. The failure that matters is not a wrong number on screen — it is a
+wrong number in a chart four weeks later, with no way to tell which of thirty
+sets it came from.
+
+So `/log` extracts and writes nothing. It renders every prospective row as an
+editable form — the same columns the database has, filled with the values that
+would be stored — and only `/save` inserts. Two colours of problem are marked:
+
+- **Blocking** — a value the database would reject: a rep count of `"eleven"`,
+  more cheat reps than reps, a blank exercise name. The field is outlined in
+  red, the message says what is wrong, and the save is refused until it is fixed
+  or the row is unticked. Bad input is kept in the box rather than dropped to
+  null, because a field silently emptied is a mistake you never see.
+- **Missing or weakly grounded** — no weight, no rep count, a name that does not
+  match the text it was read from, a score below the threshold. Marked in the
+  same red, but savable: a set with no recorded load is still a set that
+  happened, and that is your call rather than the parser's.
+
+Each row shows the span of your entry it was read from, so a suspicious value
+can be checked without scrolling back. Every row also carries a Save tick;
+unticking one drops it.
+
+The submission is rescored from what you actually typed, not from the
+extraction — so correcting a field clears its mark, and breaking one adds a mark
+where there was none. The round trip is exact: a form rendered and posted back
+untouched produces the same values, with no row falsely recorded as edited.
+
+`review.py` owns both halves of that round trip and nothing else; it holds no
+state between the two requests. The draft travels in the form itself, which is
+why the flow works unchanged on a serverless deploy where the two requests may
+not reach the same process.
+
 ### Confidence is computed, not asked for
 
 LLMs are badly calibrated at rating their own certainty, so the model is
@@ -189,10 +233,18 @@ one from things that can actually be checked:
 - does the exercise name actually match the text span it was supposedly read
   from — the check that catches a name the model invented rather than read.
 
-Below `CONFIDENCE_THRESHOLD` (0.7) an entry goes to the review list and is not
-inserted. A set missing its weight or reps lands at 0.65 and so is always
-surfaced. That is deliberate: a set with no load recorded is not much use for
-progression, and a bodyweight exercise logged this way is worth a glance.
+Below `CONFIDENCE_THRESHOLD` (0.7) a row is marked in red on the review screen.
+A set missing its weight or reps lands at 0.65 and so is always surfaced. That is
+deliberate: a set with no load recorded is not much use for progression, and a
+bodyweight exercise logged this way is worth a glance.
+
+In the web app the threshold marks rows rather than dropping them — you are
+looking at all of them anyway, and a set you can see and correct is worth more
+than one silently withheld. It still gates the CLI, which has nobody watching.
+
+A row you edit is stored at confidence 1.0. The score measures how well an
+extraction is grounded in the source text; once you have corrected a field by
+hand, your correction is better evidence than any grounding heuristic.
 
 ### Exercise names are fuzzy-matched before a new row is created
 
@@ -291,11 +343,12 @@ Logging a second time against a date that already has rows asks which you meant:
 - **Replace** - discard everything already logged on that date and use this
   entry instead. For correcting a bad parse, not for adding.
 
-Replace is deliberately never the default, and never implicit. Two safeguards
-back it: the delete and the insert that follows commit in one transaction, so a
+Replace is deliberately never the default, and never implicit. Three safeguards
+back it: the review screen says how many rows the save will delete before you
+press it; the delete and the insert that follows commit in one transaction, so a
 failure mid-way cannot leave the day emptied with nothing put back; and it only
-runs when there is something to insert, so a failed extraction or an
-all-review entry leaves the existing day untouched.
+runs when there is something to insert, so a failed extraction or a draft with
+every row unticked leaves the existing day untouched.
 
 The delete window is a UTC range covering one *local* day, so it cannot reach
 into a neighbouring date - tested at an offset zone, not just UTC.
@@ -305,9 +358,10 @@ into a neighbouring date - tested at an offset zone, not just UTC.
 ### Duplicate submissions
 
 Render's free tier cold-starts in 30–50s after idle, which is exactly when you
-double-tap submit. Before extracting anything, `/log` checks whether the same raw
-text was inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns the
-earlier result instead of re-running the model and re-inserting.
+double-tap submit. The check sits on `/save`, the step that writes: it looks for
+the same raw text inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns
+the earlier result rather than inserting the entry twice. `/log` writes nothing,
+so re-running it costs only another extraction.
 
 ## Charts
 
@@ -411,13 +465,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-201 tests, no network and no database required — they cover the Stage A rule
+393 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
-threshold) and `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution, and JSON-mode retry behaviour. These are pure functions, so they are
-cheap to cover, and they are exactly the code where a silent bug produces a wrong
-training recommendation that nobody notices.
+threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
+resolution and JSON-mode retry behaviour, and the review screen's draft/edit/save
+round trip. These are pure functions, so they are cheap to cover, and they are
+exactly the code where a silent bug produces a wrong training recommendation, or
+a saved row that does not match what was on screen, and nobody notices.
 
 ## Not built (by design)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Notes app (unchanged)
   -> editable preview of every prospective row review.render_review_body
        anything missing or invalid is red, and a row the database would
        reject cannot be saved until it is fixed or unticked
-  -> you edit, untick, and press save          app.py            POST /save
+  -> you edit, untick, add missed sets, save   app.py            POST /save
   -> rescored against what you actually typed  review.draft_from_form
   -> fuzzy match against existing exercises    pipeline.find_matching_exercise
   -> parameterized INSERT into Postgres        pipeline.commit_draft
@@ -42,7 +42,7 @@ below the confidence threshold is reported rather than saved
 | `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
 | `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
-| `review.py` | The review screen: renders a draft as an editable form and reads the submission back |
+| `review.py` | The review screen: renders a draft as an editable form, reads the submission back, and adds empty slots on request |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
 | `charts.py` | The `/progress` page - inline-SVG charts, no chart library |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
@@ -212,6 +212,19 @@ Each row shows the span of your entry it was read from, so a suspicious value
 can be checked without scrolling back. Every row also carries a Save tick;
 unticking one drops it.
 
+**Add a set** appends an empty slot for something the parser missed entirely —
+a set you forgot to write down, or one lost in a run-on sentence. Adding is a
+round trip rather than a script: the form already carries the whole draft, so
+the server hands back the same state plus a slot, and the page stays
+JavaScript-free like the rest of the app. An empty slot is not a row: it is
+neither saved nor complained about, so there is no penalty for adding one and
+changing your mind. A slot you do fill in is validated like any other row, but
+not scored on grounding — it was never read out of the entry, so there is
+nothing to ground it in — and it is stored at confidence 1.0. The same applies
+to a bodyweight reading your entry never mentioned. If the extraction comes back
+with nothing at all, the add buttons are still there, so a failed parse is not a
+dead end.
+
 The submission is rescored from what you actually typed, not from the
 extraction — so correcting a field clears its mark, and breaking one adds a mark
 where there was none. The round trip is exact: a form rendered and posted back
@@ -242,9 +255,10 @@ In the web app the threshold marks rows rather than dropping them — you are
 looking at all of them anyway, and a set you can see and correct is worth more
 than one silently withheld. It still gates the CLI, which has nobody watching.
 
-A row you edit is stored at confidence 1.0. The score measures how well an
-extraction is grounded in the source text; once you have corrected a field by
-hand, your correction is better evidence than any grounding heuristic.
+A row you edit — or type in yourself — is stored at confidence 1.0. The score
+measures how well an extraction is grounded in the source text; once you have
+corrected a field by hand your correction is better evidence than any grounding
+heuristic, and for a hand-entered row there is no extraction to score at all.
 
 ### Exercise names are fuzzy-matched before a new row is created
 
@@ -465,7 +479,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-393 tests, no network and no database required — they cover the Stage A rule
+412 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/README.md
+++ b/README.md
@@ -237,6 +237,36 @@ state between the two requests. The draft travels in the form itself, which is
 why the flow works unchanged on a serverless deploy where the two requests may
 not reach the same process.
 
+### Muscle group is suggested, then reviewed
+
+Nobody writes "chest" in a gym journal, and the extraction is never asked for a
+muscle group — so the column filled itself in silently from the static table and
+nothing ever showed you the answer. `exercises.muscle_group` is written once per
+distinct movement and then never revisited, and `insights.volume_by_muscle_group`
+buckets on it exactly as stored, so a wrong or blank one is a chart that quietly
+misreports for months.
+
+It is now suggested into the review form like any other value, and correctable
+there. The suggestion comes from what the exercise is **already filed under**
+first — matched the same fuzzy way the insert path matches names, so a reworded
+name still finds its own row — and falls back to the table. Stored wins because
+`get_or_create_exercise` never revises a stored group on its own: offering a
+table answer that disagreed with one would be offering an edit that saving
+ignores.
+
+Two things are marked in red: a name the table cannot place (left alone it
+becomes "Unassigned" in the volume chart), and a group outside the ten canonical
+ones (it would become its own bucket). Neither blocks the save — muscle group is
+a filing decision, not a fact about the set. The ten standard groups are offered
+as a pick list, which is a `<datalist>`, so it suggests without refusing
+anything you insist on.
+
+A group **you type** is treated differently from one the app suggested: it is
+the only thing that will re-file an exercise that already exists. That
+distinction is why edits are tracked per field rather than per row. Without it
+correcting a group on an exercise you had logged before would appear to work and
+change nothing.
+
 ### Confidence is computed, not asked for
 
 LLMs are badly calibrated at rating their own certainty, so the model is
@@ -526,11 +556,11 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-628 tests, no network and no database required — they cover the Stage A
+643 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
-resolution and JSON-mode retry behaviour, the muscle-group tables — both their
+resolution and JSON-mode retry behaviour, the muscle-group tables and how their answer is suggested and overridden — both their
 resolution cases and mechanical guards that every key is in the normalized form
 lookup actually produces — and the review screen's draft/edit/save round trip.
 These are pure functions, so they are cheap to cover, and they are exactly the

--- a/README.md
+++ b/README.md
@@ -456,8 +456,9 @@ so re-running it costs only another extraction.
 
 ## Charts
 
-`/progress` plots the logged data: weekly volume, estimated 1RM per exercise as
-small multiples, bodyweight, volume by muscle group, and a pain-flag view. Drawn
+`/progress` plots the logged data: weekly volume, estimated 1RM as small
+multiples sectioned by muscle group, bodyweight, volume by muscle group, and a
+pain-flag view. Drawn
 as inline SVG from a JSON blob, so there is no chart library, no external
 request, and nothing added to `requirements.txt`.
 
@@ -466,6 +467,16 @@ number on a chart and the same number in the report cannot drift apart.
 
 A few decisions that are easy to get wrong:
 
+- **e1RM is grouped by muscle, not averaged into it.** The exercises of one
+  muscle group sit together under a heading so "is my chest progressing" is one
+  glance rather than a hunt, but each keeps its own line. One averaged e1RM per
+  muscle group would read more easily and mean nothing: a 100kg bench press and
+  a 15kg cable fly have no useful mean, and the average would move when you
+  changed exercise selection rather than when you got stronger. Which exercises
+  appear is still decided by how much they are trained, so grouping never
+  reserves slots for a muscle you barely work. An exercise with no group on file
+  sections under **Unassigned**, last — which is also the nudge to go and set it
+  on the review screen.
 - **Each exercise carries a fitted trend line and its slope in kg/week.** The
   shape of a line does not give the rate: two lifts can both end higher while
   one is gaining three times as fast. The line drawn and the rate quoted beside
@@ -556,7 +567,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-643 tests, no network and no database required — they cover the Stage A
+655 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp

--- a/README.md
+++ b/README.md
@@ -266,6 +266,48 @@ without the flag it writes them. It only ever touches NULL rows, so a
 hand-corrected group is never overwritten, and it lists the names it did not
 recognize — that list is what to add to `EXERCISE_MUSCLE_GROUPS`.
 
+### A name that does not look right is flagged, not withheld
+
+The confidence gate is binary: a set is either inserted or held back for review.
+That leaves a gap. A name can be perfectly extractable and still be wrong —
+`Bech Press` reads cleanly, scores well, and quietly becomes a second exercise
+alongside `Chest Bench Press`, splitting one lift's history in two. Nothing in
+the confidence path notices, because nothing about the extraction was uncertain.
+
+So there is a third outcome between "inserted" and "held back": **inserted, with
+an amber flag**. `NameFlag` never withholds data. It is raised only when a name
+creates a *new* exercise, because that is the moment a bad name becomes a
+permanent row — re-logging something that already exists is not suspicious, and
+a flag that nags about it would be ignored within a week.
+
+Three checks, in descending order of damage, at most one reported per name:
+
+| Reason | Means | Why it matters |
+|---|---|---|
+| `near_miss` | Scored 70–85 against an existing exercise *and* the difference reads as a misspelling | The history is now split across two rows, and every later chart inherits the split |
+| `weak_grounding` | The name is under 80% similar to the text it was read from | The model may have inferred the name rather than read it |
+| `unrecognized` | No muscle-group table, muscle word or movement verb knows it | Either genuinely niche and worth adding to `muscle_groups.py`, or not an exercise |
+
+The whole design problem is silence. A flag that fires on ordinary lifts gets
+ignored, and then the real ones are invisible too — so `near_miss` distinguishes
+a misspelling from a variation before it fires. Shared tokens are paired off,
+then leftovers are matched by character similarity; only tokens that find no
+partner are allowed to be equipment qualifiers. That is what lets `Bech Press`
+flag against `Chest Bench Press` (the spare `chest` is a qualifier) while
+`Incline Bench Press` stays silent (the spare `incline` is not) — which has to
+hold, because `QUALIFIER_TOKENS` above already documents `incline` as marking a
+genuinely different movement. Qualifiers are pointedly not stripped up front:
+that would delete the partner a typo *inside* one (`Shoulderr Press`) needs to
+be compared against.
+
+Two consequences worth knowing. A typo scoring at or above 85 is never flagged,
+because the matcher already merged it and no history was split. And
+`weak_grounding` forgives equipment the model added to a name the text wrote
+bare (`Barbell Hack Squat` from "hack squat"), since the matcher forgives it
+too. Across a 41-exercise programme built from scratch, nothing flags.
+
+Tunable via `NEAR_MISS_FLOOR` and `WEAK_GROUNDING_SIMILARITY`.
+
 ### Cheat reps are counted, not flagged
 
 Entries like `Lateral raises 7.5kg 10 reps 3 were cheat` mean three reps *inside*
@@ -458,13 +500,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-545 tests, no network and no database required — they cover the Stage A rule
+581 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
 resolution, and JSON-mode retry behaviour, and the muscle-group tables — both
 their resolution cases and mechanical guards that every key is in the normalized
-form lookup actually produces. These are pure functions, so they are cheap to
+form lookup actually produces — and the name flag, most of whose tests assert
+that ordinary lifts and real variations stay silent. These are pure functions, so they are cheap to
 cover, and they are exactly the code where a silent bug produces a wrong
 training recommendation that nobody notices.
 

--- a/app.py
+++ b/app.py
@@ -438,7 +438,7 @@ async def log_entry(
 
 @app.post("/save", response_class=HTMLResponse)
 async def save_reviewed(request: Request, _user: str = Depends(require_auth)) -> HTMLResponse:
-    """Write the reviewed form. The only route that inserts.
+    """Write the reviewed form, or hand it back with one more empty slot.
 
     The rows are rescored from the submitted values rather than from the
     extraction, so a corrected field is judged on what the user actually typed.
@@ -450,6 +450,11 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
         draft = review.draft_from_form(form)
     except ValueError:
         return _invalid_date_page()
+
+    # "Add a set" posts the same form; it hands back the draft plus an empty slot
+    # rather than saving, so a half-corrected row is not judged in passing.
+    if review.add_row(draft, str(form.get("action", "save"))):
+        return _review_page(draft)
 
     if not draft.ready:
         logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)

--- a/app.py
+++ b/app.py
@@ -2,13 +2,20 @@
 
 Routes:
     GET  /               mobile-friendly entry form
-    POST /log            run the pipeline on a pasted journal entry
+    POST /log            parse a pasted journal entry into an editable review form
+    POST /save           write the reviewed rows to the database
     GET  /weekly-report  report page with a "Generate weekly report" button
     POST /weekly-report  run Stage A + Stage B and upsert the report
     GET  /healthz        unauthenticated liveness probe
 
+Saving is deliberately two steps. POST /log only extracts; it renders every
+prospective database row for editing, with anything missing or invalid marked in
+red. Nothing is written until POST /save, and what it writes is the reviewed
+form, not the raw extraction.
+
 All extraction/validation/insert logic is imported from pipeline.py; all report
-logic from insights.py. Nothing is reimplemented here.
+logic from insights.py; the review form from review.py. Nothing is
+reimplemented here.
 """
 
 from __future__ import annotations
@@ -45,11 +52,12 @@ try:
     import charts  # noqa: E402 - must follow the sys.path bootstrap above
     import insights  # noqa: E402
     import pipeline  # noqa: E402
+    import review  # noqa: E402
 except Exception:  # noqa: BLE001 - report anything that stops the app booting
     import traceback
 
     _STARTUP_ERROR = traceback.format_exc()
-    charts = insights = pipeline = None  # type: ignore[assignment]
+    charts = insights = pipeline = review = None  # type: ignore[assignment]
 
 logging.basicConfig(
     level=pipeline.env("LOG_LEVEL", "INFO").upper() if pipeline else "INFO",
@@ -277,6 +285,13 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
         )
         parts.append(f'<div class="card muted"><strong>Fuzzy-matched names</strong><ul>{rows}</ul></div>')
 
+    skipped = result.skipped_sets + result.skipped_bodyweight
+    if skipped:
+        parts.append(
+            f'<div class="card muted">You unticked {skipped} row(s) on the review '
+            "screen, so they were not saved.</div>"
+        )
+
     if result.review_items:
         rows = []
         for item in result.review_items:
@@ -292,11 +307,12 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
                 f"{html.escape(item.reason)}</li>"
             )
         parts.append(
-            '<div class="card warn"><strong>Needs manual review '
-            f"({len(result.review_items)}) &mdash; not inserted</strong><ul>{''.join(rows)}</ul></div>"
+            '<div class="card err"><strong>Could not be saved '
+            f"({len(result.review_items)})</strong> &mdash; these parts of the entry "
+            f"could not be turned into editable rows.<ul>{''.join(rows)}</ul></div>"
         )
-    elif not result.error and not result.duplicate_of_recent:
-        parts.append('<div class="card muted">Nothing needed review.</div>')
+    elif not result.error and not result.duplicate_of_recent and not skipped:
+        parts.append('<div class="card muted">Everything you ticked was saved.</div>')
 
     return "".join(parts)
 
@@ -329,14 +345,52 @@ async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
     <option value="add" selected>Add to them &mdash; a second session, or more sets</option>
     <option value="replace">Replace them &mdash; discard that day and use this instead</option>
   </select>
-  <button type="submit">Parse &amp; save</button>
+  <button type="submit">Parse &amp; review</button>
 </form>
-<p class="muted">Sets below the confidence threshold
-({pipeline.CONFIDENCE_THRESHOLD:.0%}) are listed for review instead of being saved.
-Bodyweight mentions in the same entry are picked up automatically.
-<strong>Replace</strong> deletes everything already logged on that date, so use it to
-correct a bad entry &mdash; not to add an evening session.</p>
+<p class="muted">Parsing shows you every row it is about to write, with anything
+missing or invalid marked in red. Nothing is saved until you have looked at it
+and pressed save. Bodyweight mentions in the same entry are picked up
+automatically. <strong>Replace</strong> deletes everything already logged on that
+date, so use it to correct a bad entry &mdash; not to add an evening session.</p>
 """,
+    )
+
+
+def _parse_session_date(value: str) -> Optional[date]:
+    try:
+        return datetime.strptime((value or "").strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _invalid_date_page() -> HTMLResponse:
+    return _page(
+        "Invalid date",
+        '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
+        '<p><a href="/">Back</a></p>',
+    )
+
+
+def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
+    """What is already logged on that date, for the review banner.
+
+    Best effort: this only decorates the page, so a database that is briefly
+    unreachable should not cost the user the extraction they just paid for.
+    """
+    try:
+        return pipeline.count_entries_for_date(get_engine(), session_date)
+    except Exception:  # noqa: BLE001 - the save step will surface a real outage
+        logger.warning("event=existing_counts_failed date=%s", session_date, exc_info=True)
+        return None
+
+
+def _review_page(draft: pipeline.EntryDraft) -> HTMLResponse:
+    return _page(
+        "Check before saving",
+        review.render_review_body(
+            draft, _existing_counts(draft.session_date), pipeline.CONFIDENCE_THRESHOLD
+        ),
+        extra_css=review.REVIEW_CSS,
     )
 
 
@@ -347,36 +401,77 @@ async def log_entry(
     mode: str = Form("add"),
     _user: str = Depends(require_auth),
 ) -> HTMLResponse:
-    try:
-        parsed_date = datetime.strptime(session_date.strip(), "%Y-%m-%d").date()
-    except ValueError:
+    """Extract only. Nothing reaches the database until POST /save."""
+    parsed_date = _parse_session_date(session_date)
+    if parsed_date is None:
+        return _invalid_date_page()
+
+    draft = pipeline.build_draft(raw_text, parsed_date)
+    draft.replace_existing = mode == "replace"
+    logger.info(
+        "event=entry_drafted date=%s mode=%s sets=%d bodyweight=%s flagged=%d blocked=%d error=%s",
+        parsed_date,
+        mode,
+        len(draft.sets),
+        draft.bodyweight is not None,
+        draft.flagged_count,
+        draft.blocked_count,
+        bool(draft.error),
+    )
+
+    if draft.error:
+        notes = "".join(
+            f'<div class="card muted">{html.escape(item.reason)}</div>'
+            for item in draft.review_items
+        )
         return _page(
-            "Invalid date",
-            '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
+            "Could not parse",
+            f'<h1>Could not parse that entry</h1>'
+            f'<div class="card err">{html.escape(draft.error)}</div>{notes}'
+            '<p class="muted">Nothing was saved. Go back and try again — the entry '
+            "is unchanged.</p>"
             '<p><a href="/">Back</a></p>',
         )
 
-    result = pipeline.process_entry(
-        raw_text,
-        parsed_date,
-        engine=get_engine(),
-        check_duplicates=True,
-        replace_existing=(mode == "replace"),
-    )
+    return _review_page(draft)
+
+
+@app.post("/save", response_class=HTMLResponse)
+async def save_reviewed(request: Request, _user: str = Depends(require_auth)) -> HTMLResponse:
+    """Write the reviewed form. The only route that inserts.
+
+    The rows are rescored from the submitted values rather than from the
+    extraction, so a corrected field is judged on what the user actually typed.
+    A row the database would still reject sends the whole form back for another
+    pass instead of being quietly dropped.
+    """
+    form = await request.form()
+    try:
+        draft = review.draft_from_form(form)
+    except ValueError:
+        return _invalid_date_page()
+
+    if not draft.ready:
+        logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)
+        return _review_page(draft)
+
+    result = pipeline.commit_draft(draft, engine=get_engine(), check_duplicates=True)
     logger.info(
-        "event=log_processed date=%s mode=%s inserted_sets=%d inserted_bodyweight=%d "
-        "review=%d duplicate=%s replaced=%s",
-        parsed_date,
-        mode,
+        "event=entry_saved date=%s replace=%s inserted_sets=%d inserted_bodyweight=%d "
+        "skipped=%d review=%d duplicate=%s replaced=%s",
+        draft.session_date,
+        draft.replace_existing,
         result.inserted_sets,
         result.inserted_bodyweight,
+        result.skipped_sets + result.skipped_bodyweight,
         len(result.review_items),
         result.duplicate_of_recent,
         result.replaced,
     )
     return _page(
-        "Result",
-        f'<h1>Result</h1>{_render_result(result, parsed_date)}<p><a href="/">Log another</a></p>',
+        "Saved",
+        f'<h1>Saved</h1>{_render_result(result, draft.session_date)}'
+        '<p><a href="/">Log another</a></p>',
     )
 
 

--- a/app.py
+++ b/app.py
@@ -371,6 +371,20 @@ def _invalid_date_page() -> HTMLResponse:
     )
 
 
+def _known_groups() -> Optional[dict[str, Optional[str]]]:
+    """What each known exercise is already filed under, for the suggestion.
+
+    Best effort, like `_existing_counts`: without it the suggestion falls back
+    to the static table, which is a worse answer but not a wrong one.
+    """
+    try:
+        with get_engine().connect() as conn:
+            return pipeline.load_exercise_groups(conn)
+    except Exception:  # noqa: BLE001 - the save step will surface a real outage
+        logger.warning("event=known_groups_failed", exc_info=True)
+        return None
+
+
 def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
     """What is already logged on that date, for the review banner.
 
@@ -406,7 +420,7 @@ async def log_entry(
     if parsed_date is None:
         return _invalid_date_page()
 
-    draft = pipeline.build_draft(raw_text, parsed_date)
+    draft = pipeline.build_draft(raw_text, parsed_date, known_groups=_known_groups())
     draft.replace_existing = mode == "replace"
     logger.info(
         "event=entry_drafted date=%s mode=%s sets=%d bodyweight=%s flagged=%d blocked=%d error=%s",
@@ -447,7 +461,7 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
     """
     form = await request.form()
     try:
-        draft = review.draft_from_form(form)
+        draft = review.draft_from_form(form, known_groups=_known_groups())
     except ValueError:
         return _invalid_date_page()
 

--- a/app.py
+++ b/app.py
@@ -270,6 +270,19 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
         names = ", ".join(html.escape(name) for name in result.exercises_created)
         parts.append(f'<div class="card muted">New exercises created: {names}</div>')
 
+    if result.name_flags:
+        rows = "".join(
+            f"<li><strong>{html.escape(flag.exercise_name)}</strong> "
+            f"&mdash; {html.escape(flag.detail)}</li>"
+            for flag in result.name_flags
+        )
+        parts.append(
+            '<div class="card warn"><strong>Check these names '
+            f"({len(result.name_flags)}) &mdash; saved anyway</strong><ul>{rows}</ul>"
+            "<p class=\"muted\">Flagged only when the name creates a new exercise. "
+            "Fix a wrong one by re-submitting the entry with <strong>Replace</strong>.</p></div>"
+        )
+
     if result.exercises_matched:
         rows = "".join(
             f"<li>{html.escape(proposed)} &rarr; matched existing <strong>{html.escape(matched)}</strong></li>"

--- a/charts.py
+++ b/charts.py
@@ -23,6 +23,10 @@ import json
 from datetime import date, timedelta
 from typing import Any
 
+# insights does not import this module, so this stays a one-way dependency. Only
+# the shared label for an exercise with no muscle group on file comes from it.
+import insights
+
 # Tokens are declared for both the OS setting and an explicit theme stamp, so a
 # viewer's choice wins either way.
 PROGRESS_CSS = """
@@ -91,6 +95,10 @@ PROGRESS_CSS = """
 .plot svg { display: block; overflow: visible; }
 
 .smalls { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: .9rem; }
+.smalls .section { grid-column: 1 / -1; font-size: .8rem; font-weight: 600;
+  letter-spacing: .04em; text-transform: uppercase; color: var(--ink-2);
+  margin: .3rem 0 0; padding-bottom: .25rem; border-bottom: 1px solid var(--hairline); }
+.smalls .section:first-child { margin-top: 0; }
 .small h3 { font-size: .85rem; margin: 0 0 .1rem; font-weight: 600; }
 .small .sub { font-size: .75rem; margin: 0 0 .4rem; }
 
@@ -429,14 +437,22 @@ def _tile(label: str, value: str, delta: str = "", up_is_good: bool = False) -> 
     )
 
 
-def _table(headers: list[str], rows: list[list[str]], caption: str) -> str:
-    """The table twin. Every plotted value is reachable here without hovering."""
+def _table(
+    headers: list[str], rows: list[list[str]], caption: str, numeric_from: int = 1
+) -> str:
+    """The table twin. Every plotted value is reachable here without hovering.
+
+    `numeric_from` is the first right-aligned column. One label column is the
+    common case; a table that leads with more than one needs to say so, or its
+    text columns get flushed right against the numbers.
+    """
     head = "".join(
-        f'<th class="{"num" if i else ""}">{html.escape(h)}</th>' for i, h in enumerate(headers)
+        f'<th class="{"num" if i >= numeric_from else ""}">{html.escape(h)}</th>'
+        for i, h in enumerate(headers)
     )
     body = "".join(
         "<tr>" + "".join(
-            f'<td class="{"num" if i else ""}">{html.escape(str(c))}</td>'
+            f'<td class="{"num" if i >= numeric_from else ""}">{html.escape(str(c))}</td>'
             for i, c in enumerate(row)
         ) + "</tr>"
         for row in rows
@@ -497,8 +513,15 @@ def render_progress_body(data: dict[str, Any]) -> str:
                "Table view"),
     )
 
-    smalls, e1rm_rows = [], []
+    # The series arrive already ordered so one muscle group's exercises are
+    # adjacent, so a heading goes in wherever the group changes. Ordering stays
+    # in insights.py; this only draws the seam.
+    smalls, e1rm_rows, current_group = [], [], None
     for index, series in enumerate(data["exercise_e1rm"]):
+        group = series.get("muscle_group") or insights.UNASSIGNED_GROUP
+        if group != current_group:
+            smalls.append(f'<h3 class="section">{html.escape(group)}</h3>')
+            current_group = group
         first, last = series["points"][0][1], series["points"][-1][1]
         change = last - first
         slope = series.get("slope_per_week")
@@ -510,15 +533,19 @@ def render_progress_body(data: dict[str, Any]) -> str:
             f'<div class="plot" data-chart="e1rm:{index}"></div></div>'
         )
         for day, value in series["points"]:
-            e1rm_rows.append([series["exercise"], day, _fmt(value, 1)])
+            e1rm_rows.append([group, series["exercise"], day, _fmt(value, 1)])
 
     e1rm_card = _card(
-        "Estimated 1RM by exercise",
-        "Epley, from clean reps only. The grey line is the fitted trend; the rate "
-        "beside each name is its slope.",
+        "Estimated 1RM by muscle group",
+        "Epley, from clean reps only, grouped by the muscle each exercise is filed "
+        "under. Still one line per exercise \u2014 a bench press and a fly average to "
+        "nothing useful. The grey line is the fitted trend; the rate beside each "
+        "name is its slope.",
         f'<div class="smalls">{"".join(smalls)}</div>' if smalls
         else '<p class="empty">Needs at least two sessions of an exercise to show a trend.</p>',
-        _table(["Exercise", "Session", "e1RM (kg)"], e1rm_rows, "Table view") if e1rm_rows else "",
+        _table(["Muscle group", "Exercise", "Session", "e1RM (kg)"], e1rm_rows,
+               "Table view", numeric_from=3)
+        if e1rm_rows else "",
     )
 
     bodyweight_card = _card(

--- a/insights.py
+++ b/insights.py
@@ -224,10 +224,15 @@ def volume_by_exercise(records: Iterable[SetRecord]) -> dict[str, float]:
     return {name: round(value, 1) for name, value in sorted(totals.items())}
 
 
+# What an exercise with no muscle group on file is bucketed under. One constant
+# so the volume chart and the e1RM sections cannot label the same gap differently.
+UNASSIGNED_GROUP = "Unassigned"
+
+
 def volume_by_muscle_group(records: Iterable[SetRecord]) -> dict[str, float]:
     totals: dict[str, float] = defaultdict(float)
     for record in records:
-        totals[record.muscle_group or "Unassigned"] += set_volume(record)
+        totals[record.muscle_group or UNASSIGNED_GROUP] += set_volume(record)
     return {name: round(value, 1) for name, value in sorted(totals.items())}
 
 
@@ -949,6 +954,49 @@ def exercise_e1rm_series(
     return series[:limit]
 
 
+def exercise_e1rm_by_muscle_group(
+    records: Iterable[SetRecord], limit: int = 6, min_sessions: int = 2
+) -> list[tuple[str, str, list[tuple[date, float]]]]:
+    """`exercise_e1rm_series`, ordered so one muscle group's exercises sit together.
+
+    Returns (muscle_group, exercise, points).
+
+    Grouping here is presentation, not aggregation: the series stay per
+    exercise. One averaged e1RM line per muscle group would be easier to read
+    and would not mean anything — a 100kg bench press and a 15kg cable fly have
+    no useful mean, and the average would move when exercise selection changed
+    rather than when strength did. Sectioning the real series answers "is my
+    chest progressing" without inventing a number to answer it with.
+
+    Which exercises appear is decided before grouping, so the chart still shows
+    the most-trained lifts rather than reserving slots per group. Groups follow
+    the most-trained exercise in each, with Unassigned last so a gap in the
+    muscle-group table sinks instead of splitting the groups that do read.
+    """
+    records = list(records)
+    series = exercise_e1rm_series(records, limit=limit, min_sessions=min_sessions)
+    # Every row for an exercise carries the group from the same `exercises` row,
+    # so this is a lookup rather than a reconciliation.
+    group_for = {record.exercise_name: record.muscle_group for record in records}
+
+    def group_of(name: str) -> str:
+        return group_for.get(name) or UNASSIGNED_GROUP
+
+    first_seen: dict[str, int] = {}
+    for index, (name, _) in enumerate(series):
+        first_seen.setdefault(group_of(name), index)
+
+    ordered = sorted(
+        enumerate(series),
+        key=lambda pair: (
+            group_of(pair[1][0]) == UNASSIGNED_GROUP,
+            first_seen[group_of(pair[1][0])],
+            pair[0],
+        ),
+    )
+    return [(group_of(name), name, points) for _, (name, points) in ordered]
+
+
 def pain_summary(records: Iterable[SetRecord]) -> list[dict[str, Any]]:
     """Exercises carrying pain flags, worst streak first.
 
@@ -1017,6 +1065,7 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
         "exercise_e1rm": [
             {
                 "exercise": name,
+                "muscle_group": group,
                 "points": [[day.isoformat(), value] for day, value in points],
                 "slope_per_week": trend_slope_per_week(points),
                 "trend": (
@@ -1024,7 +1073,7 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
                     if trend_endpoints(points) else None
                 ),
             }
-            for name, points in exercise_e1rm_series(records)
+            for group, name, points in exercise_e1rm_by_muscle_group(records)
         ],
         "bodyweight": [[day.isoformat(), value] for day, value in bodyweight],
         "muscle_volume": sorted(

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -296,6 +296,11 @@ def main(argv: list[str] | None = None) -> int:
     for proposed, matched in result.exercises_matched:
         print(f"Fuzzy match  : {proposed!r} -> existing {matched!r}")
 
+    if result.name_flags:
+        print(f"\nCheck these names ({len(result.name_flags)}) — saved anyway:")
+        for flag in result.name_flags:
+            print(f"  ! [{flag.reason}] {flag.exercise_name!r}: {flag.detail}")
+
     if result.review_items:
         print(f"\nNeeds manual review ({len(result.review_items)}) — NOT inserted:")
         for item in result.review_items:

--- a/pipeline.py
+++ b/pipeline.py
@@ -262,10 +262,142 @@ class PipelineResult:
     duplicate_of_recent: bool = False
     replaced: Optional[dict[str, int]] = None
     error: Optional[str] = None
+    # Rows the user unticked on the review screen. Distinct from review_items,
+    # which are rows the pipeline itself held back.
+    skipped_sets: int = 0
+    skipped_bodyweight: int = 0
 
     @property
     def total_inserted(self) -> int:
         return self.inserted_sets + self.inserted_bodyweight
+
+
+# --------------------------------------------------------------------------
+# Editable draft — what the review screen shows before anything is written
+# --------------------------------------------------------------------------
+
+# The editable columns of each row, in the order the review screen lays them
+# out. `raw_span` is carried but never edited: it is the evidence the row was
+# read from, and rewriting it would rewrite the audit trail.
+SET_COLUMNS: tuple[str, ...] = (
+    "exercise_name",
+    "weight_kg",
+    "reps",
+    "cheat_reps",
+    "set_number",
+    "logged_at_local",
+    "muscle_group",
+    "is_warmup",
+    "is_dropset",
+    "pain_flag",
+    "notes",
+    "raw_span",
+)
+
+BODYWEIGHT_COLUMNS: tuple[str, ...] = (
+    "weight_kg",
+    "body_fat_pct",
+    "logged_at_local",
+    "notes",
+    "raw_span",
+)
+
+
+@dataclass
+class DraftIssue:
+    """Something wrong with a drafted row, addressed to the person reviewing it.
+
+    `blocking` separates the two kinds the review screen treats differently:
+    a blocking issue is one the database would reject, so the row cannot be
+    saved until it is fixed; a non-blocking one is missing or weakly grounded
+    information, which is flagged but savable — a set with no recorded weight
+    is still a set that happened.
+    """
+
+    message: str
+    field: Optional[str] = None  # column it belongs to; None = the whole row
+    blocking: bool = False
+
+
+@dataclass
+class DraftRow:
+    """One prospective database row, as extracted and possibly since edited."""
+
+    kind: str  # "workout_set" | "bodyweight"
+    values: dict[str, Any] = field(default_factory=dict)
+    confidence: Optional[float] = None
+    issues: list[DraftIssue] = field(default_factory=list)
+    include: bool = True
+    edited: bool = False  # a person changed a value on the review screen
+    # The exact wording `process_entry` used before the review screen existed,
+    # kept so the CLI and the unattended path still report failures the same way.
+    validation_error: Optional[str] = None
+
+    @property
+    def blocking(self) -> bool:
+        return any(issue.blocking for issue in self.issues)
+
+    @property
+    def flagged(self) -> bool:
+        return bool(self.issues)
+
+    def issues_for(self, column: str) -> list[DraftIssue]:
+        return [issue for issue in self.issues if issue.field == column]
+
+    @property
+    def row_issues(self) -> list[DraftIssue]:
+        """Issues that belong to no single column."""
+        return [issue for issue in self.issues if issue.field is None]
+
+    def legacy_reason(self, confidence_threshold: float) -> str:
+        """Why an unattended run would have held this row back."""
+        if self.validation_error:
+            return self.validation_error
+        return (
+            f"confidence {self.confidence or 0.0:.2f} below "
+            f"threshold {confidence_threshold:.2f}"
+        )
+
+
+@dataclass
+class EntryDraft:
+    """Everything one journal entry would write, before any of it is written."""
+
+    raw_text: str
+    session_date: date
+    sets: list[DraftRow] = field(default_factory=list)
+    bodyweight: Optional[DraftRow] = None
+    # Fragments of the extraction that are not editable rows at all — a `sets`
+    # key that came back as a string, say. Nothing can be done with these on the
+    # review screen, so they pass straight through to the result.
+    review_items: list[ReviewItem] = field(default_factory=list)
+    error: Optional[str] = None
+    replace_existing: bool = False
+
+    @property
+    def rows(self) -> list[DraftRow]:
+        return self.sets + ([self.bodyweight] if self.bodyweight is not None else [])
+
+    @property
+    def included(self) -> list[DraftRow]:
+        return [row for row in self.rows if row.include]
+
+    @property
+    def flagged_count(self) -> int:
+        return sum(1 for row in self.rows if row.flagged)
+
+    @property
+    def blocked_count(self) -> int:
+        return sum(1 for row in self.included if row.blocking)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.rows
+
+    @property
+    def ready(self) -> bool:
+        """True when saving would not be rejected by the database."""
+        return self.error is None and self.blocked_count == 0
 
 
 # --------------------------------------------------------------------------
@@ -821,6 +953,44 @@ def get_groq_client() -> Any:
     return Groq(api_key=api_key)
 
 
+def score_set(
+    item: dict[str, Any],
+    raw_text: str,
+) -> tuple[Optional[WorkoutSet], float, Optional[ValidationError]]:
+    """Validate and score one raw set object.
+
+    The single place a set is turned into a model and given a confidence, so the
+    review screen, the CLI dry run and the insert path can never disagree about
+    what is wrong with a row. Returns (model, confidence, error); exactly one of
+    model and error is None.
+    """
+    try:
+        workout_set = WorkoutSet.model_validate(item)
+    except ValidationError as exc:
+        return None, compute_confidence(None, None, None, None, raw_text, validation_ok=False), exc
+
+    confidence = compute_confidence(
+        workout_set.exercise_name,
+        workout_set.weight_kg,
+        workout_set.reps,
+        workout_set.raw_span,
+        raw_text,
+    )
+    return workout_set, confidence, None
+
+
+def score_bodyweight(
+    item: dict[str, Any],
+    raw_text: str,
+) -> tuple[Optional[BodyweightEntry], float, Optional[ValidationError]]:
+    """`score_set`, for the bodyweight reading."""
+    try:
+        entry = BodyweightEntry.model_validate(item)
+    except ValidationError as exc:
+        return None, 0.0, exc
+    return entry, compute_bodyweight_confidence(entry, raw_text), None
+
+
 def validate_extraction(
     payload: dict[str, Any],
     raw_text: str,
@@ -841,39 +1011,29 @@ def validate_extraction(
             review.append(ReviewItem("workout_set", f"set {index} was not an object", 0.0,
                                      {"raw": str(item)[:500]}))
             continue
-        try:
-            workout_set = WorkoutSet.model_validate(item)
-        except ValidationError as exc:
+        workout_set, confidence, exc = score_set(item, raw_text)
+        if exc is not None:
             review.append(
                 ReviewItem(
                     "workout_set",
                     f"failed validation: {_short_errors(exc)}",
-                    compute_confidence(None, None, None, None, raw_text, validation_ok=False),
+                    confidence,
                     item,
                 )
             )
             continue
-
-        confidence = compute_confidence(
-            workout_set.exercise_name,
-            workout_set.weight_kg,
-            workout_set.reps,
-            workout_set.raw_span,
-            raw_text,
-        )
         scored_sets.append((workout_set, confidence))
 
     scored_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
     raw_bodyweight = payload.get("bodyweight")
     if isinstance(raw_bodyweight, dict):
-        try:
-            entry = BodyweightEntry.model_validate(raw_bodyweight)
-        except ValidationError as exc:
+        entry, bodyweight_confidence, exc = score_bodyweight(raw_bodyweight, raw_text)
+        if exc is not None:
             review.append(
                 ReviewItem("bodyweight", f"failed validation: {_short_errors(exc)}", 0.0, raw_bodyweight)
             )
         else:
-            scored_bodyweight = (entry, compute_bodyweight_confidence(entry, raw_text))
+            scored_bodyweight = (entry, bodyweight_confidence)
     elif raw_bodyweight not in (None, ""):
         review.append(
             ReviewItem("bodyweight", "'bodyweight' was neither null nor an object", 0.0,
@@ -920,6 +1080,227 @@ def compute_bodyweight_confidence(entry: BodyweightEntry, raw_text: str) -> floa
 def _short_errors(exc: ValidationError) -> str:
     parts = [f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()[:3]]
     return "; ".join(parts)
+
+
+# --------------------------------------------------------------------------
+# Draft building (extraction -> editable rows, still nothing written)
+# --------------------------------------------------------------------------
+
+
+def _clean_message(message: str) -> str:
+    """Pydantic prefixes custom validator failures; the prefix means nothing here."""
+    return re.sub(r"^(Value|Assertion) error, ", "", message).strip()
+
+
+def _named_column(message: str, columns: Sequence[str]) -> Optional[str]:
+    """The column a whole-model validation message is about, if it names one.
+
+    Pydantic reports a `model_validator` failure against no field at all, which
+    would leave the form saying a row is unsaveable without marking anything on
+    it. These messages are ours, so the column they name is reliable.
+    """
+    lowered = message.lower()
+    # Longest first, so "cheat_reps exceeds reps" points at cheat_reps, the
+    # column that is actually out of range, rather than the one it is compared to.
+    matches = sorted((c for c in columns if c in lowered), key=len, reverse=True)
+    return matches[0] if matches else None
+
+
+def _field_issues(exc: ValidationError, columns: Sequence[str]) -> list[DraftIssue]:
+    """Turn a validation failure into per-column issues the form can highlight."""
+    issues: list[DraftIssue] = []
+    for error in exc.errors():
+        message = _clean_message(error["msg"])
+        location = str(error["loc"][0]) if error["loc"] else None
+        column = location if location in columns else _named_column(message, columns)
+        issues.append(DraftIssue(message, column, blocking=True))
+    return issues
+
+
+def _column_defaults(model: type[BaseModel], columns: Sequence[str]) -> dict[str, Any]:
+    """What each column falls back to when the extraction leaves it out.
+
+    Read off the models rather than restated, so the review screen shows the
+    value the database would actually store — `cheat_reps` absent means 0, not
+    null, and null is what the column rejects.
+    """
+    defaults: dict[str, Any] = {}
+    for column in columns:
+        info = model.model_fields.get(column)
+        defaults[column] = (
+            None if info is None or info.is_required()
+            else info.get_default(call_default_factory=True)
+        )
+    return defaults
+
+
+SET_DEFAULTS = _column_defaults(WorkoutSet, SET_COLUMNS)
+BODYWEIGHT_DEFAULTS = _column_defaults(BodyweightEntry, BODYWEIGHT_COLUMNS)
+
+
+def _pick(
+    values: dict[str, Any], columns: Sequence[str], defaults: dict[str, Any]
+) -> dict[str, Any]:
+    """Keep only the editable columns, filling omissions with the column default.
+
+    A missing key and an explicit null are treated alike: models routinely emit
+    one or the other for a flag they had nothing to say about, and neither means
+    "store null in a NOT NULL column".
+    """
+    picked: dict[str, Any] = {}
+    for column in columns:
+        value = values.get(column)
+        picked[column] = defaults[column] if value is None else value
+    return picked
+
+
+def draft_set_row(
+    values: dict[str, Any],
+    raw_text: str,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    edited: bool = False,
+) -> DraftRow:
+    """Score one set and describe everything a person should look at before saving."""
+    row = DraftRow("workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited)
+    workout_set, confidence, exc = score_set(row.values, raw_text)
+    row.confidence = confidence
+
+    if exc is not None:
+        row.validation_error = f"failed validation: {_short_errors(exc)}"
+        row.issues = _field_issues(exc, SET_COLUMNS)
+        return row
+
+    # Show the coerced values, so what the screen displays is what gets stored.
+    row.values = _pick(workout_set.model_dump(), SET_COLUMNS, SET_DEFAULTS)
+
+    if workout_set.weight_kg is None:
+        row.issues.append(
+            DraftIssue("no weight found in your entry — saved blank unless you fill it in",
+                       "weight_kg")
+        )
+    if workout_set.reps is None:
+        row.issues.append(
+            DraftIssue("no rep count found in your entry — saved blank unless you fill it in",
+                       "reps")
+        )
+    if _grounding_similarity(workout_set.exercise_name, workout_set.raw_span or raw_text) < 0.5:
+        row.issues.append(
+            DraftIssue("this name does not closely match the text it was read from",
+                       "exercise_name")
+        )
+
+    # Only worth saying when nothing more specific already explains the score.
+    if confidence < confidence_threshold and not row.issues and not edited:
+        row.issues.append(
+            DraftIssue(
+                f"confidence {confidence:.2f}, below the {confidence_threshold:.2f} "
+                "threshold — check it against your entry"
+            )
+        )
+    return row
+
+
+def draft_bodyweight_row(
+    values: dict[str, Any],
+    raw_text: str,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    edited: bool = False,
+) -> DraftRow:
+    """`draft_set_row`, for the bodyweight reading."""
+    row = DraftRow("bodyweight", _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS), edited=edited)
+    entry, confidence, exc = score_bodyweight(row.values, raw_text)
+    row.confidence = confidence
+
+    if exc is not None:
+        row.validation_error = f"failed validation: {_short_errors(exc)}"
+        row.issues = _field_issues(exc, BODYWEIGHT_COLUMNS)
+        return row
+
+    row.values = _pick(entry.model_dump(), BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS)
+    haystack = _normalize_numeric_text(entry.raw_span or raw_text)
+    if not _number_appears_in(float(entry.weight_kg), haystack):
+        row.issues.append(
+            DraftIssue("this number does not appear in your entry", "weight_kg")
+        )
+    if confidence < confidence_threshold and not row.issues and not edited:
+        row.issues.append(
+            DraftIssue(
+                f"confidence {confidence:.2f}, below the {confidence_threshold:.2f} "
+                "threshold — check it against your entry"
+            )
+        )
+    return row
+
+
+def draft_from_payload(
+    payload: dict[str, Any],
+    raw_text: str,
+    session_date: date,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Turn a raw extraction into editable rows, keeping the ones that failed.
+
+    `validate_extraction` drops invalid sets into a review list; here they are
+    kept as rows, because a set the model got half right is exactly the one a
+    person wants to correct rather than retype.
+    """
+    draft = EntryDraft(raw_text=raw_text, session_date=session_date)
+
+    raw_sets = payload.get("sets") or []
+    if not isinstance(raw_sets, list):
+        draft.review_items.append(
+            ReviewItem("extraction", "'sets' was not a list", None, {"sets": str(raw_sets)[:500]})
+        )
+        raw_sets = []
+
+    for index, item in enumerate(raw_sets):
+        if not isinstance(item, dict):
+            draft.review_items.append(
+                ReviewItem("workout_set", f"set {index} was not an object", 0.0,
+                           {"raw": str(item)[:500]})
+            )
+            continue
+        draft.sets.append(draft_set_row(item, raw_text, confidence_threshold))
+
+    raw_bodyweight = payload.get("bodyweight")
+    if isinstance(raw_bodyweight, dict):
+        draft.bodyweight = draft_bodyweight_row(raw_bodyweight, raw_text, confidence_threshold)
+    elif raw_bodyweight not in (None, ""):
+        draft.review_items.append(
+            ReviewItem("bodyweight", "'bodyweight' was neither null nor an object", 0.0,
+                       {"raw": str(raw_bodyweight)[:500]})
+        )
+
+    return draft
+
+
+def build_draft(
+    raw_text: str,
+    session_date: date,
+    client: Any = None,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Extract one journal entry into a draft. Touches the model, not the database."""
+    raw_text = (raw_text or "").strip()
+    if not raw_text:
+        return EntryDraft(
+            raw_text=raw_text,
+            session_date=session_date,
+            error="Empty entry — nothing to parse.",
+        )
+
+    try:
+        payload = extract_entities(raw_text, session_date, client=client)
+    except ExtractionError as exc:
+        logger.error("Extraction failed: %s", exc)
+        return EntryDraft(
+            raw_text=raw_text,
+            session_date=session_date,
+            error="Extraction failed after one retry — entry not inserted.",
+            review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
+        )
+
+    return draft_from_payload(payload, raw_text, session_date, confidence_threshold)
 
 
 # --------------------------------------------------------------------------
@@ -1086,6 +1467,144 @@ def find_recent_submission(
 # --------------------------------------------------------------------------
 
 
+def commit_draft(
+    draft: EntryDraft,
+    engine: Optional[Engine] = None,
+    check_duplicates: bool = False,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    review_excluded: bool = False,
+) -> PipelineResult:
+    """Write the ticked rows of a draft. The only function that inserts.
+
+    A row that reaches here has either been looked at on the review screen or
+    cleared the threshold unattended, so the threshold is not applied again —
+    `include` is the decision. `review_excluded` makes the rows left out come
+    back as review items, which is what the unattended path reports.
+
+    Confidence is recomputed from the values as they stand. A row a person
+    edited is stored at 1.0: the score measures how well an extraction is
+    grounded in the source text, and a human correction is better evidence
+    than any grounding heuristic.
+    """
+    if engine is None:
+        engine = get_engine()
+
+    result = PipelineResult(review_items=list(draft.review_items))
+    if draft.error:
+        result.error = draft.error
+        return result
+
+    if check_duplicates:
+        prior = find_recent_submission(engine, draft.raw_text)
+        if prior is not None:
+            logger.info("Duplicate submission suppressed (%s)", prior)
+            return PipelineResult(
+                inserted_sets=prior["inserted_sets"],
+                inserted_bodyweight=prior["inserted_bodyweight"],
+                duplicate_of_recent=True,
+            )
+
+    accepted_sets: list[tuple[WorkoutSet, float]] = []
+    for row in draft.sets:
+        if not row.include:
+            result.skipped_sets += 1
+            if review_excluded:
+                result.review_items.append(
+                    ReviewItem(
+                        "workout_set",
+                        row.legacy_reason(confidence_threshold),
+                        row.confidence,
+                        dict(row.values),
+                    )
+                )
+            continue
+        workout_set, confidence, exc = score_set(row.values, draft.raw_text)
+        if exc is not None:
+            # Callers check `draft.ready` first, so this is a guard rather than a
+            # path: a row the database would reject is never silently dropped.
+            result.review_items.append(
+                ReviewItem("workout_set", f"failed validation: {_short_errors(exc)}",
+                           row.confidence, dict(row.values))
+            )
+            continue
+        accepted_sets.append((workout_set, 1.0 if row.edited else confidence))
+
+    accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
+    if draft.bodyweight is not None:
+        row = draft.bodyweight
+        if not row.include:
+            result.skipped_bodyweight += 1
+            if review_excluded:
+                result.review_items.append(
+                    ReviewItem("bodyweight", row.legacy_reason(confidence_threshold),
+                               row.confidence, dict(row.values))
+                )
+        else:
+            entry, confidence, exc = score_bodyweight(row.values, draft.raw_text)
+            if exc is not None:
+                result.review_items.append(
+                    ReviewItem("bodyweight", f"failed validation: {_short_errors(exc)}",
+                               row.confidence, dict(row.values))
+                )
+            else:
+                accepted_bodyweight = (entry, 1.0 if row.edited else confidence)
+
+    if not accepted_sets and accepted_bodyweight is None:
+        return result
+
+    with engine.begin() as conn:
+        if draft.replace_existing:
+            # Only reached when there is something to put back - the early
+            # return above means a failed extraction never empties the day.
+            result.replaced = delete_entries_for_date(conn, draft.session_date)
+            logger.info("Replaced %s on %s", result.replaced, draft.session_date)
+        known = load_exercise_names(conn)
+        for workout_set, confidence in accepted_sets:
+            exercise_id, matched_name, created = get_or_create_exercise(
+                conn, workout_set.exercise_name, workout_set.muscle_group, known
+            )
+            if created:
+                result.exercises_created.append(workout_set.exercise_name)
+            elif matched_name and matched_name != workout_set.exercise_name:
+                result.exercises_matched.append((workout_set.exercise_name, matched_name))
+
+            conn.execute(
+                _INSERT_WORKOUT_SET,
+                {
+                    "exercise_id": exercise_id,
+                    "logged_at": resolve_logged_at(workout_set.logged_at_local, draft.session_date),
+                    "weight_kg": workout_set.weight_kg,
+                    "reps": workout_set.reps,
+                    "cheat_reps": workout_set.cheat_reps,
+                    "set_number": workout_set.set_number,
+                    "is_warmup": workout_set.is_warmup,
+                    "is_dropset": workout_set.is_dropset,
+                    "pain_flag": workout_set.pain_flag,
+                    "notes": workout_set.notes,
+                    "raw_source": draft.raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_sets += 1
+
+        if accepted_bodyweight is not None:
+            entry, confidence = accepted_bodyweight
+            conn.execute(
+                _INSERT_BODYWEIGHT,
+                {
+                    "logged_at": resolve_logged_at(entry.logged_at_local, draft.session_date),
+                    "weight_kg": entry.weight_kg,
+                    "body_fat_pct": entry.body_fat_pct,
+                    "notes": entry.notes,
+                    "raw_source": draft.raw_text,
+                    "extraction_confidence": confidence,
+                },
+            )
+            result.inserted_bodyweight += 1
+
+    return result
+
+
 def process_entry(
     raw_text: str,
     session_date: date,
@@ -1095,10 +1614,12 @@ def process_entry(
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     replace_existing: bool = False,
 ) -> PipelineResult:
-    """Run the full pipeline for one journal entry.
+    """Extract and insert one journal entry with nobody watching.
 
-    Called by both the CLI and the web app. `check_duplicates` is enabled by the
-    web app, where a double-tapped submit is a real risk.
+    The CLI path: no review screen, so the confidence threshold does the
+    deciding and anything under it is reported rather than saved. The web app
+    goes through `build_draft` and `commit_draft` instead, and lets the person
+    who wrote the entry make that call.
     """
     raw_text = (raw_text or "").strip()
     if not raw_text:
@@ -1117,98 +1638,18 @@ def process_entry(
                 duplicate_of_recent=True,
             )
 
-    try:
-        payload = extract_entities(raw_text, session_date, client=client)
-    except ExtractionError as exc:
-        logger.error("Extraction failed: %s", exc)
-        return PipelineResult(
-            error="Extraction failed after one retry — entry not inserted.",
-            review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
-        )
+    draft = build_draft(raw_text, session_date, client=client,
+                        confidence_threshold=confidence_threshold)
+    if draft.error:
+        return PipelineResult(error=draft.error, review_items=list(draft.review_items))
 
-    scored_sets, scored_bodyweight, review = validate_extraction(payload, raw_text)
-    result = PipelineResult(review_items=list(review))
+    draft.replace_existing = replace_existing
+    for row in draft.rows:
+        row.include = not row.blocking and (row.confidence or 0.0) >= confidence_threshold
 
-    accepted_sets = []
-    for workout_set, confidence in scored_sets:
-        if confidence < confidence_threshold:
-            result.review_items.append(
-                ReviewItem(
-                    "workout_set",
-                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
-                    confidence,
-                    workout_set.model_dump(),
-                )
-            )
-        else:
-            accepted_sets.append((workout_set, confidence))
-
-    accepted_bodyweight = None
-    if scored_bodyweight is not None:
-        entry, confidence = scored_bodyweight
-        if confidence < confidence_threshold:
-            result.review_items.append(
-                ReviewItem(
-                    "bodyweight",
-                    f"confidence {confidence:.2f} below threshold {confidence_threshold:.2f}",
-                    confidence,
-                    entry.model_dump(),
-                )
-            )
-        else:
-            accepted_bodyweight = (entry, confidence)
-
-    if not accepted_sets and accepted_bodyweight is None:
-        return result
-
-    with engine.begin() as conn:
-        if replace_existing:
-            # Only reached when there is something to put back - the early
-            # return above means a failed extraction never empties the day.
-            result.replaced = delete_entries_for_date(conn, session_date)
-            logger.info("Replaced %s on %s", result.replaced, session_date)
-        known = load_exercise_names(conn)
-        for workout_set, confidence in accepted_sets:
-            exercise_id, matched_name, created = get_or_create_exercise(
-                conn, workout_set.exercise_name, workout_set.muscle_group, known
-            )
-            if created:
-                result.exercises_created.append(workout_set.exercise_name)
-            elif matched_name and matched_name != workout_set.exercise_name:
-                result.exercises_matched.append((workout_set.exercise_name, matched_name))
-
-            conn.execute(
-                _INSERT_WORKOUT_SET,
-                {
-                    "exercise_id": exercise_id,
-                    "logged_at": resolve_logged_at(workout_set.logged_at_local, session_date),
-                    "weight_kg": workout_set.weight_kg,
-                    "reps": workout_set.reps,
-                    "cheat_reps": workout_set.cheat_reps,
-                    "set_number": workout_set.set_number,
-                    "is_warmup": workout_set.is_warmup,
-                    "is_dropset": workout_set.is_dropset,
-                    "pain_flag": workout_set.pain_flag,
-                    "notes": workout_set.notes,
-                    "raw_source": raw_text,
-                    "extraction_confidence": confidence,
-                },
-            )
-            result.inserted_sets += 1
-
-        if accepted_bodyweight is not None:
-            entry, confidence = accepted_bodyweight
-            conn.execute(
-                _INSERT_BODYWEIGHT,
-                {
-                    "logged_at": resolve_logged_at(entry.logged_at_local, session_date),
-                    "weight_kg": entry.weight_kg,
-                    "body_fat_pct": entry.body_fat_pct,
-                    "notes": entry.notes,
-                    "raw_source": raw_text,
-                    "extraction_confidence": confidence,
-                },
-            )
-            result.inserted_bodyweight += 1
-
-    return result
+    return commit_draft(
+        draft,
+        engine=engine,
+        confidence_threshold=confidence_threshold,
+        review_excluded=True,
+    )

--- a/pipeline.py
+++ b/pipeline.py
@@ -329,6 +329,12 @@ class DraftRow:
     issues: list[DraftIssue] = field(default_factory=list)
     include: bool = True
     edited: bool = False  # a person changed a value on the review screen
+    # Typed in on the review screen rather than read out of the entry. Such a row
+    # has no source text behind it, so the grounding checks do not apply to it.
+    added: bool = False
+    # An added row nobody has filled in yet: not a row at all, so it is neither
+    # saved nor complained about.
+    blank: bool = False
     # The exact wording `process_entry` used before the review screen existed,
     # kept so the CLI and the unattended path still report failures the same way.
     validation_error: Optional[str] = None
@@ -380,7 +386,7 @@ class EntryDraft:
 
     @property
     def included(self) -> list[DraftRow]:
-        return [row for row in self.rows if row.include]
+        return [row for row in self.rows if row.include and not row.blank]
 
     @property
     def flagged_count(self) -> int:
@@ -1154,16 +1160,45 @@ def _pick(
     return picked
 
 
+def _is_blank(values: dict[str, Any], defaults: dict[str, Any]) -> bool:
+    """True when nothing has been entered — every column still holds its default.
+
+    Compared as text as well as by value, because anything that has been through
+    a form arrives as a string: an untouched cheat-rep box submits "0", not 0,
+    and an empty slot that failed this check would fail validation on its blank
+    exercise name instead of being ignored.
+    """
+    return all(
+        value == defaults[column] or str(value).strip() == str(defaults[column])
+        for column, value in values.items()
+    )
+
+
 def draft_set_row(
     values: dict[str, Any],
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
+    added: bool = False,
 ) -> DraftRow:
-    """Score one set and describe everything a person should look at before saving."""
-    row = DraftRow("workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited)
+    """Score one set and describe everything a person should look at before saving.
+
+    `added` marks a row typed in on the review screen rather than read out of the
+    entry. There is no source text behind such a row, so the grounding checks —
+    which ask how well a reading is supported by what was written — would be
+    measuring nothing. Missing weights and reps are still worth pointing out.
+    """
+    row = DraftRow(
+        "workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited, added=added
+    )
+    if _is_blank(row.values, SET_DEFAULTS):
+        # An empty slot the user has not filled in. Not a row, so it is neither
+        # saved nor complained about.
+        row.blank = True
+        return row
+
     workout_set, confidence, exc = score_set(row.values, raw_text)
-    row.confidence = confidence
+    row.confidence = 1.0 if added else confidence
 
     if exc is not None:
         row.validation_error = f"failed validation: {_short_errors(exc)}"
@@ -1175,14 +1210,15 @@ def draft_set_row(
 
     if workout_set.weight_kg is None:
         row.issues.append(
-            DraftIssue("no weight found in your entry — saved blank unless you fill it in",
-                       "weight_kg")
+            DraftIssue("no weight recorded — saved blank unless you fill it in", "weight_kg")
         )
     if workout_set.reps is None:
         row.issues.append(
-            DraftIssue("no rep count found in your entry — saved blank unless you fill it in",
-                       "reps")
+            DraftIssue("no rep count recorded — saved blank unless you fill it in", "reps")
         )
+    if added:
+        return row
+
     if _grounding_similarity(workout_set.exercise_name, workout_set.raw_span or raw_text) < 0.5:
         row.issues.append(
             DraftIssue("this name does not closely match the text it was read from",
@@ -1205,11 +1241,21 @@ def draft_bodyweight_row(
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
+    added: bool = False,
 ) -> DraftRow:
     """`draft_set_row`, for the bodyweight reading."""
-    row = DraftRow("bodyweight", _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS), edited=edited)
+    row = DraftRow(
+        "bodyweight",
+        _pick(values, BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS),
+        edited=edited,
+        added=added,
+    )
+    if _is_blank(row.values, BODYWEIGHT_DEFAULTS):
+        row.blank = True
+        return row
+
     entry, confidence, exc = score_bodyweight(row.values, raw_text)
-    row.confidence = confidence
+    row.confidence = 1.0 if added else confidence
 
     if exc is not None:
         row.validation_error = f"failed validation: {_short_errors(exc)}"
@@ -1217,6 +1263,9 @@ def draft_bodyweight_row(
         return row
 
     row.values = _pick(entry.model_dump(), BODYWEIGHT_COLUMNS, BODYWEIGHT_DEFAULTS)
+    if added:
+        return row
+
     haystack = _normalize_numeric_text(entry.raw_span or raw_text)
     if not _number_appears_in(float(entry.weight_kg), haystack):
         row.issues.append(
@@ -1230,6 +1279,16 @@ def draft_bodyweight_row(
             )
         )
     return row
+
+
+def blank_set_row() -> DraftRow:
+    """An empty slot for a set the extraction missed entirely."""
+    return DraftRow("workout_set", dict(SET_DEFAULTS), added=True, blank=True)
+
+
+def blank_bodyweight_row() -> DraftRow:
+    """An empty slot for a bodyweight reading the entry never mentioned."""
+    return DraftRow("bodyweight", dict(BODYWEIGHT_DEFAULTS), added=True, blank=True)
 
 
 def draft_from_payload(
@@ -1482,9 +1541,13 @@ def commit_draft(
     back as review items, which is what the unattended path reports.
 
     Confidence is recomputed from the values as they stand. A row a person
-    edited is stored at 1.0: the score measures how well an extraction is
-    grounded in the source text, and a human correction is better evidence
-    than any grounding heuristic.
+    edited or typed in themselves is stored at 1.0: the score measures how well
+    an extraction is grounded in the source text, and a human correction is
+    better evidence than any grounding heuristic — for a hand-entered row there
+    is no extraction to score at all.
+
+    Blank slots are skipped in silence. They are offers to add a row that nobody
+    took up, so they are neither saved nor reported as left out.
     """
     if engine is None:
         engine = get_engine()
@@ -1506,6 +1569,8 @@ def commit_draft(
 
     accepted_sets: list[tuple[WorkoutSet, float]] = []
     for row in draft.sets:
+        if row.blank:
+            continue
         if not row.include:
             result.skipped_sets += 1
             if review_excluded:
@@ -1527,10 +1592,10 @@ def commit_draft(
                            row.confidence, dict(row.values))
             )
             continue
-        accepted_sets.append((workout_set, 1.0 if row.edited else confidence))
+        accepted_sets.append((workout_set, 1.0 if row.edited or row.added else confidence))
 
     accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
-    if draft.bodyweight is not None:
+    if draft.bodyweight is not None and not draft.bodyweight.blank:
         row = draft.bodyweight
         if not row.include:
             result.skipped_bodyweight += 1
@@ -1547,7 +1612,7 @@ def commit_draft(
                                row.confidence, dict(row.values))
                 )
             else:
-                accepted_bodyweight = (entry, 1.0 if row.edited else confidence)
+                accepted_bodyweight = (entry, 1.0 if row.edited or row.added else confidence)
 
     if not accepted_sets and accepted_bodyweight is None:
         return result

--- a/pipeline.py
+++ b/pipeline.py
@@ -21,7 +21,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from rapidfuzz import fuzz
@@ -331,6 +331,10 @@ class DraftRow:
     issues: list[DraftIssue] = field(default_factory=list)
     include: bool = True
     edited: bool = False  # a person changed a value on the review screen
+    # Which columns they changed. Muscle group needs this: a value the user
+    # chose may overwrite what is on record for an exercise, a suggestion the
+    # app filled in must not.
+    edited_fields: frozenset[str] = frozenset()
     # Typed in on the review screen rather than read out of the entry. Such a row
     # has no source text behind it, so the grounding checks do not apply to it.
     added: bool = False
@@ -1186,12 +1190,34 @@ def _is_blank(values: dict[str, Any], defaults: dict[str, Any]) -> bool:
     )
 
 
+def suggest_muscle_group(
+    exercise_name: str,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
+) -> Optional[str]:
+    """The muscle group to offer for an exercise name, or None if nothing fits.
+
+    What is already on record wins over the table. `get_or_create_exercise`
+    never revises a stored group on its own, so offering a table answer that
+    disagrees with one would show the user a value that saving quietly ignores.
+    The name is fuzzy-matched the same way the insert path matches it, so a
+    reworded name still finds its own row.
+    """
+    if known_groups:
+        matched = find_matching_exercise(exercise_name, known_groups.keys())
+        if matched is not None and known_groups[matched]:
+            return known_groups[matched]
+    return resolve_muscle_group(exercise_name)
+
+
 def draft_set_row(
     values: dict[str, Any],
     raw_text: str,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     edited: bool = False,
     added: bool = False,
+    edited_fields: frozenset[str] = frozenset(),
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
+    resuggest_muscle_group: bool = False,
 ) -> DraftRow:
     """Score one set and describe everything a person should look at before saving.
 
@@ -1201,7 +1227,11 @@ def draft_set_row(
     measuring nothing. Missing weights and reps are still worth pointing out.
     """
     row = DraftRow(
-        "workout_set", _pick(values, SET_COLUMNS, SET_DEFAULTS), edited=edited, added=added
+        "workout_set",
+        _pick(values, SET_COLUMNS, SET_DEFAULTS),
+        edited=edited,
+        added=added,
+        edited_fields=edited_fields,
     )
     if _is_blank(row.values, SET_DEFAULTS):
         # An empty slot the user has not filled in. Not a row, so it is neither
@@ -1228,6 +1258,20 @@ def draft_set_row(
         row.issues.append(
             DraftIssue("no rep count recorded — saved blank unless you fill it in", "reps")
         )
+
+    # Suggested rather than read: the extraction is never asked for a muscle
+    # group. A value already there is kept on the way in, so the rare one a model
+    # does volunteer still counts; on the way back from the review screen it is
+    # recomputed unless the user took the field over, because by then the value
+    # sitting in the box is this function's own last answer — and renaming the
+    # exercise has to re-answer it rather than leave the old name's group behind.
+    if "muscle_group" not in row.edited_fields:
+        current = None if resuggest_muscle_group else row.values.get("muscle_group")
+        row.values["muscle_group"] = current or suggest_muscle_group(
+            workout_set.exercise_name, known_groups
+        )
+    _flag_muscle_group(row)
+
     if added:
         return row
 
@@ -1246,6 +1290,34 @@ def draft_set_row(
             )
         )
     return row
+
+
+def _flag_muscle_group(row: DraftRow) -> None:
+    """Mark a muscle group that nothing can be done with downstream.
+
+    `insights.volume_by_muscle_group` buckets on this column exactly as stored,
+    so a blank one silently becomes "Unassigned" and a typo becomes its own
+    bucket. Neither is an error the database would catch, which is why both are
+    flagged here rather than left to be discovered in a chart.
+    """
+    group = (row.values.get("muscle_group") or "").strip()
+    if not group:
+        row.issues.append(
+            DraftIssue(
+                "no muscle group matched this name — volume by muscle group will "
+                "count it as Unassigned",
+                "muscle_group",
+            )
+        )
+    elif group not in muscle_groups.CANONICAL_GROUPS:
+        row.issues.append(
+            DraftIssue(
+                f"“{group}” is not one of the standard groups "
+                f"({', '.join(muscle_groups.CANONICAL_GROUPS)}) — it will be "
+                "counted as its own bucket",
+                "muscle_group",
+            )
+        )
 
 
 def draft_bodyweight_row(
@@ -1293,6 +1365,12 @@ def draft_bodyweight_row(
     return row
 
 
+def load_exercise_groups(conn: Connection) -> dict[str, Optional[str]]:
+    """Every known exercise name and the muscle group it is filed under."""
+    rows = conn.execute(text("SELECT name, muscle_group FROM exercises")).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
 def blank_set_row() -> DraftRow:
     """An empty slot for a set the extraction missed entirely."""
     return DraftRow("workout_set", dict(SET_DEFAULTS), added=True, blank=True)
@@ -1308,6 +1386,7 @@ def draft_from_payload(
     raw_text: str,
     session_date: date,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
     """Turn a raw extraction into editable rows, keeping the ones that failed.
 
@@ -1331,7 +1410,9 @@ def draft_from_payload(
                            {"raw": str(item)[:500]})
             )
             continue
-        draft.sets.append(draft_set_row(item, raw_text, confidence_threshold))
+        draft.sets.append(
+            draft_set_row(item, raw_text, confidence_threshold, known_groups=known_groups)
+        )
 
     raw_bodyweight = payload.get("bodyweight")
     if isinstance(raw_bodyweight, dict):
@@ -1350,8 +1431,14 @@ def build_draft(
     session_date: date,
     client: Any = None,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
-    """Extract one journal entry into a draft. Touches the model, not the database."""
+    """Extract one journal entry into a draft. Touches the model, not the database.
+
+    `known_groups` is what the `exercises` table already records, so the muscle
+    group offered for an exercise you have logged before is the one it is
+    actually filed under.
+    """
     raw_text = (raw_text or "").strip()
     if not raw_text:
         return EntryDraft(
@@ -1371,7 +1458,9 @@ def build_draft(
             review_items=[ReviewItem("extraction", str(exc), None, {"raw_text": raw_text})],
         )
 
-    return draft_from_payload(payload, raw_text, session_date, confidence_threshold)
+    return draft_from_payload(
+        payload, raw_text, session_date, confidence_threshold, known_groups
+    )
 
 
 # --------------------------------------------------------------------------
@@ -1405,14 +1494,29 @@ def get_or_create_exercise(
     proposed_name: str,
     muscle_group: Optional[str],
     known: dict[str, int],
+    chosen_group: bool = False,
 ) -> tuple[int, Optional[str], bool]:
     """Resolve an exercise name to an id, fuzzy-matching before inserting.
 
     Returns (exercise_id, matched_existing_name_or_None, created).
+
+    `chosen_group` says the muscle group came from a person on the review
+    screen rather than from the table. Only then is an existing exercise's group
+    revised: a suggestion must never quietly overwrite a filing decision that
+    has already been made, but a correction the user typed has to stick, or the
+    review screen would be offering an edit that does nothing.
     """
     matched = find_matching_exercise(proposed_name, known.keys())
     if matched is not None:
-        return known[matched], matched, False
+        exercise_id = known[matched]
+        if chosen_group:
+            conn.execute(
+                text("UPDATE exercises SET muscle_group = :muscle_group "
+                     "WHERE exercise_id = :exercise_id "
+                     "AND muscle_group IS DISTINCT FROM :muscle_group"),
+                {"muscle_group": muscle_group, "exercise_id": exercise_id},
+            )
+        return exercise_id, matched, False
 
     # An explicit group from the caller wins; otherwise look the name up in the
     # static table. Either may be None, which stores NULL and reports as
@@ -1587,7 +1691,8 @@ def commit_draft(
                 duplicate_of_recent=True,
             )
 
-    accepted_sets: list[tuple[WorkoutSet, float]] = []
+    # (model, confidence, the muscle group was chosen by the user not suggested)
+    accepted_sets: list[tuple[WorkoutSet, float, bool]] = []
     for row in draft.sets:
         if row.blank:
             continue
@@ -1612,7 +1717,11 @@ def commit_draft(
                            row.confidence, dict(row.values))
             )
             continue
-        accepted_sets.append((workout_set, 1.0 if row.edited or row.added else confidence))
+        accepted_sets.append((
+            workout_set,
+            1.0 if row.edited or row.added else confidence,
+            "muscle_group" in row.edited_fields,
+        ))
 
     accepted_bodyweight: Optional[tuple[BodyweightEntry, float]] = None
     if draft.bodyweight is not None and not draft.bodyweight.blank:
@@ -1644,9 +1753,10 @@ def commit_draft(
             result.replaced = delete_entries_for_date(conn, draft.session_date)
             logger.info("Replaced %s on %s", result.replaced, draft.session_date)
         known = load_exercise_names(conn)
-        for workout_set, confidence in accepted_sets:
+        for workout_set, confidence, chosen_group in accepted_sets:
             exercise_id, matched_name, created = get_or_create_exercise(
-                conn, workout_set.exercise_name, workout_set.muscle_group, known
+                conn, workout_set.exercise_name, workout_set.muscle_group, known,
+                chosen_group=chosen_group,
             )
             if created:
                 result.exercises_created.append(workout_set.exercise_name)

--- a/pipeline.py
+++ b/pipeline.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from typing import Any, Iterable, Optional, Sequence
@@ -75,6 +76,18 @@ CONFIDENCE_THRESHOLD = float(env("CONFIDENCE_THRESHOLD", "0.7"))
 # rapidfuzz score (0-100) at or above which a proposed exercise name is treated
 # as the same exercise as an existing row.
 FUZZY_MATCH_THRESHOLD = float(env("FUZZY_MATCH_THRESHOLD", "85"))
+
+# Band immediately below FUZZY_MATCH_THRESHOLD. A new name scoring in here is
+# too far from an existing exercise to merge automatically, but close enough
+# that a typo is the likeliest explanation - which is exactly the case that
+# silently splits one lift's history across two rows.
+NEAR_MISS_FLOOR = float(env("NEAR_MISS_FLOOR", "70"))
+
+# Grounding similarity below which a name that WAS saved is still treated as
+# weakly supported by the text it was read from. Confidence already penalizes
+# this band by 0.15, which on its own does not drop a set with a weight and a
+# rep count under CONFIDENCE_THRESHOLD - so without a flag it passes unseen.
+WEAK_GROUNDING_SIMILARITY = float(env("WEAK_GROUNDING_SIMILARITY", "0.8"))
 
 # Groq's Llama chat models (llama-3.3-70b-versatile, llama-3.1-8b-instant) were
 # deprecated for free/developer tiers on 2026-06-17. openai/gpt-oss-120b is the
@@ -255,11 +268,30 @@ class ReviewItem:
 
 
 @dataclass
+class NameFlag:
+    """A saved exercise name that does not look right - niche, or just wrong.
+
+    Distinct from `ReviewItem` in the one way that matters: the row this refers
+    to WAS inserted. A flag is an amber "look at this", not a rejection, so it
+    never withholds data. Raised only when the name creates a NEW exercise,
+    because that is the moment a bad name becomes a permanent row; re-logging an
+    exercise that already exists is not suspicious and must not nag.
+    """
+
+    exercise_name: str
+    reason: str  # "near_miss" | "weak_grounding" | "unrecognized"
+    detail: str
+    nearest_name: Optional[str] = None
+    score: Optional[float] = None
+
+
+@dataclass
 class PipelineResult:
     inserted_sets: int = 0
     inserted_bodyweight: int = 0
     review_items: list[ReviewItem] = field(default_factory=list)
     exercises_created: list[str] = field(default_factory=list)
+    name_flags: list[NameFlag] = field(default_factory=list)
     exercises_matched: list[tuple[str, str]] = field(default_factory=list)
     duplicate_of_recent: bool = False
     replaced: Optional[dict[str, int]] = None
@@ -351,19 +383,159 @@ def name_match_score(proposed: str, existing: str) -> float:
     return score
 
 
-def find_matching_exercise(
-    proposed: str,
-    existing_names: Iterable[str],
-    threshold: float = FUZZY_MATCH_THRESHOLD,
-) -> Optional[str]:
-    """Return the best existing name at/above `threshold`, else None."""
+def nearest_existing_exercise(
+    proposed: str, existing_names: Iterable[str]
+) -> tuple[Optional[str], float]:
+    """The closest existing name and its score, whatever that score is.
+
+    Split out from `find_matching_exercise` because the near-miss flag needs the
+    score precisely when it is too low to merge on.
+    """
     best_name: Optional[str] = None
     best_score = 0.0
     for candidate in existing_names:
         score = name_match_score(proposed, candidate)
         if score > best_score:
             best_name, best_score = candidate, score
+    return best_name, best_score
+
+
+def find_matching_exercise(
+    proposed: str,
+    existing_names: Iterable[str],
+    threshold: float = FUZZY_MATCH_THRESHOLD,
+) -> Optional[str]:
+    """Return the best existing name at/above `threshold`, else None."""
+    best_name, best_score = nearest_existing_exercise(proposed, existing_names)
     return best_name if best_score >= threshold else None
+
+
+def _content_tokens(name: str) -> list[str]:
+    """Sorted name tokens with equipment/muscle qualifiers removed.
+
+    Qualifiers are exactly what `name_match_score` already forgives, so they
+    must not be what makes a name look suspicious.
+    """
+    return sorted(
+        token for token in normalize_tokens(name)
+        if token not in _QUALIFIER_TOKENS_SINGULAR
+    )
+
+
+def _is_probable_typo(proposed: str, existing: str, per_token_ratio: float = 80.0) -> bool:
+    """True when two names differ by misspelling rather than by movement.
+
+    The distinction the near-miss flag lives or dies on. "Bech Press" against
+    "Chest Bench Press" is a typo splitting one lift in two. "Incline Bench
+    Press" against "Chest Bench Press" is two different lifts that SHOULD be
+    separate rows - `QUALIFIER_TOKENS` already documents `incline` as marking a
+    genuinely different movement, so flagging it would contradict the matcher.
+
+    Tokens shared exactly are paired off, then what is left is matched up by
+    character similarity - that pairing is the misspelling. Only tokens that
+    find no partner at all are allowed to be qualifiers, which is what lets
+    "Bech Press" pair against "Chest Bench Press" (the spare "chest" is an
+    equipment/muscle word) while "Incline Bench Press" does not (the spare
+    "incline" is not). Qualifiers are deliberately NOT stripped up front: doing
+    so deletes the partner a typo inside one ("Shoulderr Press") needs to be
+    compared against.
+    """
+    shared = Counter(normalize_tokens(proposed)) & Counter(normalize_tokens(existing))
+    leftover_left = sorted((Counter(normalize_tokens(proposed)) - shared).elements())
+    unpaired_right = sorted((Counter(normalize_tokens(existing)) - shared).elements())
+
+    unpaired_left: list[str] = []
+    paired = 0
+    for token in leftover_left:
+        best_index, best_score = None, per_token_ratio
+        for index, candidate in enumerate(unpaired_right):
+            score = fuzz.ratio(token, candidate)
+            if score >= best_score:
+                best_index, best_score = index, score
+        if best_index is None:
+            unpaired_left.append(token)
+        else:
+            unpaired_right.pop(best_index)
+            paired += 1
+
+    if paired == 0:
+        return False
+    # A leftover with no partner is only forgivable as an equipment/muscle word;
+    # anything else is a genuine variation and must not read as a misspelling.
+    return all(token in _QUALIFIER_TOKENS_SINGULAR
+               for token in unpaired_left + unpaired_right)
+
+
+def flag_exercise_name(
+    proposed: str,
+    existing_names: Iterable[str],
+    raw_span: Optional[str] = None,
+    raw_text: str = "",
+    near_miss_floor: float = NEAR_MISS_FLOOR,
+    merge_threshold: float = FUZZY_MATCH_THRESHOLD,
+    weak_grounding: float = WEAK_GROUNDING_SIMILARITY,
+) -> Optional["NameFlag"]:
+    """Amber-flag a newly created exercise name that does not look right.
+
+    Three checks, in descending order of how much damage the case does, and at
+    most one flag is returned so the report stays readable:
+
+      1. `near_miss`      - close to an existing exercise but under the merge
+                            threshold. A typo here splits one lift's history in
+                            two, and every later chart inherits the split.
+      2. `weak_grounding` - the name is poorly supported by the text it was
+                            read from, i.e. the model may have tidied it into
+                            something that was never written.
+      3. `unrecognized`   - no muscle-group table, muscle word or movement verb
+                            knows this name. Either genuinely niche, or wrong.
+
+    Returns None when the name looks ordinary. Pure: no database, no network.
+    """
+    nearest, score = nearest_existing_exercise(proposed, existing_names)
+    if (nearest is not None
+            and near_miss_floor <= score < merge_threshold
+            and _is_probable_typo(proposed, nearest)):
+        return NameFlag(
+            exercise_name=proposed,
+            reason="near_miss",
+            detail=(f"close to existing {nearest!r} (score {score:.0f}, merge needs "
+                    f"{merge_threshold:.0f}) - if these are the same lift, the history "
+                    f"is now split across two exercises"),
+            nearest_name=nearest,
+            score=score,
+        )
+
+    # Same haystack rule `compute_confidence` uses: the span if the model gave
+    # one, otherwise the whole entry.
+    haystack = (raw_span or "").strip() or (raw_text or "")
+    if haystack:
+        # Take the better of the full name and the name stripped of qualifiers:
+        # the model routinely adds "Barbell"/"Dumbbell" to a name the text wrote
+        # bare, and that is normalization, not invention.
+        similarity = max(
+            _grounding_similarity(proposed, haystack),
+            _grounding_similarity(" ".join(_content_tokens(proposed)), haystack),
+        )
+        if similarity < weak_grounding:
+            return NameFlag(
+                exercise_name=proposed,
+                reason="weak_grounding",
+                detail=(f"only {similarity:.0%} similar to the text it was read from "
+                        f"({haystack.strip()[:60]!r}) - check the name was actually "
+                        f"written, not inferred"),
+                score=similarity,
+            )
+
+    if resolve_muscle_group(proposed) is None:
+        return NameFlag(
+            exercise_name=proposed,
+            reason="unrecognized",
+            detail=("no muscle group, muscle word or movement verb recognized - either "
+                    "a niche movement worth adding to muscle_groups.py, or not an "
+                    "exercise name at all"),
+        )
+
+    return None
 
 
 def compute_confidence(
@@ -1194,6 +1366,23 @@ def process_entry(
             )
             if created:
                 result.exercises_created.append(workout_set.exercise_name)
+                # Flag against everything known EXCEPT the row just inserted -
+                # `get_or_create_exercise` has already added it to `known`, and a
+                # name always scores 100 against itself. Names created earlier in
+                # this same entry stay in scope, so a typo of a lift first logged
+                # two sets ago is still caught.
+                flag = flag_exercise_name(
+                    workout_set.exercise_name,
+                    [name for name in known if name != workout_set.exercise_name],
+                    workout_set.raw_span,
+                    raw_text,
+                )
+                if flag is not None:
+                    result.name_flags.append(flag)
+                    logger.info(
+                        "event=name_flagged exercise=%r reason=%s",
+                        workout_set.exercise_name, flag.reason,
+                    )
             elif matched_name and matched_name != workout_set.exercise_name:
                 result.exercises_matched.append((workout_set.exercise_name, matched_name))
 

--- a/review.py
+++ b/review.py
@@ -60,6 +60,7 @@ body { max-width: 60rem; }
          padding: .6rem .8rem .8rem; margin: .7rem 0; }
 .draft.flagged { border-left-color: #dc2626; }
 .draft.dropped { opacity: .55; }
+.draft.blank { border-style: dashed; }
 .draft-head { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
               margin-bottom: .5rem; }
 .draft-head .name { font-weight: 600; }
@@ -68,6 +69,7 @@ body { max-width: 60rem; }
 .save-toggle input { width: 1.05rem; height: 1.05rem; margin: 0; accent-color: #2563eb; }
 .chip { font-size: .78rem; padding: .1rem .45rem; border-radius: 1rem;
         border: 1px solid #8886; opacity: .85; }
+.chip.chip-bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
 .chip.bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
 .chip.edited { border-color: #2563eb; color: #2563eb; opacity: 1; }
 .draft-grid { display: grid; gap: .5rem .6rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -94,7 +96,8 @@ body { max-width: 60rem; }
 .evidence { margin: .5rem 0 0; font-size: .82rem; opacity: .65; }
 .actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-top: 1.2rem; }
 .actions button { margin-top: 0; width: auto; padding: .7rem 1.4rem; }
-.actions button[disabled] { background: #8886; cursor: not-allowed; }
+.actions button.secondary { background: transparent; color: inherit; border: 1px solid #8886; }
+.actions button.secondary:active { background: #8882; }
 details.entry summary { cursor: pointer; font-weight: 600; }
 details.entry pre { margin: .6rem 0 0; font-size: .9rem; opacity: .85; }
 """
@@ -169,9 +172,11 @@ def _row_card(
         # "confidence 0.00" on a row that never validated says nothing useful.
         chips.append('<span class="chip bad">cannot be saved yet</span>')
     elif row.confidence is not None:
-        bad = " bad" if row.confidence < confidence_threshold else ""
+        bad = " chip-bad" if row.confidence < confidence_threshold else ""
         chips.append(f'<span class="chip{bad}">confidence {row.confidence:.2f}</span>')
-    if row.edited:
+    if row.added:
+        chips.append('<span class="chip edited">typed in by you</span>')
+    elif row.edited:
         chips.append('<span class="chip edited">edited</span>')
 
     grid = "".join(
@@ -198,14 +203,27 @@ def _row_card(
     if span:
         evidence = f'<p class="evidence">Read from: &ldquo;{html.escape(span)}&rdquo;</p>'
 
+    if row.blank:
+        problems = (
+            '<p class="evidence">Fill this in to add something the parser missed. '
+            "Left empty, it is ignored.</p>"
+        )
+
     hidden = (
         f'<input type="hidden" name="{html.escape(prefix)}.raw_span" '
         f'value="{html.escape(display_value(row.values.get("raw_span")))}">'
         f'<input type="hidden" name="{html.escape(prefix)}.origin" '
         f'value="{html.escape(_origin_blob(row, columns))}">'
+        + (f'<input type="hidden" name="{html.escape(prefix)}.added" value="1">'
+           if row.added else "")
     )
 
-    classes = "draft" + (" flagged" if row.flagged else "") + ("" if row.include else " dropped")
+    classes = (
+        "draft"
+        + (" flagged" if row.flagged else "")
+        + (" blank" if row.blank else "")
+        + ("" if row.include else " dropped")
+    )
     return (
         f'<div class="{classes}">'
         f'<div class="draft-head">'
@@ -216,6 +234,29 @@ def _row_card(
         f"{flags}{problems}{evidence}{hidden}"
         f"</div>"
     )
+
+
+def _add_buttons(draft: EntryDraft, standalone: bool = True) -> str:
+    """Submit buttons that re-render the form with one more empty slot.
+
+    Adding a row is a round trip rather than a script: the form already carries
+    the whole draft, so the server can hand back the same state plus a slot, and
+    the page stays JavaScript-free like the rest of the app.
+
+    Save comes first in the markup on the full form, because pressing Enter in a
+    text field submits via the first button — and that should save, not add.
+    """
+    buttons = [
+        '<button type="submit" class="secondary" name="action" value="add_set">'
+        "Add a set</button>"
+    ]
+    if draft.bodyweight is None:
+        buttons.append(
+            '<button type="submit" class="secondary" name="action" value="add_bodyweight">'
+            "Add bodyweight</button>"
+        )
+    joined = "".join(buttons)
+    return f'<div class="actions">{joined}</div>' if standalone else joined
 
 
 def _banner(draft: EntryDraft, existing: Optional[Mapping[str, int]]) -> str:
@@ -287,19 +328,21 @@ def render_review_body(
     )
 
     if draft.is_empty:
+        # A dead end otherwise: the parser found nothing, but the workout still
+        # happened, so the same add buttons are offered without any rows above them.
         return (
             "<h1>Nothing to save</h1>"
             '<div class="card err">No sets or bodyweight readings came back from '
-            "that entry.</div>"
+            "that entry. You can still enter them by hand.</div>"
             f"{_banner(draft, existing)}{entry}"
-            '<p><a href="/">Back</a></p>'
+            f'<form method="post" action="/save">{hidden}{_add_buttons(draft)}</form>'
         )
 
     cards = "".join(
         _row_card(
             row,
             f"s{index}",
-            f"Set {index + 1}",
+            "New set" if row.blank else f"Set {index + 1}",
             SET_FIELDS,
             pipeline.SET_COLUMNS,
             SET_CHECKBOXES,
@@ -313,7 +356,7 @@ def render_review_body(
         bodyweight = "<h2>Bodyweight</h2>" + _row_card(
             draft.bodyweight,
             "bw",
-            "Bodyweight",
+            "New bodyweight reading" if draft.bodyweight.blank else "Bodyweight",
             BODYWEIGHT_FIELDS,
             pipeline.BODYWEIGHT_COLUMNS,
             (),
@@ -322,7 +365,7 @@ def render_review_body(
 
     # The button label stays static: the page carries no JavaScript, so a count
     # baked in at render time would go stale the moment a box is unticked.
-    total = len(draft.rows)
+    total = len(draft.included)
 
     return f"""
 <h1>Check before saving</h1>
@@ -333,14 +376,16 @@ untick anything that should not be saved, then save. Nothing has been stored yet
 {entry}
 <form method="post" action="/save">
 {hidden}
-<h2>Sets ({len(draft.sets)})</h2>
+<h2>Sets ({sum(1 for row in draft.sets if not row.blank)})</h2>
 {cards}
 {bodyweight}
 <div class="actions">
-  <button type="submit">Save to database</button>
+  <button type="submit" name="action" value="save">Save to database</button>
+  {_add_buttons(draft, standalone=False)}
   <a href="/">Discard and start over</a>
 </div>
-<p class="muted">{total} row(s) drafted. Only the ticked ones are saved.</p>
+<p class="muted">{total} row(s) drafted. Only the ticked ones are saved; an empty
+slot is ignored.</p>
 </form>
 """
 
@@ -424,7 +469,11 @@ def draft_from_form(
         prefix = f"s{index}"
         values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
         row = pipeline.draft_set_row(
-            values, raw_text, confidence_threshold, edited=_was_edited(form, prefix, values)
+            values,
+            raw_text,
+            confidence_threshold,
+            edited=_was_edited(form, prefix, values),
+            added=f"{prefix}.added" in form,
         )
         row.include = f"{prefix}.include" in form
         draft.sets.append(row)
@@ -432,9 +481,28 @@ def draft_from_form(
     if str(form.get("has_bodyweight", "")).strip():
         values = _row_values(form, "bw", pipeline.BODYWEIGHT_COLUMNS, ())
         row = pipeline.draft_bodyweight_row(
-            values, raw_text, confidence_threshold, edited=_was_edited(form, "bw", values)
+            values,
+            raw_text,
+            confidence_threshold,
+            edited=_was_edited(form, "bw", values),
+            added="bw.added" in form,
         )
         row.include = "bw.include" in form
         draft.bodyweight = row
 
     return draft
+
+
+def add_row(draft: EntryDraft, action: str) -> bool:
+    """Give the draft one more empty slot. True when `action` asked for one.
+
+    Adding never validates or saves — the user may well be part way through
+    fixing something else on the same form.
+    """
+    if action == "add_set":
+        draft.sets.append(pipeline.blank_set_row())
+        return True
+    if action == "add_bodyweight" and draft.bodyweight is None:
+        draft.bodyweight = pipeline.blank_bodyweight_row()
+        return True
+    return False

--- a/review.py
+++ b/review.py
@@ -1,0 +1,440 @@
+"""The review screen: what the extraction produced, before any of it is saved.
+
+The web app never inserts straight from an extraction. It builds a draft
+(`pipeline.build_draft`), renders it here as an editable form showing every
+prospective database row, and only writes what comes back from that form
+(`pipeline.commit_draft`). Anything missing, ungrounded or outright invalid is
+marked in red, so a bad reading is corrected in place rather than discovered
+weeks later in a chart.
+
+This module owns the two halves of that round trip:
+    render_review_body()  draft  -> HTML form
+    draft_from_form()     posted -> draft, rescored against the edited values
+
+Nothing here talks to the database or the model. Every dynamic value is escaped
+before it reaches the page: exercise names come from LLM output, so escaping is
+a correctness concern here, not a formality.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence
+
+import pipeline
+from pipeline import CONFIDENCE_THRESHOLD, DraftRow, EntryDraft
+
+# Column -> (label, css class, input mode). The order is the order the fields
+# are laid out in; the grid classes decide how many columns each one spans.
+SET_FIELDS: Sequence[tuple[str, str, str, str]] = (
+    ("exercise_name", "Exercise", "n2 w2", "text"),
+    ("weight_kg", "Weight (kg)", "", "decimal"),
+    ("reps", "Reps", "", "numeric"),
+    ("cheat_reps", "Cheat reps", "", "numeric"),
+    ("set_number", "Set #", "", "numeric"),
+    ("logged_at_local", "Time", "", "text"),
+    ("muscle_group", "Muscle group", "w2", "text"),
+    ("notes", "Notes", "n2 w3", "text"),
+)
+
+BODYWEIGHT_FIELDS: Sequence[tuple[str, str, str, str]] = (
+    ("weight_kg", "Weight (kg)", "", "decimal"),
+    ("body_fat_pct", "Body fat %", "", "decimal"),
+    ("logged_at_local", "Time", "", "text"),
+    ("notes", "Notes", "n2 w3", "text"),
+)
+
+SET_CHECKBOXES: Sequence[tuple[str, str]] = (
+    ("is_warmup", "Warm-up"),
+    ("is_dropset", "Drop set"),
+    ("pain_flag", "Pain"),
+)
+
+REVIEW_CSS = """
+/* The review grid needs more room than the entry form, which is sized for a
+   phone held in one hand. Overrides the base rule by coming later in the sheet. */
+body { max-width: 60rem; }
+.draft { border: 1px solid #8884; border-left: 4px solid #8884; border-radius: .6rem;
+         padding: .6rem .8rem .8rem; margin: .7rem 0; }
+.draft.flagged { border-left-color: #dc2626; }
+.draft.dropped { opacity: .55; }
+.draft-head { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
+              margin-bottom: .5rem; }
+.draft-head .name { font-weight: 600; }
+.save-toggle { display: inline-flex; align-items: center; gap: .35rem; font-weight: 600;
+               margin: 0; white-space: nowrap; }
+.save-toggle input { width: 1.05rem; height: 1.05rem; margin: 0; accent-color: #2563eb; }
+.chip { font-size: .78rem; padding: .1rem .45rem; border-radius: 1rem;
+        border: 1px solid #8886; opacity: .85; }
+.chip.bad { border-color: #dc2626; color: #dc2626; opacity: 1; }
+.chip.edited { border-color: #2563eb; color: #2563eb; opacity: 1; }
+.draft-grid { display: grid; gap: .5rem .6rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.field { min-width: 0; }
+.field.n2 { grid-column: span 2; }
+.field label { font-size: .78rem; font-weight: 600; opacity: .8; margin: 0 0 .15rem; }
+.field input[type=text] { width: 100%; font-size: 1rem; padding: .45rem .5rem;
+        border-radius: .4rem; border: 1px solid #8884; font-family: inherit;
+        background: transparent; color: inherit; }
+.field input.bad { border-color: #dc2626; background: rgba(220, 38, 38, .1); }
+.field input:focus { outline: 2px solid #2563eb; outline-offset: -1px; }
+@media (min-width: 34rem) {
+  .draft-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .field.n2 { grid-column: span 1; }
+  .field.w2 { grid-column: span 2; }
+  .field.w3 { grid-column: span 3; }
+}
+.flags { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: .55rem; }
+.flags label { display: inline-flex; align-items: center; gap: .35rem; font-weight: 400;
+               font-size: .9rem; margin: 0; }
+.flags input { width: 1rem; height: 1rem; margin: 0; }
+.problems { margin: .55rem 0 0; padding-left: 1.1rem; color: #dc2626; font-size: .88rem; }
+.problems li { margin: .15rem 0; }
+.evidence { margin: .5rem 0 0; font-size: .82rem; opacity: .65; }
+.actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-top: 1.2rem; }
+.actions button { margin-top: 0; width: auto; padding: .7rem 1.4rem; }
+.actions button[disabled] { background: #8886; cursor: not-allowed; }
+details.entry summary { cursor: pointer; font-weight: 600; }
+details.entry pre { margin: .6rem 0 0; font-size: .9rem; opacity: .85; }
+"""
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+def display_value(value: Any) -> str:
+    """A field value as it should appear in a text input.
+
+    `%g` on floats so a weight the model returned as 28.0 shows as "28" — the
+    round trip has to look like what the user wrote, or every row reads as edited.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "yes" if value else ""
+    if isinstance(value, float):
+        return f"{value:g}"
+    return str(value)
+
+
+def _origin_blob(row: DraftRow, columns: Sequence[str]) -> str:
+    """The values as extracted, in submitted form, so edits can be detected later."""
+    snapshot: dict[str, Any] = {}
+    for column in columns:
+        value = row.values.get(column)
+        snapshot[column] = value if isinstance(value, bool) else display_value(value)
+    return json.dumps(snapshot, separators=(",", ":"), sort_keys=True)
+
+
+PLACEHOLDERS = {"logged_at_local": "HH:MM"}
+
+
+def _text_field(prefix: str, column: str, label: str, css: str, mode: str, row: DraftRow) -> str:
+    field_id = f"{prefix}.{column}"
+    classes = "bad" if row.issues_for(column) else ""
+    placeholder = PLACEHOLDERS.get(column, "")
+    return (
+        f'<div class="field {css}">'
+        f'<label for="{html.escape(field_id)}">{html.escape(label)}</label>'
+        f'<input type="text" inputmode="{mode}" id="{html.escape(field_id)}" '
+        f'name="{html.escape(field_id)}" class="{classes}" autocomplete="off" '
+        f'placeholder="{html.escape(placeholder)}" '
+        f'value="{html.escape(display_value(row.values.get(column)))}">'
+        f"</div>"
+    )
+
+
+def _checkbox(name: str, label: str, checked: bool, css: str = "") -> str:
+    mark = " checked" if checked else ""
+    return (
+        f'<label class="{css}"><input type="checkbox" name="{html.escape(name)}"'
+        f"{mark}> {html.escape(label)}</label>"
+    )
+
+
+def _row_card(
+    row: DraftRow,
+    prefix: str,
+    title: str,
+    fields: Sequence[tuple[str, str, str, str]],
+    columns: Sequence[str],
+    checkboxes: Sequence[tuple[str, str]] = (),
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> str:
+    chips = []
+    if row.validation_error:
+        # "confidence 0.00" on a row that never validated says nothing useful.
+        chips.append('<span class="chip bad">cannot be saved yet</span>')
+    elif row.confidence is not None:
+        bad = " bad" if row.confidence < confidence_threshold else ""
+        chips.append(f'<span class="chip{bad}">confidence {row.confidence:.2f}</span>')
+    if row.edited:
+        chips.append('<span class="chip edited">edited</span>')
+
+    grid = "".join(
+        _text_field(prefix, column, label, css, mode, row)
+        for column, label, css, mode in fields
+    )
+
+    flags = ""
+    if checkboxes:
+        flags = '<div class="flags">' + "".join(
+            _checkbox(f"{prefix}.{column}", label, bool(row.values.get(column)))
+            for column, label in checkboxes
+        ) + "</div>"
+
+    problems = ""
+    messages = [issue.message for issue in row.issues]
+    if messages:
+        problems = '<ul class="problems">' + "".join(
+            f"<li>{html.escape(message)}</li>" for message in messages
+        ) + "</ul>"
+
+    evidence = ""
+    span = (row.values.get("raw_span") or "").strip()
+    if span:
+        evidence = f'<p class="evidence">Read from: &ldquo;{html.escape(span)}&rdquo;</p>'
+
+    hidden = (
+        f'<input type="hidden" name="{html.escape(prefix)}.raw_span" '
+        f'value="{html.escape(display_value(row.values.get("raw_span")))}">'
+        f'<input type="hidden" name="{html.escape(prefix)}.origin" '
+        f'value="{html.escape(_origin_blob(row, columns))}">'
+    )
+
+    classes = "draft" + (" flagged" if row.flagged else "") + ("" if row.include else " dropped")
+    return (
+        f'<div class="{classes}">'
+        f'<div class="draft-head">'
+        f'{_checkbox(f"{prefix}.include", "Save", row.include, css="save-toggle")}'
+        f'<span class="name">{html.escape(title)}</span>{"".join(chips)}'
+        f"</div>"
+        f'<div class="draft-grid">{grid}</div>'
+        f"{flags}{problems}{evidence}{hidden}"
+        f"</div>"
+    )
+
+
+def _banner(draft: EntryDraft, existing: Optional[Mapping[str, int]]) -> str:
+    parts: list[str] = []
+
+    flagged, blocked = draft.flagged_count, draft.blocked_count
+    if flagged:
+        detail = (
+            f" {blocked} of them cannot be saved until the red fields are fixed "
+            "or the row is unticked."
+            if blocked
+            else " Nothing stops you saving them — check them against your entry first."
+        )
+        parts.append(
+            f'<div class="card err"><strong>{flagged} row(s) marked in red.</strong>'
+            f"{html.escape(detail)}</div>"
+        )
+
+    if draft.replace_existing:
+        if existing and (existing["sets"] or existing["bodyweight"]):
+            parts.append(
+                '<div class="card warn"><strong>Replace mode.</strong> Saving first '
+                f"deletes the {existing['sets']} set(s) and {existing['bodyweight']} "
+                "bodyweight entry/entries already logged on "
+                f"{html.escape(draft.session_date.isoformat())}.</div>"
+            )
+        else:
+            parts.append(
+                '<div class="card warn"><strong>Replace mode.</strong> Nothing is '
+                f"logged on {html.escape(draft.session_date.isoformat())} yet, so "
+                "there is nothing to replace.</div>"
+            )
+    elif existing and (existing["sets"] or existing["bodyweight"]):
+        parts.append(
+            f'<div class="card muted">{existing["sets"]} set(s) are already logged on '
+            f"{html.escape(draft.session_date.isoformat())}. These will be added to them.</div>"
+        )
+
+    for item in draft.review_items:
+        parts.append(
+            '<div class="card err"><strong>Could not be read as a row.</strong> '
+            f"{html.escape(item.reason)} &mdash; this part of the entry cannot be "
+            "edited here and will not be saved.</div>"
+        )
+
+    return "".join(parts)
+
+
+def render_review_body(
+    draft: EntryDraft,
+    existing: Optional[Mapping[str, int]] = None,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> str:
+    """The review form: every prospective row, editable, before anything is written."""
+    hidden = (
+        f'<input type="hidden" name="raw_text" value="{html.escape(draft.raw_text)}">'
+        f'<input type="hidden" name="session_date" '
+        f'value="{html.escape(draft.session_date.isoformat())}">'
+        f'<input type="hidden" name="mode" '
+        f'value="{"replace" if draft.replace_existing else "add"}">'
+        f'<input type="hidden" name="set_count" value="{len(draft.sets)}">'
+        f'<input type="hidden" name="has_bodyweight" '
+        f'value="{"1" if draft.bodyweight is not None else ""}">'
+    )
+
+    entry = (
+        '<details class="card entry"><summary>Your entry</summary>'
+        f"<pre>{html.escape(draft.raw_text)}</pre></details>"
+    )
+
+    if draft.is_empty:
+        return (
+            "<h1>Nothing to save</h1>"
+            '<div class="card err">No sets or bodyweight readings came back from '
+            "that entry.</div>"
+            f"{_banner(draft, existing)}{entry}"
+            '<p><a href="/">Back</a></p>'
+        )
+
+    cards = "".join(
+        _row_card(
+            row,
+            f"s{index}",
+            f"Set {index + 1}",
+            SET_FIELDS,
+            pipeline.SET_COLUMNS,
+            SET_CHECKBOXES,
+            confidence_threshold,
+        )
+        for index, row in enumerate(draft.sets)
+    )
+
+    bodyweight = ""
+    if draft.bodyweight is not None:
+        bodyweight = "<h2>Bodyweight</h2>" + _row_card(
+            draft.bodyweight,
+            "bw",
+            "Bodyweight",
+            BODYWEIGHT_FIELDS,
+            pipeline.BODYWEIGHT_COLUMNS,
+            (),
+            confidence_threshold,
+        )
+
+    # The button label stays static: the page carries no JavaScript, so a count
+    # baked in at render time would go stale the moment a box is unticked.
+    total = len(draft.rows)
+
+    return f"""
+<h1>Check before saving</h1>
+<p class="muted">This is exactly what will be written to the database for
+{html.escape(draft.session_date.isoformat())}. Correct anything that is wrong,
+untick anything that should not be saved, then save. Nothing has been stored yet.</p>
+{_banner(draft, existing)}
+{entry}
+<form method="post" action="/save">
+{hidden}
+<h2>Sets ({len(draft.sets)})</h2>
+{cards}
+{bodyweight}
+<div class="actions">
+  <button type="submit">Save to database</button>
+  <a href="/">Discard and start over</a>
+</div>
+<p class="muted">{total} row(s) drafted. Only the ticked ones are saved.</p>
+</form>
+"""
+
+
+# --------------------------------------------------------------------------
+# Reading the form back
+# --------------------------------------------------------------------------
+
+
+def _coerce(value: str) -> Optional[str]:
+    """Form strings back into field values, leaving bad input for the model to reject.
+
+    Nothing is repaired here: "twelve" in the reps box stays "twelve" so Pydantic
+    can fail on it and the field comes back red, rather than being silently
+    dropped to null. A blank box becomes None, which `pipeline._pick` resolves to
+    that column's default.
+    """
+    return (value or "").strip() or None
+
+
+def _row_values(
+    form: Mapping[str, Any],
+    prefix: str,
+    columns: Sequence[str],
+    checkboxes: Sequence[str],
+) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for column in columns:
+        if column in checkboxes:
+            # An unticked checkbox is simply absent from the submission.
+            values[column] = f"{prefix}.{column}" in form
+        else:
+            values[column] = _coerce(str(form.get(f"{prefix}.{column}", "")))
+    return values
+
+
+def _was_edited(form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]) -> bool:
+    """True when a submitted value differs from what the extraction proposed.
+
+    Compared in submitted form — display strings and booleans — so a float that
+    round-tripped through the input does not read as a change.
+    """
+    try:
+        origin = json.loads(str(form.get(f"{prefix}.origin", "")))
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(origin, dict):
+        return False
+    return any(
+        origin.get(column) != (value if isinstance(value, bool) else display_value(value))
+        for column, value in values.items()
+    )
+
+
+def draft_from_form(
+    form: Mapping[str, Any],
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
+) -> EntryDraft:
+    """Rebuild a draft from a submitted review form, rescored against the edits.
+
+    Every row is validated again from scratch, so a field the user fixed loses
+    its red mark and a field they broke gains one. Raises ValueError if the
+    round-tripped session date is unusable.
+    """
+    raw_text = str(form.get("raw_text", "")).strip()
+    session_date = datetime.strptime(str(form.get("session_date", "")).strip(), "%Y-%m-%d").date()
+
+    try:
+        set_count = int(str(form.get("set_count", "0")).strip() or 0)
+    except ValueError:
+        set_count = 0
+
+    draft = EntryDraft(
+        raw_text=raw_text,
+        session_date=session_date,
+        replace_existing=str(form.get("mode", "add")) == "replace",
+    )
+
+    checkbox_columns = [column for column, _ in SET_CHECKBOXES]
+    for index in range(max(0, set_count)):
+        prefix = f"s{index}"
+        values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
+        row = pipeline.draft_set_row(
+            values, raw_text, confidence_threshold, edited=_was_edited(form, prefix, values)
+        )
+        row.include = f"{prefix}.include" in form
+        draft.sets.append(row)
+
+    if str(form.get("has_bodyweight", "")).strip():
+        values = _row_values(form, "bw", pipeline.BODYWEIGHT_COLUMNS, ())
+        row = pipeline.draft_bodyweight_row(
+            values, raw_text, confidence_threshold, edited=_was_edited(form, "bw", values)
+        )
+        row.include = "bw.include" in form
+        draft.bodyweight = row
+
+    return draft

--- a/review.py
+++ b/review.py
@@ -23,6 +23,7 @@ import json
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
+import muscle_groups
 import pipeline
 from pipeline import CONFIDENCE_THRESHOLD, DraftRow, EntryDraft
 
@@ -134,18 +135,28 @@ def _origin_blob(row: DraftRow, columns: Sequence[str]) -> str:
 
 PLACEHOLDERS = {"logged_at_local": "HH:MM"}
 
+# Columns offered as a pick list. `<datalist>` suggests without restricting, so
+# a group the table does not know can still be typed in — it just gets flagged.
+DATALISTS = {"muscle_group": "muscle-groups"}
+
+MUSCLE_GROUP_OPTIONS = '<datalist id="muscle-groups">' + "".join(
+    f'<option value="{html.escape(group)}">' for group in muscle_groups.CANONICAL_GROUPS
+) + "</datalist>"
+
 
 def _text_field(prefix: str, column: str, label: str, css: str, mode: str, row: DraftRow) -> str:
     field_id = f"{prefix}.{column}"
     classes = "bad" if row.issues_for(column) else ""
     placeholder = PLACEHOLDERS.get(column, "")
+    listed = DATALISTS.get(column)
     return (
         f'<div class="field {css}">'
         f'<label for="{html.escape(field_id)}">{html.escape(label)}</label>'
         f'<input type="text" inputmode="{mode}" id="{html.escape(field_id)}" '
         f'name="{html.escape(field_id)}" class="{classes}" autocomplete="off" '
         f'placeholder="{html.escape(placeholder)}" '
-        f'value="{html.escape(display_value(row.values.get(column)))}">'
+        + (f'list="{html.escape(listed)}" ' if listed else "")
+        + f'value="{html.escape(display_value(row.values.get(column)))}">'
         f"</div>"
     )
 
@@ -371,11 +382,13 @@ def render_review_body(
 <h1>Check before saving</h1>
 <p class="muted">This is exactly what will be written to the database for
 {html.escape(draft.session_date.isoformat())}. Correct anything that is wrong,
-untick anything that should not be saved, then save. Nothing has been stored yet.</p>
+untick anything that should not be saved, then save. Nothing has been stored yet.
+Muscle group is suggested from the exercise name, not read from your entry &mdash;
+correcting one re-files that exercise for good.</p>
 {_banner(draft, existing)}
 {entry}
 <form method="post" action="/save">
-{hidden}
+{hidden}{MUSCLE_GROUP_OPTIONS}
 <h2>Sets ({sum(1 for row in draft.sets if not row.blank)})</h2>
 {cards}
 {bodyweight}
@@ -422,27 +435,33 @@ def _row_values(
     return values
 
 
-def _was_edited(form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]) -> bool:
-    """True when a submitted value differs from what the extraction proposed.
+def _edited_fields(
+    form: Mapping[str, Any], prefix: str, values: Mapping[str, Any]
+) -> frozenset[str]:
+    """Which submitted values differ from what was put on the screen.
 
     Compared in submitted form — display strings and booleans — so a float that
-    round-tripped through the input does not read as a change.
+    round-tripped through the input does not read as a change. Per column rather
+    than per row because the muscle group needs it: one the user chose may
+    overwrite what an exercise is filed under, one the app suggested must not.
     """
     try:
         origin = json.loads(str(form.get(f"{prefix}.origin", "")))
     except (TypeError, ValueError):
-        return False
+        return frozenset()
     if not isinstance(origin, dict):
-        return False
-    return any(
-        origin.get(column) != (value if isinstance(value, bool) else display_value(value))
+        return frozenset()
+    return frozenset(
+        column
         for column, value in values.items()
+        if origin.get(column) != (value if isinstance(value, bool) else display_value(value))
     )
 
 
 def draft_from_form(
     form: Mapping[str, Any],
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    known_groups: Optional[Mapping[str, Optional[str]]] = None,
 ) -> EntryDraft:
     """Rebuild a draft from a submitted review form, rescored against the edits.
 
@@ -468,12 +487,16 @@ def draft_from_form(
     for index in range(max(0, set_count)):
         prefix = f"s{index}"
         values = _row_values(form, prefix, pipeline.SET_COLUMNS, checkbox_columns)
+        changed = _edited_fields(form, prefix, values)
         row = pipeline.draft_set_row(
             values,
             raw_text,
             confidence_threshold,
-            edited=_was_edited(form, prefix, values),
+            edited=bool(changed),
             added=f"{prefix}.added" in form,
+            edited_fields=changed,
+            known_groups=known_groups,
+            resuggest_muscle_group=True,
         )
         row.include = f"{prefix}.include" in form
         draft.sets.append(row)
@@ -484,7 +507,7 @@ def draft_from_form(
             values,
             raw_text,
             confidence_threshold,
-            edited=_was_edited(form, "bw", values),
+            edited=bool(_edited_fields(form, "bw", values)),
             added="bw.added" in form,
         )
         row.include = "bw.include" in form

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import date, timedelta
+from itertools import groupby
 
 import pytest
 
@@ -109,17 +110,66 @@ class TestPainSummary:
         assert pain_summary(records)[0]["exercise"] == "Lat Pulldown"
 
 
+class TestE1rmMuscleGrouping:
+    """The chart answers "is my chest progressing", so the exercises of one
+    muscle group have to sit together — but as their own series. See
+    `exercise_e1rm_by_muscle_group` for why they are not averaged into one."""
+
+    def _mixed(self):
+        days = [MONDAY, MONDAY + timedelta(days=2), MONDAY + timedelta(days=4)]
+        records = []
+        for day in days:
+            records += sets_for("Bench", day, 60, [10, 10], muscle="Chest")
+            records += sets_for("Row", day, 50, [10], muscle="Back")
+            records += sets_for("Fly", day, 15, [12], muscle="Chest")
+            records += sets_for("High to Low", day, 16, [12], muscle=None)
+        return records
+
+    def test_each_series_is_labelled_with_its_group(self):
+        grouped = insights.exercise_e1rm_by_muscle_group(self._mixed())
+        assert {name: group for group, name, _ in grouped} == {
+            "Bench": "Chest", "Fly": "Chest", "Row": "Back", "High to Low": "Unassigned"}
+
+    def test_a_group_appears_as_one_run_not_several(self):
+        groups = [group for group, _, _ in insights.exercise_e1rm_by_muscle_group(self._mixed())]
+        runs = [group for group, _ in groupby(groups)]
+        assert len(runs) == len(set(runs))
+
+    def test_an_exercise_with_no_group_falls_under_the_shared_label(self):
+        grouped = insights.exercise_e1rm_by_muscle_group(self._mixed())
+        assert ("Unassigned", "High to Low") in [(g, n) for g, n, _ in grouped]
+
+    def test_unassigned_sorts_last_so_it_does_not_split_the_rest(self):
+        groups = [group for group, _, _ in insights.exercise_e1rm_by_muscle_group(self._mixed())]
+        assert groups[-1] == insights.UNASSIGNED_GROUP
+
+    def test_the_series_themselves_are_unchanged_by_grouping(self):
+        records = self._mixed()
+        flat = dict(insights.exercise_e1rm_series(records))
+        grouped = {name: points for _, name, points in
+                   insights.exercise_e1rm_by_muscle_group(records)}
+        assert grouped == flat
+
+    def test_which_exercises_appear_is_still_decided_by_training_volume(self):
+        """Grouping must not start reserving slots per muscle group."""
+        records = self._mixed()
+        assert ([name for name, _ in insights.exercise_e1rm_series(records, limit=2)]
+                == sorted(name for _, name, _ in
+                          insights.exercise_e1rm_by_muscle_group(records, limit=2)))
+
+
 class TestRendering:
-    def _data(self, exercise="Bench Press"):
+    def _data(self, exercise="Bench Press", series=None):
         return {
             "week_start": MONDAY.isoformat(), "weeks": 12, "timezone": "Asia/Karachi",
             "kpis": {"volume_this_week": 7139.0, "volume_delta_pct": 1.0,
                      "sets_this_week": 15, "exercises_this_week": 5,
                      "bodyweight": 82.4, "bodyweight_delta": -0.7},
             "weekly_volume": [[MONDAY.isoformat(), 7139.0]],
-            "exercise_e1rm": [{"exercise": exercise,
-                               "points": [[MONDAY.isoformat(), 80.0],
-                                          [(MONDAY + timedelta(7)).isoformat(), 82.0]]}],
+            "exercise_e1rm": series or [
+                {"exercise": exercise, "muscle_group": "Chest",
+                 "points": [[MONDAY.isoformat(), 80.0],
+                            [(MONDAY + timedelta(7)).isoformat(), 82.0]]}],
             "bodyweight": [[MONDAY.isoformat(), 82.4]],
             "muscle_volume": [["Chest", 1269.0]],
             "pain": [{"exercise": exercise, "sessions_flagged": 1,
@@ -127,9 +177,49 @@ class TestRendering:
             "has_data": True,
         }
 
+    def _series(self, *pairs):
+        return [{"exercise": name, "muscle_group": group,
+                 "points": [[MONDAY.isoformat(), 80.0],
+                            [(MONDAY + timedelta(7)).isoformat(), 82.0]]}
+                for name, group in pairs]
+
+    def test_a_heading_is_drawn_for_each_muscle_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Row", "Back"))))
+        assert '<h3 class="section">Chest</h3>' in body
+        assert '<h3 class="section">Back</h3>' in body
+
+    def test_one_heading_covers_a_whole_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"), ("Fly", "Chest"))))
+        assert body.count('<h3 class="section">Chest</h3>') == 1
+
+    def test_a_missing_group_is_labelled_rather_than_left_blank(self):
+        body = charts.render_progress_body(self._data(series=self._series(("Bench", None))))
+        assert f'<h3 class="section">{insights.UNASSIGNED_GROUP}</h3>' in body
+
+    def test_a_group_name_is_escaped(self):
+        """It reaches the page from the review form, so it is user text."""
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "</h3><script>alert(1)</script>"))))
+        assert "<script>alert(1)</script>" not in body.split("</script>", 1)[1]
+
+    def test_the_table_view_names_the_group(self):
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"))))
+        assert ">Muscle group</th>" in body
+
+    def test_only_the_e1rm_number_is_right_aligned(self):
+        """Three label columns lead this table, not one."""
+        body = charts.render_progress_body(
+            self._data(series=self._series(("Bench", "Chest"))))
+        header = body.split(">Muscle group</th>")[0].rsplit("<th", 1)[1]
+        assert "num" not in header
+        assert '<th class="num">e1RM (kg)</th>' in body
+
     def test_renders_the_expected_cards(self):
         body = charts.render_progress_body(self._data())
-        for heading in ("Weekly volume", "Estimated 1RM by exercise", "Bodyweight",
+        for heading in ("Weekly volume", "Estimated 1RM by muscle group", "Bodyweight",
                         "Volume by muscle group", "Pain flags"):
             assert heading in body
 

--- a/tests/test_name_flags.py
+++ b/tests/test_name_flags.py
@@ -1,0 +1,215 @@
+"""Unit tests for the amber name flag.
+
+The flag exists to catch an exercise name that was SAVED but does not look
+right - a typo about to split one lift's history in two, a name the model may
+have inferred rather than read, or a movement nothing recognizes.
+
+The hard part is not detection, it is silence. A flag that fires on ordinary
+lifts gets ignored within a week and then the real ones are invisible too, so
+most of what follows asserts that nothing is flagged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline import (
+    FUZZY_MATCH_THRESHOLD,
+    NEAR_MISS_FLOOR,
+    _is_probable_typo,
+    find_matching_exercise,
+    flag_exercise_name,
+    nearest_existing_exercise,
+)
+
+EXISTING = ["Chest Bench Press", "Lat Pulldown", "Barbell Row", "Leg Press", "Lateral Raise"]
+
+
+def flag_for(name, span=None, existing=EXISTING):
+    """Flag a name as the pipeline would, reading it from its own raw span."""
+    span = span if span is not None else name.lower()
+    return flag_exercise_name(name, existing, span, span)
+
+
+# --------------------------------------------------------------------------
+# Silence on ordinary names
+# --------------------------------------------------------------------------
+
+
+class TestOrdinaryNamesAreNotFlagged:
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Squat", "squat 100kg 5 reps"),
+            ("Hip Thrust", "hip thrust 60kg 12"),
+            ("Cable Crossover", "some cable crossovers 15kg"),
+            ("Face Pull", "face pulls 20kg 15"),
+            ("Hammer Curl", "hammer curls 12.5kg each hand 10"),
+        ],
+    )
+    def test_common_new_lift_is_silent(self, name, span):
+        assert flag_for(name, span) is None
+
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Incline Bench Press", "incline bench press 30kg 8"),
+            ("Front Squat", "front squat 60kg 8"),
+            ("Romanian Deadlift", "romanian deadlift 70kg 10"),
+            ("Close Grip Bench Press", "close grip bench press 40kg 8"),
+        ],
+    )
+    def test_real_variation_is_not_a_typo(self, name, span):
+        """`incline`, `front`, `romanian` and `close grip` mark different lifts.
+
+        `QUALIFIER_TOKENS` documents these as blocking a fuzzy merge on purpose,
+        so calling one a probable typo of the lift it varies would contradict
+        the matcher and train the reader to ignore the flag.
+        """
+        assert flag_for(name, span) is None
+
+    def test_model_added_equipment_is_not_weak_grounding(self):
+        """"Barbell" in front of a name the text wrote bare is normalization.
+
+        The matcher already forgives equipment qualifiers, so the grounding
+        check has to forgive them too.
+        """
+        assert flag_for("Barbell Hack Squat", "hack squat 80kg 8") is None
+
+    def test_niche_but_placeable_is_silent(self):
+        """Unusual is fine when the name still resolves to a muscle group."""
+        assert flag_for("Jefferson Curl", "jefferson curl 20kg 10") is None
+
+
+# --------------------------------------------------------------------------
+# near_miss
+# --------------------------------------------------------------------------
+
+
+class TestNearMiss:
+    def test_typo_below_the_merge_threshold_is_flagged(self):
+        flag = flag_for("Bech Press", "bech press 40kg 8")
+        assert flag is not None
+        assert flag.reason == "near_miss"
+        assert flag.nearest_name == "Chest Bench Press"
+        assert NEAR_MISS_FLOOR <= flag.score < FUZZY_MATCH_THRESHOLD
+
+    def test_detail_names_the_exercise_it_nearly_matched(self):
+        """The name is the actionable part - without it there is nothing to do."""
+        assert "Chest Bench Press" in flag_for("Bech Press", "bech press 40kg 8").detail
+
+    @pytest.mark.parametrize("name", ["Lateral Rasie", "Leg Pres"])
+    def test_typo_the_matcher_already_absorbs_is_not_flagged(self, name):
+        """Scoring at/above the merge threshold means no new row was created.
+
+        The history never splits, so there is nothing to warn about - the
+        matcher has already done the job.
+        """
+        assert find_matching_exercise(name, EXISTING) is not None
+        _, score = nearest_existing_exercise(name, EXISTING)
+        assert score >= FUZZY_MATCH_THRESHOLD
+
+    def test_wildly_different_name_is_not_a_near_miss(self):
+        """Below the floor there is no reason to think two names are related."""
+        flag = flag_for("Zercher Carry", "zercher carry 60kg 30s")
+        assert flag.reason != "near_miss"
+
+
+class TestIsProbableTypo:
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Bech Press", "Chest Bench Press"),      # qualifier ignored on one side
+            ("Lateral Rasie", "Lateral Raise"),       # transposition
+            ("Shoulderr Press", "Shoulder Press"),
+        ],
+    )
+    def test_misspelling(self, proposed, existing):
+        assert _is_probable_typo(proposed, existing) is True
+
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Incline Bench Press", "Chest Bench Press"),   # extra content token
+            ("Front Squat", "Squat"),
+            ("Romanian Deadlift", "Deadlift"),
+            ("Leg Curl", "Leg Extension"),                  # different movement
+        ],
+    )
+    def test_variation_is_not_a_typo(self, proposed, existing):
+        assert _is_probable_typo(proposed, existing) is False
+
+    def test_identical_content_is_not_a_typo(self):
+        """Differing only by an equipment word is a match, not a misspelling."""
+        assert _is_probable_typo("Barbell Bench Press", "Bench Press") is False
+
+
+# --------------------------------------------------------------------------
+# weak_grounding
+# --------------------------------------------------------------------------
+
+
+class TestWeakGrounding:
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Seated Row Machine", "machine rows 40kg 10"),
+            ("Overhead Tricep Extension", "tricep thing overhead 15kg 12"),
+        ],
+    )
+    def test_name_loosely_supported_by_its_span_is_flagged(self, name, span):
+        flag = flag_for(name, span)
+        assert flag is not None and flag.reason == "weak_grounding"
+
+    def test_detail_quotes_the_text_it_was_read_from(self):
+        """Judging the flag means seeing what was actually written."""
+        flag = flag_for("Seated Row Machine", "machine rows 40kg 10")
+        assert "machine rows" in flag.detail
+
+    def test_name_copied_from_the_text_is_silent(self):
+        assert flag_for("Barbell Row", "barbell row 50kg 9") is None
+
+
+# --------------------------------------------------------------------------
+# unrecognized
+# --------------------------------------------------------------------------
+
+
+class TestUnrecognized:
+    @pytest.mark.parametrize("name", ["Zercher Carry", "Wibble Machine", "Thing Doer"])
+    def test_name_no_table_recognizes_is_flagged(self, name):
+        flag = flag_for(name)
+        assert flag is not None and flag.reason == "unrecognized"
+
+    def test_resolvable_name_is_silent(self):
+        assert flag_for("Kettlebell Swing", "kettlebell swings 24kg 20") is None
+
+
+# --------------------------------------------------------------------------
+# Precedence and shape
+# --------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_at_most_one_flag_per_name(self):
+        """One reason keeps the report readable; the list can get long."""
+        flag = flag_for("Bech Press", "bech press 40kg 8")
+        assert isinstance(flag.reason, str)
+
+    def test_near_miss_outranks_unrecognized(self):
+        """A split history is worse than an unplaceable name, so it reports first.
+
+        "Bech Press" is also unrecognized by the muscle tables, but the typo is
+        the thing worth acting on.
+        """
+        assert flag_for("Bech Press", "bech press 40kg 8").reason == "near_miss"
+
+    def test_flag_carries_the_name_it_describes(self):
+        assert flag_for("Wibble Machine").exercise_name == "Wibble Machine"
+
+    def test_no_existing_exercises_still_resolves(self):
+        """First ever entry: nothing to near-miss against, other checks still run."""
+        assert flag_exercise_name("Squat", [], "squat 100kg 5", "squat 100kg 5") is None
+        assert flag_exercise_name("Wibble", [], "wibble 10kg", "wibble 10kg").reason == (
+            "unrecognized"
+        )

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -188,7 +188,7 @@ class TestRendering:
         assert 'name="s0.reps" class=""' in page
 
     def test_the_issue_is_spelled_out_next_to_the_row(self):
-        assert "no rep count found" in review.render_review_body(draft_for())
+        assert "no rep count recorded" in review.render_review_body(draft_for())
 
     def test_a_row_that_cannot_be_saved_says_so_instead_of_showing_a_zero_score(self):
         payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
@@ -220,9 +220,19 @@ class TestRendering:
         page = review.render_review_body(draft, {"sets": 12, "bodyweight": 1})
         assert "deletes the 12 set(s)" in page
 
-    def test_an_empty_draft_offers_no_form(self):
+    def test_an_empty_draft_still_offers_a_way_in(self):
+        """The parser finding nothing does not mean the workout did not happen."""
         page = review.render_review_body(draft_for({"sets": [], "bodyweight": None}))
-        assert "Nothing to save" in page and "<form" not in page
+        assert "Nothing to save" in page and 'value="add_set"' in page
+
+    def test_save_is_the_first_button_so_enter_does_not_add_a_row(self):
+        page = review.render_review_body(draft_for())
+        assert page.index('value="save"') < page.index('value="add_set"')
+
+    def test_bodyweight_can_only_be_added_when_there_is_none(self):
+        assert 'value="add_bodyweight"' not in review.render_review_body(draft_for())
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        assert 'value="add_bodyweight"' in review.render_review_body(without)
 
 
 # --------------------------------------------------------------------------
@@ -335,6 +345,89 @@ class TestEditing:
         corrected = review.draft_from_form(form)
         again = review.draft_from_form(submitted(corrected))
         assert [row.values for row in again.sets] == [row.values for row in corrected.sets]
+
+
+class TestAddingRows:
+    """A set the parser missed entirely is typed in on the same form. Adding is a
+    round trip rather than a script, so the state has to survive the extra hop."""
+
+    def add(self, draft, action="add_set"):
+        returned = review.draft_from_form(submitted(draft))
+        assert review.add_row(returned, action)
+        return returned
+
+    def test_an_empty_slot_is_appended(self):
+        assert len(self.add(draft_for()).sets) == 4
+
+    def test_an_unknown_action_adds_nothing(self):
+        draft = draft_for()
+        assert not review.add_row(draft, "save") and len(draft.sets) == 3
+
+    def test_bodyweight_is_not_added_twice(self):
+        draft = draft_for()
+        assert not review.add_row(draft, "add_bodyweight")
+
+    def test_an_empty_slot_is_not_a_row(self):
+        draft = self.add(draft_for())
+        assert draft.sets[3].blank and len(draft.included) == 4
+
+    def test_an_empty_slot_does_not_block_the_save(self):
+        """A blank exercise name would otherwise fail validation on sight."""
+        draft = self.add(draft_for())
+        assert draft.ready and draft.flagged_count == 2
+
+    def test_an_empty_slot_survives_the_round_trip_still_empty(self):
+        draft = review.draft_from_form(submitted(self.add(draft_for())))
+        assert len(draft.sets) == 4 and draft.sets[3].blank
+
+    def test_filling_a_slot_in_makes_it_a_row(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        form["s3.weight_kg"] = "15"
+        form["s3.reps"] = "12"
+        row = review.draft_from_form(form).sets[3]
+        assert not row.blank and row.added and row.values["exercise_name"] == "Face Pull"
+
+    def test_a_typed_row_is_not_judged_on_grounding(self):
+        """It was never read out of the entry, so there is nothing to ground it in."""
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Bulgarian Split Squat"
+        form["s3.weight_kg"] = "20"
+        form["s3.reps"] = "10"
+        row = review.draft_from_form(form).sets[3]
+        assert row.issues == [] and row.confidence == 1.0
+
+    def test_a_typed_row_still_says_what_is_missing(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        assert review.draft_from_form(form).sets[3].issues_for("weight_kg")
+
+    def test_a_typed_row_is_still_validated(self):
+        form = submitted(self.add(draft_for()))
+        form["s3.exercise_name"] = "Face Pull"
+        form["s3.reps"] = "twelve"
+        returned = review.draft_from_form(form)
+        assert not returned.ready and returned.sets[3].issues_for("reps")
+
+    def test_a_typed_bodyweight_reading_survives(self):
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        form = submitted(self.add(without, "add_bodyweight"))
+        form["bw.weight_kg"] = "81.2"
+        row = review.draft_from_form(form).bodyweight
+        assert row.added and not row.blank and row.values["weight_kg"] == 81.2
+
+    def test_a_typed_bodyweight_reading_is_not_judged_on_grounding(self):
+        without = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        form = submitted(self.add(without, "add_bodyweight"))
+        form["bw.weight_kg"] = "81.2"
+        assert review.draft_from_form(form).bodyweight.issues == []
+
+    def test_an_empty_slot_reads_as_an_invitation_not_a_fault(self):
+        page = review.render_review_body(self.add(draft_for()))
+        assert "New set" in page and "cannot be saved yet" not in page
+
+    def test_an_empty_slot_is_not_counted_as_a_set(self):
+        assert "<h2>Sets (3)</h2>" in review.render_review_body(self.add(draft_for()))
 
 
 # --------------------------------------------------------------------------
@@ -460,6 +553,27 @@ class TestCommitting:
         draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
         result, _ = commit(draft)
         assert len(result.review_items) == 1
+
+    def test_an_empty_slot_is_neither_saved_nor_reported(self):
+        draft = draft_for()
+        draft.sets.append(pipeline.blank_set_row())
+        result, engine = commit(draft)
+        assert len(engine.inserted) == 4
+        assert result.skipped_sets == 0 and result.review_items == []
+
+    def test_an_empty_bodyweight_slot_is_ignored(self):
+        draft = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        draft.bodyweight = pipeline.blank_bodyweight_row()
+        result, _ = commit(draft)
+        assert result.inserted_bodyweight == 0 and result.skipped_bodyweight == 0
+
+    def test_a_typed_row_is_written(self):
+        draft = draft_for()
+        draft.sets.append(pipeline.draft_set_row(
+            {"exercise_name": "Face Pull", "weight_kg": 15, "reps": 12}, RAW_ENTRY, added=True))
+        result, engine = commit(draft)
+        assert result.inserted_sets == 4
+        assert engine.inserted[3]["extraction_confidence"] == 1.0
 
     def test_an_extraction_failure_writes_nothing(self):
         draft = pipeline.EntryDraft(RAW_ENTRY, SESSION, error="Extraction failed")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -110,11 +110,11 @@ class TestDraftBuilding:
 class TestFlagging:
     def test_missing_weight_is_flagged_on_its_own_field(self):
         row = draft_for().sets[2]
-        assert [issue.field for issue in row.issues] == ["weight_kg"]
+        assert "weight_kg" in [issue.field for issue in row.issues]
 
     def test_missing_reps_is_flagged_on_its_own_field(self):
         row = draft_for().sets[1]
-        assert [issue.field for issue in row.issues] == ["reps"]
+        assert "reps" in [issue.field for issue in row.issues]
 
     def test_missing_information_does_not_block_the_save(self):
         """A set with no recorded weight is still a set that happened."""
@@ -166,6 +166,93 @@ class TestBlockingIssues:
     def test_a_blank_name_blocks_rather_than_inserting_an_empty_exercise(self):
         payload = {"sets": [{"exercise_name": "   ", "weight_kg": 20, "reps": 10}]}
         assert draft_for(payload).sets[0].blocking
+
+
+class TestMuscleGroupSuggestion:
+    """The entry never mentions a muscle group and the extraction is not asked
+    for one, so it is suggested — which makes it exactly the kind of value that
+    has to be visible and correctable rather than decided off-screen."""
+
+    def test_a_recognised_name_is_filled_in(self):
+        assert draft_for().sets[0].values["muscle_group"] == "Chest"
+
+    def test_a_recognised_name_is_not_flagged(self):
+        assert draft_for().sets[0].issues_for("muscle_group") == []
+
+    def test_a_name_the_table_does_not_know_is_flagged(self):
+        """Left alone it becomes "Unassigned" in the volume chart, silently."""
+        row = draft_for().sets[1]
+        assert row.values["muscle_group"] is None
+        assert "Unassigned" in row.issues_for("muscle_group")[0].message
+
+    def test_an_unknown_group_does_not_block_the_save(self):
+        assert draft_for().ready
+
+    def test_what_the_exercise_is_already_filed_under_wins(self):
+        """`get_or_create_exercise` never revises a stored group on its own, so
+        offering a table answer that disagreed would be offering a lie."""
+        known = {"Chest Bench Press": "Shoulders"}
+        row = pipeline.draft_set_row(PAYLOAD["sets"][0], RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Shoulders"
+
+    def test_a_stored_group_is_found_through_a_reworded_name(self):
+        known = {"Chest Bench Press": "Chest"}
+        row = pipeline.draft_set_row(
+            {"exercise_name": "Barbell Chest Bench Press", "weight_kg": 28, "reps": 11},
+            RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Chest"
+
+    def test_a_stored_blank_falls_through_to_the_table(self):
+        known = {"Chest Bench Press": None}
+        row = pipeline.draft_set_row(PAYLOAD["sets"][0], RAW_ENTRY, known_groups=known)
+        assert row.values["muscle_group"] == "Chest"
+
+    def test_an_extracted_group_is_kept(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], muscle_group="Triceps")]}
+        assert draft_for(payload).sets[0].values["muscle_group"] == "Triceps"
+
+
+class TestMuscleGroupEditing:
+    def test_a_correction_is_taken(self):
+        form = submitted(draft_for())
+        form["s1.muscle_group"] = "Back"
+        row = review.draft_from_form(form).sets[1]
+        assert row.values["muscle_group"] == "Back" and row.issues_for("muscle_group") == []
+
+    def test_a_correction_is_recorded_as_chosen_by_the_user(self):
+        form = submitted(draft_for())
+        form["s1.muscle_group"] = "Back"
+        assert "muscle_group" in review.draft_from_form(form).sets[1].edited_fields
+
+    def test_a_suggestion_left_alone_is_not_chosen_by_the_user(self):
+        form = submitted(draft_for())
+        assert "muscle_group" not in review.draft_from_form(form).sets[0].edited_fields
+
+    def test_a_group_the_user_clears_is_not_suggested_again(self):
+        """Otherwise the box could never be emptied on purpose."""
+        form = submitted(draft_for())
+        form["s0.muscle_group"] = ""
+        row = review.draft_from_form(form).sets[0]
+        assert row.values["muscle_group"] is None
+        assert "muscle_group" in row.edited_fields
+
+    def test_renaming_the_exercise_reanswers_an_untouched_group(self):
+        """The old suggestion belongs to the old name."""
+        form = submitted(draft_for())
+        form["s0.exercise_name"] = "Preacher Curl"
+        assert review.draft_from_form(form).sets[0].values["muscle_group"] == "Biceps"
+
+    def test_a_non_standard_group_is_flagged_but_savable(self):
+        form = submitted(draft_for())
+        form["s0.muscle_group"] = "Pecs"
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].issues_for("muscle_group") and returned.ready
+
+    def test_the_standard_groups_are_offered_as_a_pick_list(self):
+        page = review.render_review_body(draft_for())
+        assert '<datalist id="muscle-groups">' in page
+        assert 'list="muscle-groups"' in page
+        assert '<option value="Glutes">' in page
 
 
 # --------------------------------------------------------------------------
@@ -282,7 +369,7 @@ class TestEditing:
     def test_correcting_a_field_clears_its_mark(self):
         form = submitted(draft_for())
         form["s1.reps"] = "9"
-        assert review.draft_from_form(form).sets[1].issues == []
+        assert review.draft_from_form(form).sets[1].issues_for("reps") == []
 
     def test_a_corrected_row_is_recorded_as_edited(self):
         form = submitted(draft_for())
@@ -396,6 +483,7 @@ class TestAddingRows:
         form["s3.reps"] = "10"
         row = review.draft_from_form(form).sets[3]
         assert row.issues == [] and row.confidence == 1.0
+        assert row.values["muscle_group"] == "Legs"
 
     def test_a_typed_row_still_says_what_is_missing(self):
         form = submitted(self.add(draft_for()))

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,488 @@
+"""Tests for the review screen: draft, edit, save.
+
+Nothing reaches the database from the web app without passing through here, so
+these cover the two ways that guarantee could fail quietly. One is the round
+trip: a row rendered into the form and posted straight back must come out
+identical, or an untouched entry silently changes on save. The other is the red
+marking: a row the database would reject has to block the save and say which
+field is wrong, otherwise the screen tells the user their entry is fine while
+dropping half of it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from html.parser import HTMLParser
+
+import pytest
+
+import pipeline
+import review
+from pipeline import CONFIDENCE_THRESHOLD
+
+SESSION = date(2026, 8, 22)
+
+RAW_ENTRY = (
+    "Chest bench press 28kg 11 reps almost died. Cable pulls 28kg. "
+    "External rotation 15 reps each side. Tricep pushdown. Was 82.4kg this morning."
+)
+
+PAYLOAD = {
+    "sets": [
+        {"exercise_name": "Chest Bench Press", "weight_kg": 28, "reps": 11,
+         "notes": "almost died", "raw_span": "Chest bench press 28kg 11 reps almost died"},
+        {"exercise_name": "Cable Pulls", "weight_kg": 28, "raw_span": "Cable pulls 28kg"},
+        {"exercise_name": "External Rotation", "reps": 15,
+         "raw_span": "External rotation 15 reps each side"},
+    ],
+    "bodyweight": {"weight_kg": 82.4, "raw_span": "Was 82.4kg this morning"},
+}
+
+
+def draft_for(payload=None, raw_text=RAW_ENTRY) -> pipeline.EntryDraft:
+    return pipeline.draft_from_payload(payload or PAYLOAD, raw_text, SESSION)
+
+
+class FormScraper(HTMLParser):
+    """Read a rendered review form back as the browser would submit it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: dict[str, str] = {}
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag != "input" or "name" not in attributes:
+            return
+        if attributes.get("type") == "checkbox":
+            # An unticked box is simply absent from the submission.
+            if "checked" in attributes:
+                self.data[attributes["name"]] = "on"
+        else:
+            self.data[attributes["name"]] = attributes.get("value", "")
+
+
+def submitted(draft: pipeline.EntryDraft) -> dict[str, str]:
+    scraper = FormScraper()
+    scraper.feed(review.render_review_body(draft))
+    return scraper.data
+
+
+# --------------------------------------------------------------------------
+# Building the draft
+# --------------------------------------------------------------------------
+
+
+class TestDraftBuilding:
+    def test_every_extracted_set_becomes_a_row(self):
+        assert len(draft_for().sets) == 3
+
+    def test_bodyweight_becomes_its_own_row(self):
+        assert draft_for().bodyweight.values["weight_kg"] == 82.4
+
+    def test_a_clean_row_is_not_flagged(self):
+        assert draft_for().sets[0].issues == []
+
+    def test_omitted_columns_fall_back_to_the_model_default(self):
+        """A missing cheat_reps means zero, not null — the column is NOT NULL."""
+        row = draft_for().sets[0]
+        assert row.values["cheat_reps"] == 0
+        assert row.values["is_warmup"] is False
+
+    def test_an_explicit_null_is_treated_as_omitted(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], cheat_reps=None, pain_flag=None)]}
+        row = draft_for(payload).sets[0]
+        assert row.values["cheat_reps"] == 0 and row.values["pain_flag"] is False
+
+    def test_values_are_coerced_to_what_will_be_stored(self):
+        assert draft_for().sets[0].values["weight_kg"] == 28.0
+
+    def test_nothing_extracted_is_reported_as_empty(self):
+        assert draft_for({"sets": [], "bodyweight": None}).is_empty
+
+    def test_a_fragment_that_is_not_a_row_stays_out_of_the_form(self):
+        """It cannot be edited, so it is reported rather than rendered."""
+        draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
+        assert draft.sets == []
+        assert "was not an object" in draft.review_items[0].reason
+
+
+class TestFlagging:
+    def test_missing_weight_is_flagged_on_its_own_field(self):
+        row = draft_for().sets[2]
+        assert [issue.field for issue in row.issues] == ["weight_kg"]
+
+    def test_missing_reps_is_flagged_on_its_own_field(self):
+        row = draft_for().sets[1]
+        assert [issue.field for issue in row.issues] == ["reps"]
+
+    def test_missing_information_does_not_block_the_save(self):
+        """A set with no recorded weight is still a set that happened."""
+        draft = draft_for()
+        assert draft.flagged_count == 2
+        assert draft.blocked_count == 0 and draft.ready
+
+    def test_a_name_the_model_invented_is_flagged(self):
+        payload = {"sets": [{"exercise_name": "Bulgarian Split Squat", "weight_kg": 20,
+                             "reps": 10, "raw_span": "Cable pulls 28kg"}]}
+        assert draft_for(payload).sets[0].issues_for("exercise_name")
+
+    def test_a_low_score_with_no_specific_cause_is_still_explained(self):
+        """Nothing is missing here — the name is only loosely supported by the
+        text and there is no span to check it against."""
+        payload = {"sets": [{"exercise_name": "Overhead Press", "weight_kg": 40, "reps": 8}]}
+        row = draft_for(payload).sets[0]
+        assert row.confidence < CONFIDENCE_THRESHOLD
+        assert [issue.field for issue in row.issues] == [None]
+
+    def test_a_bodyweight_number_not_in_the_entry_is_flagged(self):
+        payload = {"sets": [], "bodyweight": {"weight_kg": 91.0, "raw_span": "Was 82.4kg"}}
+        assert draft_for(payload).bodyweight.issues_for("weight_kg")
+
+
+class TestBlockingIssues:
+    def test_an_invalid_value_blocks_the_save(self):
+        payload = {"sets": [{"exercise_name": "Bench", "weight_kg": 28, "reps": "eleven"}]}
+        draft = draft_for(payload)
+        assert draft.sets[0].blocking and not draft.ready
+
+    def test_the_blocked_field_is_named(self):
+        payload = {"sets": [{"exercise_name": "Bench", "weight_kg": 28, "reps": "eleven"}]}
+        assert draft_for(payload).sets[0].issues_for("reps")
+
+    def test_a_whole_row_check_is_pinned_to_the_column_it_names(self):
+        """Pydantic reports a model validator against no field at all."""
+        payload = {"sets": [{"exercise_name": "Leg Press", "weight_kg": 100, "reps": 8,
+                             "cheat_reps": 12}]}
+        row = draft_for(payload).sets[0]
+        assert [issue.field for issue in row.issues] == ["cheat_reps"]
+
+    def test_an_unticked_row_cannot_block_the_save(self):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
+        draft = draft_for(payload)
+        draft.sets[0].include = False
+        assert draft.ready
+
+    def test_a_blank_name_blocks_rather_than_inserting_an_empty_exercise(self):
+        payload = {"sets": [{"exercise_name": "   ", "weight_kg": 20, "reps": 10}]}
+        assert draft_for(payload).sets[0].blocking
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+class TestRendering:
+    def test_every_editable_column_gets_a_field(self):
+        page = review.render_review_body(draft_for())
+        for column in pipeline.SET_COLUMNS:
+            assert f'name="s0.{column}"' in page
+
+    def test_a_flagged_field_is_marked(self):
+        page = review.render_review_body(draft_for())
+        assert 'name="s1.reps" class="bad"' in page
+
+    def test_a_clean_field_is_not_marked(self):
+        page = review.render_review_body(draft_for())
+        assert 'name="s0.reps" class=""' in page
+
+    def test_the_issue_is_spelled_out_next_to_the_row(self):
+        assert "no rep count found" in review.render_review_body(draft_for())
+
+    def test_a_row_that_cannot_be_saved_says_so_instead_of_showing_a_zero_score(self):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}]}
+        page = review.render_review_body(draft_for(payload))
+        assert "cannot be saved yet" in page and "confidence 0.00" not in page
+
+    def test_exercise_names_are_escaped(self):
+        """Names come straight from model output and land in an attribute."""
+        payload = {"sets": [{"exercise_name": '"><script>alert(1)</script>',
+                             "weight_kg": 20, "reps": 10}]}
+        page = review.render_review_body(draft_for(payload))
+        assert "<script>" not in page and "&lt;script&gt;" in page
+
+    def test_the_entry_text_is_escaped_in_the_hidden_field(self):
+        page = review.render_review_body(draft_for(raw_text='bench "20kg" <b>'))
+        assert "<b>" not in page and "&lt;b&gt;" in page
+
+    def test_the_original_entry_is_carried_forward_for_the_save(self):
+        assert submitted(draft_for())["raw_text"] == RAW_ENTRY
+
+    def test_replace_mode_survives_the_review_step(self):
+        draft = draft_for()
+        draft.replace_existing = True
+        assert submitted(draft)["mode"] == "replace"
+
+    def test_replace_mode_says_what_it_will_delete(self):
+        draft = draft_for()
+        draft.replace_existing = True
+        page = review.render_review_body(draft, {"sets": 12, "bodyweight": 1})
+        assert "deletes the 12 set(s)" in page
+
+    def test_an_empty_draft_offers_no_form(self):
+        page = review.render_review_body(draft_for({"sets": [], "bodyweight": None}))
+        assert "Nothing to save" in page and "<form" not in page
+
+
+# --------------------------------------------------------------------------
+# Reading the form back
+# --------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_an_untouched_submission_reproduces_the_draft(self):
+        original = draft_for()
+        returned = review.draft_from_form(submitted(original))
+        assert [row.values for row in returned.sets] == [row.values for row in original.sets]
+
+    def test_an_untouched_submission_is_not_reported_as_edited(self):
+        """Otherwise every row would be stored as human-confirmed."""
+        returned = review.draft_from_form(submitted(draft_for()))
+        assert not any(row.edited for row in returned.rows)
+
+    def test_an_untouched_submission_keeps_its_scores(self):
+        original = draft_for()
+        returned = review.draft_from_form(submitted(original))
+        assert [row.confidence for row in returned.sets] == [row.confidence for row in original.sets]
+
+    def test_the_session_date_survives(self):
+        assert review.draft_from_form(submitted(draft_for())).session_date == SESSION
+
+    def test_an_unusable_session_date_is_refused(self):
+        form = submitted(draft_for())
+        form["session_date"] = "22/08/2026"
+        with pytest.raises(ValueError):
+            review.draft_from_form(form)
+
+    def test_the_bodyweight_row_survives(self):
+        assert review.draft_from_form(submitted(draft_for())).bodyweight is not None
+
+    def test_no_bodyweight_stays_no_bodyweight(self):
+        draft = draft_for({"sets": PAYLOAD["sets"], "bodyweight": None})
+        assert review.draft_from_form(submitted(draft)).bodyweight is None
+
+
+class TestEditing:
+    def test_a_corrected_field_is_taken(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        assert review.draft_from_form(form).sets[1].values["reps"] == 9
+
+    def test_correcting_a_field_clears_its_mark(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        assert review.draft_from_form(form).sets[1].issues == []
+
+    def test_a_corrected_row_is_recorded_as_edited(self):
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        returned = review.draft_from_form(form)
+        assert returned.sets[1].edited and not returned.sets[0].edited
+
+    def test_a_toggled_flag_counts_as_an_edit(self):
+        form = submitted(draft_for())
+        form["s0.pain_flag"] = "on"
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["pain_flag"] is True and returned.sets[0].edited
+
+    def test_clearing_a_flag_counts_as_an_edit(self):
+        payload = {"sets": [dict(PAYLOAD["sets"][0], is_warmup=True)]}
+        form = submitted(draft_for(payload))
+        del form["s0.is_warmup"]
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["is_warmup"] is False and returned.sets[0].edited
+
+    def test_unticking_a_row_leaves_it_out(self):
+        form = submitted(draft_for())
+        del form["s1.include"]
+        returned = review.draft_from_form(form)
+        assert not returned.sets[1].include and len(returned.included) == 3
+
+    def test_unticking_the_bodyweight_row_leaves_it_out(self):
+        form = submitted(draft_for())
+        del form["bw.include"]
+        assert not review.draft_from_form(form).bodyweight.include
+
+    def test_breaking_a_field_blocks_the_save(self):
+        form = submitted(draft_for())
+        form["s0.reps"] = "eleven"
+        returned = review.draft_from_form(form)
+        assert not returned.ready and returned.sets[0].issues_for("reps")
+
+    def test_bad_input_is_kept_so_it_can_be_corrected(self):
+        """Dropping it to null would hide the mistake and save the row anyway."""
+        form = submitted(draft_for())
+        form["s0.reps"] = "eleven"
+        page = review.render_review_body(review.draft_from_form(form))
+        assert 'value="eleven"' in page
+
+    def test_clearing_a_field_empties_it_rather_than_failing(self):
+        form = submitted(draft_for())
+        form["s0.weight_kg"] = "  "
+        returned = review.draft_from_form(form)
+        assert returned.sets[0].values["weight_kg"] is None and returned.ready
+
+    def test_a_cleared_cheat_rep_count_becomes_zero(self):
+        form = submitted(draft_for())
+        form["s0.cheat_reps"] = ""
+        assert review.draft_from_form(form).sets[0].values["cheat_reps"] == 0
+
+    def test_a_second_pass_over_a_corrected_form_is_stable(self):
+        """The re-rendered page has to submit back to the same values."""
+        form = submitted(draft_for())
+        form["s1.reps"] = "9"
+        corrected = review.draft_from_form(form)
+        again = review.draft_from_form(submitted(corrected))
+        assert [row.values for row in again.sets] == [row.values for row in corrected.sets]
+
+
+# --------------------------------------------------------------------------
+# Saving
+# --------------------------------------------------------------------------
+
+
+class FakeConnection:
+    def __init__(self, log: list) -> None:
+        self.log = log
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        self.log.append(params or {})
+
+        class Result:
+            @staticmethod
+            def fetchall():
+                return []
+
+            @staticmethod
+            def fetchone():
+                return (1,)
+
+            @staticmethod
+            def scalar_one():
+                return 0
+
+        return Result()
+
+
+class FakeEngine:
+    """Enough of an Engine for commit_draft; every statement is recorded."""
+
+    def __init__(self) -> None:
+        self.log: list = []
+
+    def begin(self):
+        return FakeConnection(self.log)
+
+    def connect(self):
+        return FakeConnection(self.log)
+
+    @property
+    def inserted(self) -> list:
+        return [params for params in self.log if "extraction_confidence" in params]
+
+
+def commit(draft, engine=None, **kwargs):
+    engine = engine or FakeEngine()
+    result = pipeline.commit_draft(draft, engine=engine, **kwargs)
+    return result, engine
+
+
+class TestCommitting:
+    def test_ticked_rows_are_written(self):
+        result, engine = commit(draft_for())
+        assert result.inserted_sets == 3 and result.inserted_bodyweight == 1
+        assert len(engine.inserted) == 4
+
+    def test_unticked_rows_are_not_written(self):
+        draft = draft_for()
+        draft.sets[1].include = False
+        result, _ = commit(draft)
+        assert result.inserted_sets == 2 and result.skipped_sets == 1
+
+    def test_an_unticked_bodyweight_row_is_counted_separately(self):
+        draft = draft_for()
+        draft.bodyweight.include = False
+        result, _ = commit(draft)
+        assert result.inserted_bodyweight == 0 and result.skipped_bodyweight == 1
+
+    def test_a_low_score_no_longer_holds_a_row_back(self):
+        """The threshold gates the unattended path; here a person decided."""
+        draft = draft_for()
+        assert draft.sets[1].confidence < CONFIDENCE_THRESHOLD
+        result, _ = commit(draft)
+        assert result.inserted_sets == 3 and result.review_items == []
+
+    def test_an_edited_row_is_stored_as_human_confirmed(self):
+        draft = draft_for()
+        draft.sets[1].edited = True
+        _, engine = commit(draft)
+        assert engine.inserted[1]["extraction_confidence"] == 1.0
+
+    def test_an_untouched_row_keeps_its_computed_score(self):
+        draft = draft_for()
+        _, engine = commit(draft)
+        assert engine.inserted[1]["extraction_confidence"] == draft.sets[1].confidence
+
+    def test_the_original_entry_is_stored_against_every_row(self):
+        _, engine = commit(draft_for())
+        assert all(params["raw_source"] == RAW_ENTRY for params in engine.inserted)
+
+    def test_a_row_the_database_would_reject_is_reported_not_dropped(self):
+        """A guard: the route checks `ready` first, so this should be unreachable."""
+        draft = draft_for({"sets": [{"exercise_name": "Bench", "reps": "eleven"}]})
+        result, engine = commit(draft)
+        assert engine.inserted == [] and len(result.review_items) == 1
+
+    def test_nothing_ticked_writes_nothing(self):
+        draft = draft_for()
+        for row in draft.rows:
+            row.include = False
+        result, engine = commit(draft)
+        assert engine.log == [] and result.total_inserted == 0
+
+    def test_replace_only_deletes_when_something_replaces_it(self):
+        """An all-unticked draft must never empty the day."""
+        draft = draft_for()
+        draft.replace_existing = True
+        for row in draft.rows:
+            row.include = False
+        result, engine = commit(draft)
+        assert engine.log == [] and result.replaced is None
+
+    def test_fragments_that_were_never_rows_carry_through_to_the_result(self):
+        draft = draft_for({"sets": ["a bare string"], "bodyweight": None})
+        result, _ = commit(draft)
+        assert len(result.review_items) == 1
+
+    def test_an_extraction_failure_writes_nothing(self):
+        draft = pipeline.EntryDraft(RAW_ENTRY, SESSION, error="Extraction failed")
+        result, engine = commit(draft)
+        assert engine.log == [] and result.error == "Extraction failed"
+
+
+class TestUnattendedPathIsUnchanged:
+    """`process_entry` is the CLI's route and has no reviewer, so the threshold
+    still decides there."""
+
+    def test_a_low_score_is_held_back_for_review(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: PAYLOAD)
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
+        engine = FakeEngine()
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=engine)
+        assert result.inserted_sets == 1
+        assert len(result.review_items) == 2
+        assert all("below threshold" in item.reason for item in result.review_items)
+
+    def test_an_invalid_row_is_reported_the_same_way_as_before(self, monkeypatch):
+        payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}], "bodyweight": None}
+        monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: payload)
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=FakeEngine())
+        assert result.review_items[0].reason.startswith("failed validation:")


### PR DESCRIPTION
## Summary

`main` was missing work from three branches. **Nothing was lost** — no merge on `main` ever dropped content. All 19 merge commits on `main` were checked by comparing what each side branch introduced against what the merge tree actually landed, and every one matched exactly.

The cause was **PRs opened against the wrong base branch**. PRs #18 and #20 targeted `claude/gym-tracker-build-spec-iquerq` instead of `main`, so merging them advanced that branch and left `main` untouched. Two further commits were never opened as PRs at all.

## Commits recovered

| Commit | Feature | Why it missed `main` |
|---|---|---|
| `3bb59a1` | Resolve exercise muscle groups from a static table | PR #18 → wrong base |
| `902489e` | Derive today's date from `LOCAL_TIMEZONE`, not the server clock | PR #20 → wrong base |
| `992cf9c` | Suggest the muscle group into the review form | never merged |
| `a14f973` | Section the e1RM chart by muscle group | never merged |
| `559be1b` | Amber-flag newly created exercise names that do not look right | never merged |

Reconstructed by merging all three branches back onto `main`. The branch is a verified strict superset: zero commits from any branch in the repository are missing from it.

## The one conflict that needed more than a resolution

The name flag was written against the old `process_entry`, which inserted inline. PR #19 has since split that into `build_draft`/`commit_draft` and made `commit_draft` the only function that inserts. Taking either side of the conflict would have dropped a feature, so the flag call moved to the new insert site, where it covers the web and CLI paths exactly as the single call site did before.

That move put the flag behind the review screen, which the original could not have accounted for: a name the user types there is now flagged with no source text. This skips the grounding check while leaving `near_miss` and `unrecognized` in force. Grounding asks whether the model read a name or invented it, and for a name a person wrote there is no extraction to score — the same reason `commit_draft` pins confidence to `1.0` on an edited row. Asking it anyway would flag every hand-typed name, and a flag that fires on ordinary lifts hides the real ones.

## Tests

**702 passing**, up from 413 on `main`.

The re-homed call site had no test on either branch — the existing name-flag tests all cover the pure `flag_exercise_name` function, not the wiring. Since it is the piece that moved, it is the piece most likely to break silently, so `TestFlagsReachTheResult` now covers it. Both mutations were verified to fail it: removing the wiring fails 3 tests, removing the typed-name suppression fails 1.

Also verified that no stale `date.today()` call sites survived the timezone fix, including in the newer review-screen code that fix was never written against.

The README's test count and its two divergent feature lists are reconciled.

## Note on the base branch

This PR was originally opened against `claude/gym-tracker-build-spec-iquerq` — the same wrong-base mistake that stranded PRs #18 and #20. It has been retargeted to `main`, which is what actually delivers these commits. Worth checking the base on future PRs from these branches, as it defaults to the last branch used.