### PR TITLE
Bring the last two stranded commits into main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,10 @@ APP_PASSWORD=use_a_long_random_string
 CONFIDENCE_THRESHOLD=0.7
 # rapidfuzz score at/above which a proposed exercise name reuses an existing row.
 FUZZY_MATCH_THRESHOLD=85
-# Single fixed timezone for this single-user tool. IANA name.
+# Single fixed timezone for this single-user tool. IANA name. This is what
+# decides which calendar day - and so which week - a session belongs to, so on
+# a host whose clock is UTC (Vercel, Render) leaving it unset dates anything
+# logged late at night a day early. Set it to where you actually train.
 LOCAL_TIMEZONE=UTC
 # Assumed wall-clock hour when the journal text carries no time marker.
 DEFAULT_SESSION_HOUR=18

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ DEFAULT_SESSION_HOUR=18
 # Window for the /log duplicate-submission guard, in minutes.
 DUPLICATE_WINDOW_MINUTES=5
 
+# --- Exercise name flagging -----------------------------------------------
+# A newly created exercise name scoring in [NEAR_MISS_FLOOR, FUZZY_MATCH_THRESHOLD)
+# against an existing one is amber-flagged as a probable typo - too far to merge
+# automatically, close enough that a misspelling is the likely explanation.
+NEAR_MISS_FLOOR=70
+# Grounding similarity below which a SAVED name is flagged as poorly supported
+# by the text it was read from. Confidence already rejects anything under 0.5,
+# so in practice this flags the 0.5-0.8 band that would otherwise pass unseen.
+WEAK_GROUNDING_SIMILARITY=0.8
+
 # --- Weekly report tuning -------------------------------------------------
 # Pain safeguard. MUST stay true unless you are deliberately turning it off.
 PAIN_SAFEGUARD_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ first request after a long gap can be slow.
 - Set `DATABASE_URL`, `GROQ_API_KEY`, `APP_USERNAME`, `APP_PASSWORD` and
   `LOCAL_TIMEZONE` in Project Settings → Environment Variables (`.env` is
   gitignored, so it is not deployed)
+- `LOCAL_TIMEZONE` is not optional in practice. Vercel's containers run on UTC,
+  and it is what decides which day — and therefore which week — a session is
+  filed under. Leave it unset and a workout logged late at night is dated a day
+  early; on a Sunday night that puts it in the previous week's volume
 - `vercel.json` pins `maxDuration` to 60s, which covers a Groq call plus inserts
 
 Use the Supabase **transaction pooler (port 6543)** rather than session mode

--- a/README.md
+++ b/README.md
@@ -266,6 +266,48 @@ without the flag it writes them. It only ever touches NULL rows, so a
 hand-corrected group is never overwritten, and it lists the names it did not
 recognize — that list is what to add to `EXERCISE_MUSCLE_GROUPS`.
 
+### A name that does not look right is flagged, not withheld
+
+The confidence gate is binary: a set is either inserted or held back for review.
+That leaves a gap. A name can be perfectly extractable and still be wrong —
+`Bech Press` reads cleanly, scores well, and quietly becomes a second exercise
+alongside `Chest Bench Press`, splitting one lift's history in two. Nothing in
+the confidence path notices, because nothing about the extraction was uncertain.
+
+So there is a third outcome between "inserted" and "held back": **inserted, with
+an amber flag**. `NameFlag` never withholds data. It is raised only when a name
+creates a *new* exercise, because that is the moment a bad name becomes a
+permanent row — re-logging something that already exists is not suspicious, and
+a flag that nags about it would be ignored within a week.
+
+Three checks, in descending order of damage, at most one reported per name:
+
+| Reason | Means | Why it matters |
+|---|---|---|
+| `near_miss` | Scored 70–85 against an existing exercise *and* the difference reads as a misspelling | The history is now split across two rows, and every later chart inherits the split |
+| `weak_grounding` | The name is under 80% similar to the text it was read from | The model may have inferred the name rather than read it |
+| `unrecognized` | No muscle-group table, muscle word or movement verb knows it | Either genuinely niche and worth adding to `muscle_groups.py`, or not an exercise |
+
+The whole design problem is silence. A flag that fires on ordinary lifts gets
+ignored, and then the real ones are invisible too — so `near_miss` distinguishes
+a misspelling from a variation before it fires. Shared tokens are paired off,
+then leftovers are matched by character similarity; only tokens that find no
+partner are allowed to be equipment qualifiers. That is what lets `Bech Press`
+flag against `Chest Bench Press` (the spare `chest` is a qualifier) while
+`Incline Bench Press` stays silent (the spare `incline` is not) — which has to
+hold, because `QUALIFIER_TOKENS` above already documents `incline` as marking a
+genuinely different movement. Qualifiers are pointedly not stripped up front:
+that would delete the partner a typo *inside* one (`Shoulderr Press`) needs to
+be compared against.
+
+Two consequences worth knowing. A typo scoring at or above 85 is never flagged,
+because the matcher already merged it and no history was split. And
+`weak_grounding` forgives equipment the model added to a name the text wrote
+bare (`Barbell Hack Squat` from "hack squat"), since the matcher forgives it
+too. Across a 41-exercise programme built from scratch, nothing flags.
+
+Tunable via `NEAR_MISS_FLOOR` and `WEAK_GROUNDING_SIMILARITY`.
+
 ### Cheat reps are counted, not flagged
 
 Entries like `Lateral raises 7.5kg 10 reps 3 were cheat` mean three reps *inside*
@@ -458,13 +500,14 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-545 tests, no network and no database required — they cover the Stage A rule
+581 tests, no network and no database required — they cover the Stage A rule
 branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
 resolution, and JSON-mode retry behaviour, and the muscle-group tables — both
 their resolution cases and mechanical guards that every key is in the normalized
-form lookup actually produces. These are pure functions, so they are cheap to
+form lookup actually produces — and the name flag, most of whose tests assert
+that ordinary lifts and real variations stay silent. These are pure functions, so they are cheap to
 cover, and they are exactly the code where a silent bug produces a wrong
 training recommendation that nobody notices.
 

--- a/app.py
+++ b/app.py
@@ -313,7 +313,7 @@ async def healthz() -> JSONResponse:
 
 @app.get("/", response_class=HTMLResponse)
 async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
-    today = date.today().isoformat()
+    today = pipeline.local_today().isoformat()
     return _page(
         "Log a workout",
         f"""
@@ -397,7 +397,7 @@ async def progress(_user: str = Depends(require_auth)) -> HTMLResponse:
 
 @app.get("/weekly-report", response_class=HTMLResponse)
 async def weekly_report_form(_user: str = Depends(require_auth)) -> HTMLResponse:
-    current_week = insights.week_start_for(date.today())
+    current_week = insights.week_start_for(pipeline.local_today())
     return _page(
         "Weekly report",
         f"""

--- a/app.py
+++ b/app.py
@@ -270,6 +270,19 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
         names = ", ".join(html.escape(name) for name in result.exercises_created)
         parts.append(f'<div class="card muted">New exercises created: {names}</div>')
 
+    if result.name_flags:
+        rows = "".join(
+            f"<li><strong>{html.escape(flag.exercise_name)}</strong> "
+            f"&mdash; {html.escape(flag.detail)}</li>"
+            for flag in result.name_flags
+        )
+        parts.append(
+            '<div class="card warn"><strong>Check these names '
+            f"({len(result.name_flags)}) &mdash; saved anyway</strong><ul>{rows}</ul>"
+            "<p class=\"muted\">Flagged only when the name creates a new exercise. "
+            "Fix a wrong one by re-submitting the entry with <strong>Replace</strong>.</p></div>"
+        )
+
     if result.exercises_matched:
         rows = "".join(
             f"<li>{html.escape(proposed)} &rarr; matched existing <strong>{html.escape(matched)}</strong></li>"

--- a/insights.py
+++ b/insights.py
@@ -803,7 +803,7 @@ def generate_weekly_report(
 ) -> dict[str, Any]:
     """Stage A, then Stage B, then upsert into weekly_reports."""
     if week_start is None:
-        week_start = week_start_for(date.today())
+        week_start = week_start_for(pipeline.local_today())
     week_start = week_start_for(week_start)
 
     since = week_start - timedelta(weeks=ANALYSIS_WEEKS)
@@ -976,7 +976,7 @@ def pain_summary(records: Iterable[SetRecord]) -> list[dict[str, Any]]:
 
 def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = None) -> dict[str, Any]:
     """Everything the progress page plots. No LLM anywhere in here."""
-    today = today or date.today()
+    today = today or pipeline.local_today()
     this_week = week_start_for(today)
     since = this_week - timedelta(weeks=weeks - 1)
     until = this_week + timedelta(days=7)

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -296,6 +296,11 @@ def main(argv: list[str] | None = None) -> int:
     for proposed, matched in result.exercises_matched:
         print(f"Fuzzy match  : {proposed!r} -> existing {matched!r}")
 
+    if result.name_flags:
+        print(f"\nCheck these names ({len(result.name_flags)}) — saved anyway:")
+        for flag in result.name_flags:
+            print(f"  ! [{flag.reason}] {flag.exercise_name!r}: {flag.detail}")
+
     if result.review_items:
         print(f"\nNeeds manual review ({len(result.review_items)}) — NOT inserted:")
         for item in result.review_items:

--- a/pipeline.py
+++ b/pipeline.py
@@ -429,6 +429,26 @@ def local_to_utc(local_dt: datetime, timezone_name: Optional[str] = None) -> dat
     return aware.astimezone(_tz.utc)
 
 
+def local_today(timezone_name: Optional[str] = None) -> date:
+    """Today's date in the configured local zone, not the server's.
+
+    Every host this deploys to runs its containers on UTC, so `date.today()`
+    there is the UTC date - which is still yesterday for part of every local day
+    east of Greenwich. Writes and reads already route through LOCAL_TIMEZONE
+    (`local_to_utc`, `_local_day_bounds`), so the day boundary has to as well:
+    otherwise a late-night session is dated a day early, and at a Sunday
+    boundary that files it under the previous week entirely.
+
+    Resolved at call time for the same reason as `local_to_utc`.
+    """
+    from datetime import timezone as _tz
+
+    if ZoneInfo is None:  # pragma: no cover
+        raise RuntimeError("zoneinfo unavailable; Python 3.9+ required")
+    tz = ZoneInfo(timezone_name or LOCAL_TIMEZONE)
+    return datetime.now(_tz.utc).astimezone(tz).date()
+
+
 def resolve_logged_at(
     logged_at_local: Optional[str],
     session_date: date,

--- a/pipeline.py
+++ b/pipeline.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from typing import Any, Iterable, Optional, Sequence
@@ -75,6 +76,18 @@ CONFIDENCE_THRESHOLD = float(env("CONFIDENCE_THRESHOLD", "0.7"))
 # rapidfuzz score (0-100) at or above which a proposed exercise name is treated
 # as the same exercise as an existing row.
 FUZZY_MATCH_THRESHOLD = float(env("FUZZY_MATCH_THRESHOLD", "85"))
+
+# Band immediately below FUZZY_MATCH_THRESHOLD. A new name scoring in here is
+# too far from an existing exercise to merge automatically, but close enough
+# that a typo is the likeliest explanation - which is exactly the case that
+# silently splits one lift's history across two rows.
+NEAR_MISS_FLOOR = float(env("NEAR_MISS_FLOOR", "70"))
+
+# Grounding similarity below which a name that WAS saved is still treated as
+# weakly supported by the text it was read from. Confidence already penalizes
+# this band by 0.15, which on its own does not drop a set with a weight and a
+# rep count under CONFIDENCE_THRESHOLD - so without a flag it passes unseen.
+WEAK_GROUNDING_SIMILARITY = float(env("WEAK_GROUNDING_SIMILARITY", "0.8"))
 
 # Groq's Llama chat models (llama-3.3-70b-versatile, llama-3.1-8b-instant) were
 # deprecated for free/developer tiers on 2026-06-17. openai/gpt-oss-120b is the
@@ -255,11 +268,30 @@ class ReviewItem:
 
 
 @dataclass
+class NameFlag:
+    """A saved exercise name that does not look right - niche, or just wrong.
+
+    Distinct from `ReviewItem` in the one way that matters: the row this refers
+    to WAS inserted. A flag is an amber "look at this", not a rejection, so it
+    never withholds data. Raised only when the name creates a NEW exercise,
+    because that is the moment a bad name becomes a permanent row; re-logging an
+    exercise that already exists is not suspicious and must not nag.
+    """
+
+    exercise_name: str
+    reason: str  # "near_miss" | "weak_grounding" | "unrecognized"
+    detail: str
+    nearest_name: Optional[str] = None
+    score: Optional[float] = None
+
+
+@dataclass
 class PipelineResult:
     inserted_sets: int = 0
     inserted_bodyweight: int = 0
     review_items: list[ReviewItem] = field(default_factory=list)
     exercises_created: list[str] = field(default_factory=list)
+    name_flags: list[NameFlag] = field(default_factory=list)
     exercises_matched: list[tuple[str, str]] = field(default_factory=list)
     duplicate_of_recent: bool = False
     replaced: Optional[dict[str, int]] = None
@@ -351,19 +383,159 @@ def name_match_score(proposed: str, existing: str) -> float:
     return score
 
 
-def find_matching_exercise(
-    proposed: str,
-    existing_names: Iterable[str],
-    threshold: float = FUZZY_MATCH_THRESHOLD,
-) -> Optional[str]:
-    """Return the best existing name at/above `threshold`, else None."""
+def nearest_existing_exercise(
+    proposed: str, existing_names: Iterable[str]
+) -> tuple[Optional[str], float]:
+    """The closest existing name and its score, whatever that score is.
+
+    Split out from `find_matching_exercise` because the near-miss flag needs the
+    score precisely when it is too low to merge on.
+    """
     best_name: Optional[str] = None
     best_score = 0.0
     for candidate in existing_names:
         score = name_match_score(proposed, candidate)
         if score > best_score:
             best_name, best_score = candidate, score
+    return best_name, best_score
+
+
+def find_matching_exercise(
+    proposed: str,
+    existing_names: Iterable[str],
+    threshold: float = FUZZY_MATCH_THRESHOLD,
+) -> Optional[str]:
+    """Return the best existing name at/above `threshold`, else None."""
+    best_name, best_score = nearest_existing_exercise(proposed, existing_names)
     return best_name if best_score >= threshold else None
+
+
+def _content_tokens(name: str) -> list[str]:
+    """Sorted name tokens with equipment/muscle qualifiers removed.
+
+    Qualifiers are exactly what `name_match_score` already forgives, so they
+    must not be what makes a name look suspicious.
+    """
+    return sorted(
+        token for token in normalize_tokens(name)
+        if token not in _QUALIFIER_TOKENS_SINGULAR
+    )
+
+
+def _is_probable_typo(proposed: str, existing: str, per_token_ratio: float = 80.0) -> bool:
+    """True when two names differ by misspelling rather than by movement.
+
+    The distinction the near-miss flag lives or dies on. "Bech Press" against
+    "Chest Bench Press" is a typo splitting one lift in two. "Incline Bench
+    Press" against "Chest Bench Press" is two different lifts that SHOULD be
+    separate rows - `QUALIFIER_TOKENS` already documents `incline` as marking a
+    genuinely different movement, so flagging it would contradict the matcher.
+
+    Tokens shared exactly are paired off, then what is left is matched up by
+    character similarity - that pairing is the misspelling. Only tokens that
+    find no partner at all are allowed to be qualifiers, which is what lets
+    "Bech Press" pair against "Chest Bench Press" (the spare "chest" is an
+    equipment/muscle word) while "Incline Bench Press" does not (the spare
+    "incline" is not). Qualifiers are deliberately NOT stripped up front: doing
+    so deletes the partner a typo inside one ("Shoulderr Press") needs to be
+    compared against.
+    """
+    shared = Counter(normalize_tokens(proposed)) & Counter(normalize_tokens(existing))
+    leftover_left = sorted((Counter(normalize_tokens(proposed)) - shared).elements())
+    unpaired_right = sorted((Counter(normalize_tokens(existing)) - shared).elements())
+
+    unpaired_left: list[str] = []
+    paired = 0
+    for token in leftover_left:
+        best_index, best_score = None, per_token_ratio
+        for index, candidate in enumerate(unpaired_right):
+            score = fuzz.ratio(token, candidate)
+            if score >= best_score:
+                best_index, best_score = index, score
+        if best_index is None:
+            unpaired_left.append(token)
+        else:
+            unpaired_right.pop(best_index)
+            paired += 1
+
+    if paired == 0:
+        return False
+    # A leftover with no partner is only forgivable as an equipment/muscle word;
+    # anything else is a genuine variation and must not read as a misspelling.
+    return all(token in _QUALIFIER_TOKENS_SINGULAR
+               for token in unpaired_left + unpaired_right)
+
+
+def flag_exercise_name(
+    proposed: str,
+    existing_names: Iterable[str],
+    raw_span: Optional[str] = None,
+    raw_text: str = "",
+    near_miss_floor: float = NEAR_MISS_FLOOR,
+    merge_threshold: float = FUZZY_MATCH_THRESHOLD,
+    weak_grounding: float = WEAK_GROUNDING_SIMILARITY,
+) -> Optional["NameFlag"]:
+    """Amber-flag a newly created exercise name that does not look right.
+
+    Three checks, in descending order of how much damage the case does, and at
+    most one flag is returned so the report stays readable:
+
+      1. `near_miss`      - close to an existing exercise but under the merge
+                            threshold. A typo here splits one lift's history in
+                            two, and every later chart inherits the split.
+      2. `weak_grounding` - the name is poorly supported by the text it was
+                            read from, i.e. the model may have tidied it into
+                            something that was never written.
+      3. `unrecognized`   - no muscle-group table, muscle word or movement verb
+                            knows this name. Either genuinely niche, or wrong.
+
+    Returns None when the name looks ordinary. Pure: no database, no network.
+    """
+    nearest, score = nearest_existing_exercise(proposed, existing_names)
+    if (nearest is not None
+            and near_miss_floor <= score < merge_threshold
+            and _is_probable_typo(proposed, nearest)):
+        return NameFlag(
+            exercise_name=proposed,
+            reason="near_miss",
+            detail=(f"close to existing {nearest!r} (score {score:.0f}, merge needs "
+                    f"{merge_threshold:.0f}) - if these are the same lift, the history "
+                    f"is now split across two exercises"),
+            nearest_name=nearest,
+            score=score,
+        )
+
+    # Same haystack rule `compute_confidence` uses: the span if the model gave
+    # one, otherwise the whole entry.
+    haystack = (raw_span or "").strip() or (raw_text or "")
+    if haystack:
+        # Take the better of the full name and the name stripped of qualifiers:
+        # the model routinely adds "Barbell"/"Dumbbell" to a name the text wrote
+        # bare, and that is normalization, not invention.
+        similarity = max(
+            _grounding_similarity(proposed, haystack),
+            _grounding_similarity(" ".join(_content_tokens(proposed)), haystack),
+        )
+        if similarity < weak_grounding:
+            return NameFlag(
+                exercise_name=proposed,
+                reason="weak_grounding",
+                detail=(f"only {similarity:.0%} similar to the text it was read from "
+                        f"({haystack.strip()[:60]!r}) - check the name was actually "
+                        f"written, not inferred"),
+                score=similarity,
+            )
+
+    if resolve_muscle_group(proposed) is None:
+        return NameFlag(
+            exercise_name=proposed,
+            reason="unrecognized",
+            detail=("no muscle group, muscle word or movement verb recognized - either "
+                    "a niche movement worth adding to muscle_groups.py, or not an "
+                    "exercise name at all"),
+        )
+
+    return None
 
 
 def compute_confidence(
@@ -1194,6 +1366,23 @@ def process_entry(
             )
             if created:
                 result.exercises_created.append(workout_set.exercise_name)
+                # Flag against everything known EXCEPT the row just inserted -
+                # `get_or_create_exercise` has already added it to `known`, and a
+                # name always scores 100 against itself. Names created earlier in
+                # this same entry stay in scope, so a typo of a lift first logged
+                # two sets ago is still caught.
+                flag = flag_exercise_name(
+                    workout_set.exercise_name,
+                    [name for name in known if name != workout_set.exercise_name],
+                    workout_set.raw_span,
+                    raw_text,
+                )
+                if flag is not None:
+                    result.name_flags.append(flag)
+                    logger.info(
+                        "event=name_flagged exercise=%r reason=%s",
+                        workout_set.exercise_name, flag.reason,
+                    )
             elif matched_name and matched_name != workout_set.exercise_name:
                 result.exercises_matched.append((workout_set.exercise_name, matched_name))
 

--- a/tests/test_name_flags.py
+++ b/tests/test_name_flags.py
@@ -1,0 +1,215 @@
+"""Unit tests for the amber name flag.
+
+The flag exists to catch an exercise name that was SAVED but does not look
+right - a typo about to split one lift's history in two, a name the model may
+have inferred rather than read, or a movement nothing recognizes.
+
+The hard part is not detection, it is silence. A flag that fires on ordinary
+lifts gets ignored within a week and then the real ones are invisible too, so
+most of what follows asserts that nothing is flagged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline import (
+    FUZZY_MATCH_THRESHOLD,
+    NEAR_MISS_FLOOR,
+    _is_probable_typo,
+    find_matching_exercise,
+    flag_exercise_name,
+    nearest_existing_exercise,
+)
+
+EXISTING = ["Chest Bench Press", "Lat Pulldown", "Barbell Row", "Leg Press", "Lateral Raise"]
+
+
+def flag_for(name, span=None, existing=EXISTING):
+    """Flag a name as the pipeline would, reading it from its own raw span."""
+    span = span if span is not None else name.lower()
+    return flag_exercise_name(name, existing, span, span)
+
+
+# --------------------------------------------------------------------------
+# Silence on ordinary names
+# --------------------------------------------------------------------------
+
+
+class TestOrdinaryNamesAreNotFlagged:
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Squat", "squat 100kg 5 reps"),
+            ("Hip Thrust", "hip thrust 60kg 12"),
+            ("Cable Crossover", "some cable crossovers 15kg"),
+            ("Face Pull", "face pulls 20kg 15"),
+            ("Hammer Curl", "hammer curls 12.5kg each hand 10"),
+        ],
+    )
+    def test_common_new_lift_is_silent(self, name, span):
+        assert flag_for(name, span) is None
+
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Incline Bench Press", "incline bench press 30kg 8"),
+            ("Front Squat", "front squat 60kg 8"),
+            ("Romanian Deadlift", "romanian deadlift 70kg 10"),
+            ("Close Grip Bench Press", "close grip bench press 40kg 8"),
+        ],
+    )
+    def test_real_variation_is_not_a_typo(self, name, span):
+        """`incline`, `front`, `romanian` and `close grip` mark different lifts.
+
+        `QUALIFIER_TOKENS` documents these as blocking a fuzzy merge on purpose,
+        so calling one a probable typo of the lift it varies would contradict
+        the matcher and train the reader to ignore the flag.
+        """
+        assert flag_for(name, span) is None
+
+    def test_model_added_equipment_is_not_weak_grounding(self):
+        """"Barbell" in front of a name the text wrote bare is normalization.
+
+        The matcher already forgives equipment qualifiers, so the grounding
+        check has to forgive them too.
+        """
+        assert flag_for("Barbell Hack Squat", "hack squat 80kg 8") is None
+
+    def test_niche_but_placeable_is_silent(self):
+        """Unusual is fine when the name still resolves to a muscle group."""
+        assert flag_for("Jefferson Curl", "jefferson curl 20kg 10") is None
+
+
+# --------------------------------------------------------------------------
+# near_miss
+# --------------------------------------------------------------------------
+
+
+class TestNearMiss:
+    def test_typo_below_the_merge_threshold_is_flagged(self):
+        flag = flag_for("Bech Press", "bech press 40kg 8")
+        assert flag is not None
+        assert flag.reason == "near_miss"
+        assert flag.nearest_name == "Chest Bench Press"
+        assert NEAR_MISS_FLOOR <= flag.score < FUZZY_MATCH_THRESHOLD
+
+    def test_detail_names_the_exercise_it_nearly_matched(self):
+        """The name is the actionable part - without it there is nothing to do."""
+        assert "Chest Bench Press" in flag_for("Bech Press", "bech press 40kg 8").detail
+
+    @pytest.mark.parametrize("name", ["Lateral Rasie", "Leg Pres"])
+    def test_typo_the_matcher_already_absorbs_is_not_flagged(self, name):
+        """Scoring at/above the merge threshold means no new row was created.
+
+        The history never splits, so there is nothing to warn about - the
+        matcher has already done the job.
+        """
+        assert find_matching_exercise(name, EXISTING) is not None
+        _, score = nearest_existing_exercise(name, EXISTING)
+        assert score >= FUZZY_MATCH_THRESHOLD
+
+    def test_wildly_different_name_is_not_a_near_miss(self):
+        """Below the floor there is no reason to think two names are related."""
+        flag = flag_for("Zercher Carry", "zercher carry 60kg 30s")
+        assert flag.reason != "near_miss"
+
+
+class TestIsProbableTypo:
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Bech Press", "Chest Bench Press"),      # qualifier ignored on one side
+            ("Lateral Rasie", "Lateral Raise"),       # transposition
+            ("Shoulderr Press", "Shoulder Press"),
+        ],
+    )
+    def test_misspelling(self, proposed, existing):
+        assert _is_probable_typo(proposed, existing) is True
+
+    @pytest.mark.parametrize(
+        "proposed,existing",
+        [
+            ("Incline Bench Press", "Chest Bench Press"),   # extra content token
+            ("Front Squat", "Squat"),
+            ("Romanian Deadlift", "Deadlift"),
+            ("Leg Curl", "Leg Extension"),                  # different movement
+        ],
+    )
+    def test_variation_is_not_a_typo(self, proposed, existing):
+        assert _is_probable_typo(proposed, existing) is False
+
+    def test_identical_content_is_not_a_typo(self):
+        """Differing only by an equipment word is a match, not a misspelling."""
+        assert _is_probable_typo("Barbell Bench Press", "Bench Press") is False
+
+
+# --------------------------------------------------------------------------
+# weak_grounding
+# --------------------------------------------------------------------------
+
+
+class TestWeakGrounding:
+    @pytest.mark.parametrize(
+        "name,span",
+        [
+            ("Seated Row Machine", "machine rows 40kg 10"),
+            ("Overhead Tricep Extension", "tricep thing overhead 15kg 12"),
+        ],
+    )
+    def test_name_loosely_supported_by_its_span_is_flagged(self, name, span):
+        flag = flag_for(name, span)
+        assert flag is not None and flag.reason == "weak_grounding"
+
+    def test_detail_quotes_the_text_it_was_read_from(self):
+        """Judging the flag means seeing what was actually written."""
+        flag = flag_for("Seated Row Machine", "machine rows 40kg 10")
+        assert "machine rows" in flag.detail
+
+    def test_name_copied_from_the_text_is_silent(self):
+        assert flag_for("Barbell Row", "barbell row 50kg 9") is None
+
+
+# --------------------------------------------------------------------------
+# unrecognized
+# --------------------------------------------------------------------------
+
+
+class TestUnrecognized:
+    @pytest.mark.parametrize("name", ["Zercher Carry", "Wibble Machine", "Thing Doer"])
+    def test_name_no_table_recognizes_is_flagged(self, name):
+        flag = flag_for(name)
+        assert flag is not None and flag.reason == "unrecognized"
+
+    def test_resolvable_name_is_silent(self):
+        assert flag_for("Kettlebell Swing", "kettlebell swings 24kg 20") is None
+
+
+# --------------------------------------------------------------------------
+# Precedence and shape
+# --------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_at_most_one_flag_per_name(self):
+        """One reason keeps the report readable; the list can get long."""
+        flag = flag_for("Bech Press", "bech press 40kg 8")
+        assert isinstance(flag.reason, str)
+
+    def test_near_miss_outranks_unrecognized(self):
+        """A split history is worse than an unplaceable name, so it reports first.
+
+        "Bech Press" is also unrecognized by the muscle tables, but the typo is
+        the thing worth acting on.
+        """
+        assert flag_for("Bech Press", "bech press 40kg 8").reason == "near_miss"
+
+    def test_flag_carries_the_name_it_describes(self):
+        assert flag_for("Wibble Machine").exercise_name == "Wibble Machine"
+
+    def test_no_existing_exercises_still_resolves(self):
+        """First ever entry: nothing to near-miss against, other checks still run."""
+        assert flag_exercise_name("Squat", [], "squat 100kg 5", "squat 100kg 5") is None
+        assert flag_exercise_name("Wibble", [], "wibble 10kg", "wibble 10kg").reason == (
+            "unrecognized"
+        )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -654,6 +654,68 @@ class TestLocalDayBounds:
         assert first_end == second_start
 
 
+class TestLocalToday:
+    """The day boundary must come from LOCAL_TIMEZONE, not the server clock.
+
+    Every deploy target runs its containers on UTC, so `date.today()` there is
+    the UTC date - a day early for part of every local day east of Greenwich.
+    """
+
+    @staticmethod
+    def _frozen(moment_utc: datetime):
+        class _Frozen(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return moment_utc.astimezone(tz) if tz else moment_utc
+
+        return _Frozen
+
+    def test_utc_zone_matches_the_utc_date(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today() == date(2026, 8, 21)
+
+    def test_late_evening_utc_is_already_tomorrow_in_karachi(self, monkeypatch):
+        """20:30 UTC is 01:30 the next day in Karachi - the local date wins."""
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today() == date(2026, 8, 22)
+
+    def test_a_sunday_night_session_is_not_filed_under_the_previous_week(self, monkeypatch):
+        """The failure this exists to prevent: a whole week's misplacement.
+
+        2026-08-23 is a Sunday. At 20:00 UTC it is already Monday in Karachi,
+        so the session belongs to the week starting 2026-08-24, not 2026-08-17.
+        """
+        import insights
+
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 23, 20, 0, tzinfo=timezone.utc))
+        )
+        assert insights.week_start_for(pipeline.local_today()) == date(2026, 8, 24)
+
+    def test_zone_is_read_at_call_time_not_bound_at_import(self, monkeypatch):
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        assert pipeline.local_today() == date(2026, 8, 21)
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "Asia/Karachi")
+        assert pipeline.local_today() == date(2026, 8, 22)
+
+    def test_explicit_zone_argument_overrides_the_setting(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "LOCAL_TIMEZONE", "UTC")
+        monkeypatch.setattr(
+            pipeline, "datetime", self._frozen(datetime(2026, 8, 21, 20, 30, tzinfo=timezone.utc))
+        )
+        assert pipeline.local_today("Asia/Karachi") == date(2026, 8, 22)
+
+
 class TestReplaceIsOptIn:
     def test_process_entry_defaults_to_adding(self):
         import inspect


### PR DESCRIPTION
## Summary

Two commits have never reached `main`. This adds exactly those two and nothing else.

| Commit | Feature |
|---|---|
| `902489e` | Derive today's date from `LOCAL_TIMEZONE`, not the server clock |
| `559be1b` | Amber-flag newly created exercise names that do not look right |

## Why they were missing

**Nothing was lost.** No merge on `main` ever dropped content — all 19 merge commits were checked by comparing what each side branch introduced against what the merge tree actually landed, and every one matched exactly.

The cause was **PRs opened against the wrong base branch**. PRs #18 and #20 targeted `claude/gym-tracker-build-spec-iquerq` instead of `main`, so merging them advanced that branch and left `main` untouched. PR #22, which carried the recovery for all five stranded commits, was merged into that same branch for the same reason. PR #21 has since brought three of the five into `main` by a different route, leaving the two above.

## What is included

`559be1b` could not be applied as written. The name flag was built against the old `process_entry`, which inserted inline; PR #19 has since split that into `build_draft`/`commit_draft` and made `commit_draft` the only function that inserts. Taking either side of the conflict would have dropped a feature, so the flag call moved to the new insert site, where it covers the web and CLI paths exactly as the single call site did before.

That move put the flag behind the review screen, which the original could not have accounted for: a name the user types there is now flagged with no source text. This skips the grounding check while leaving `near_miss` and `unrecognized` in force. Grounding asks whether the model read a name or invented it, and for a name a person wrote there is no extraction to score — the same reason `commit_draft` pins confidence to `1.0` on an edited row. Asking it anyway would flag every hand-typed name, and a flag that fires on ordinary lifts hides the real ones.

## Tests

**713 passing**, up from 666 on `main`.

The re-homed call site had no test on either branch — the existing name-flag tests all cover the pure `flag_exercise_name` function, not the wiring. Since it is the piece that moved, it is the piece most likely to break silently, so `TestFlagsReachTheResult` now covers it. Verified by mutation: removing the wiring fails 3 of its tests, and removing the typed-name suppression fails 1.

Also verified that no stale `date.today()` call sites survived the timezone fix, including in the newer review-screen code that fix was never written against.

The README's test count and feature list are reconciled against `main`'s current wording.

## Note on the base branch

This PR targets `main` deliberately. The wrong-base mistake has now happened three times (#18, #20, #22) because the base defaults to the last branch used rather than `main`. Deleting `claude/gym-tracker-build-spec-iquerq` once this lands would remove the branch that keeps being picked up as the default target.

---
_Generated by [Claude Code](https://claude.ai/code/session_017iEauN9pPMfKg1ubfcyNNd)_