### PR TITLE
Make the duplicate guard ask instead of refuse, and scope it to the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,9 +492,20 @@ into a neighbouring date - tested at an offset zone, not just UTC.
 
 Render's free tier cold-starts in 30–50s after idle, which is exactly when you
 double-tap submit. The check sits on `/save`, the step that writes: it looks for
-the same raw text inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) and returns
-the earlier result rather than inserting the entry twice. `/log` writes nothing,
-so re-running it costs only another extraction.
+the same raw text inserted in the last `DUPLICATE_WINDOW_MINUTES` (5) **against
+the day being logged**. `/log` writes nothing, so re-running it costs only
+another extraction.
+
+It asks rather than refuses. Re-pasting an entry to correct a bad parse is the
+same bytes arriving twice as a double-tapped submit, so the guard cannot tell
+them apart and does not try. On a match nothing is written and the review screen
+comes straight back — rows intact and still editable — with the earlier save
+listed exercise by exercise as the evidence for the claim, and two ways forward:
+replace that day, or add a second copy. Going back is the third.
+
+The day scoping matters for short entries: without it, "rest day, weighed 82.4"
+logged against Saturday and then against Sunday reads as a double-tap, and the
+second date is silently dropped.
 
 ## Charts
 
@@ -625,7 +636,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-713 tests, no network and no database required — they cover the Stage A
+741 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
@@ -633,10 +644,11 @@ resolution and JSON-mode retry behaviour, the muscle-group tables and how their
 answer is suggested and overridden — both their resolution cases and mechanical
 guards that every key is in the normalized form lookup actually produces — the
 name flag, most of whose tests assert that ordinary lifts and real variations
-stay silent, and the review screen's draft/edit/save round trip. These are pure
-functions, so they are cheap to cover, and they are exactly the code where a
-silent bug produces a wrong training recommendation, or a saved row that does
-not match what was on screen, and nobody notices.
+stay silent, the duplicate guard's day scoping and its two ways forward, and the
+review screen's draft/edit/save round trip. These are pure functions, so they are
+cheap to cover, and they are exactly the code where a silent bug produces a wrong
+training recommendation, or a saved row that does not match what was on screen,
+and nobody notices.
 
 ## Not built (by design)
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ import sys
 import time
 from datetime import date, datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
@@ -251,20 +251,13 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
     if result.error:
         parts.append(f'<div class="card err"><strong>Error.</strong> {html.escape(result.error)}</div>')
 
-    if result.duplicate_of_recent:
-        parts.append(
-            '<div class="card warn"><strong>Duplicate submission.</strong> '
-            "This exact text was already processed within the last "
-            f"{pipeline.DUPLICATE_WINDOW_MINUTES} minutes, so nothing was re-inserted. "
-            f"The earlier run saved {result.inserted_sets} set(s) and "
-            f"{result.inserted_bodyweight} bodyweight entry/entries.</div>"
-        )
-    else:
-        parts.append(
-            f'<div class="card ok"><strong>Inserted {result.inserted_sets} set(s)</strong> and '
-            f"{result.inserted_bodyweight} bodyweight entry/entries for "
-            f"{html.escape(session_date.isoformat())}.</div>"
-        )
+    # A duplicate never reaches here: /save intercepts it and asks instead,
+    # so by this point something really was written.
+    parts.append(
+        f'<div class="card ok"><strong>Inserted {result.inserted_sets} set(s)</strong> and '
+        f"{result.inserted_bodyweight} bodyweight entry/entries for "
+        f"{html.escape(session_date.isoformat())}.</div>"
+    )
 
     if result.replaced:
         removed = result.replaced
@@ -411,11 +404,17 @@ def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
         return None
 
 
-def _review_page(draft: pipeline.EntryDraft) -> HTMLResponse:
+def _review_page(
+    draft: pipeline.EntryDraft,
+    duplicate: Optional[dict[str, Any]] = None,
+) -> HTMLResponse:
     return _page(
-        "Check before saving",
+        "Already saved once" if duplicate else "Check before saving",
         review.render_review_body(
-            draft, _existing_counts(draft.session_date), pipeline.CONFIDENCE_THRESHOLD
+            draft,
+            _existing_counts(draft.session_date),
+            pipeline.CONFIDENCE_THRESHOLD,
+            duplicate=duplicate,
         ),
         extra_css=review.REVIEW_CSS,
     )
@@ -487,7 +486,34 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
         logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)
         return _review_page(draft)
 
-    result = pipeline.commit_draft(draft, engine=get_engine(), check_duplicates=True)
+    # Set only by the duplicate decision page below, so a first save always
+    # passes through the guard.
+    override = bool(str(form.get("override_duplicate", "")).strip())
+    result = pipeline.commit_draft(
+        draft,
+        engine=get_engine(),
+        check_duplicates=True,
+        override_duplicate=override,
+    )
+
+    if result.duplicate_of_recent:
+        # Nothing was written. Hand the draft straight back with the two ways
+        # forward rather than dead-ending on a refusal the user cannot answer.
+        logger.info(
+            "event=duplicate_decision_offered date=%s prior_sets=%d prior_bodyweight=%d",
+            draft.session_date,
+            result.inserted_sets,
+            result.inserted_bodyweight,
+        )
+        return _review_page(
+            draft,
+            duplicate={
+                "inserted_sets": result.inserted_sets,
+                "inserted_bodyweight": result.inserted_bodyweight,
+                "evidence": result.duplicate_evidence,
+            },
+        )
+
     logger.info(
         "event=entry_saved date=%s replace=%s inserted_sets=%d inserted_bodyweight=%d "
         "skipped=%d review=%d duplicate=%s replaced=%s",

--- a/pipeline.py
+++ b/pipeline.py
@@ -294,6 +294,10 @@ class PipelineResult:
     name_flags: list[NameFlag] = field(default_factory=list)
     exercises_matched: list[tuple[str, str]] = field(default_factory=list)
     duplicate_of_recent: bool = False
+    # What the matched earlier save actually produced, per exercise. Empty
+    # unless `duplicate_of_recent`; it is the evidence for that claim, so the
+    # user can check a match that looks wrong rather than having to believe it.
+    duplicate_evidence: list[dict[str, Any]] = field(default_factory=list)
     replaced: Optional[dict[str, int]] = None
     error: Optional[str] = None
     # Rows the user unticked on the review screen. Distinct from review_items,
@@ -1799,42 +1803,98 @@ def delete_entries_for_date(conn: Connection, session_date: date) -> dict[str, i
     return {"sets": int(sets or 0), "bodyweight": int(bodyweight or 0)}
 
 
+def _submission_clauses(
+    raw_text: str,
+    window_minutes: int,
+    session_date: Optional[date],
+) -> tuple[str, dict[str, Any]]:
+    """The WHERE fragment identifying rows written from one journal entry.
+
+    Matching is exact text equality — `raw_source` is TEXT, so nothing is
+    truncated and two different entries cannot collide here.
+    """
+    params: dict[str, Any] = {
+        "raw_source": raw_text,
+        "window": f"{int(window_minutes)} minutes",
+    }
+    clauses = [
+        "raw_source = :raw_source",
+        "created_at >= now() - CAST(:window AS interval)",
+    ]
+
+    if session_date is not None:
+        # Scoped to the day being logged. Without this, pasting the same short
+        # entry ("rest day, weighed 82.4") against two dates in one sitting
+        # reads as a double-tap and the second date is silently dropped.
+        start, end = _local_day_bounds(session_date)
+        clauses.append("logged_at >= :day_start AND logged_at < :day_end")
+        params["day_start"] = start
+        params["day_end"] = end
+
+    return " AND ".join(clauses), params
+
+
 def find_recent_submission(
     engine: Engine,
     raw_text: str,
     window_minutes: int = DUPLICATE_WINDOW_MINUTES,
+    session_date: Optional[date] = None,
 ) -> Optional[dict[str, int]]:
     """Return counts for an identical entry inserted within the window, else None.
 
     Backs the /log duplicate-submission guard: Render's free tier cold-starts for
     30-50s, which is exactly when a user double-taps submit.
+
+    `session_date` scopes the match to the day being logged. It is optional only
+    so the older two-argument call still works; every caller that knows the date
+    should pass it, or logging one short entry against two dates in one sitting
+    reads as a double-tap and the second date is dropped.
     """
+    where, params = _submission_clauses(raw_text, window_minutes, session_date)
     with engine.connect() as conn:
-        params = {"raw_source": raw_text, "window": f"{int(window_minutes)} minutes"}
         sets = conn.execute(
-            text(
-                """
-                SELECT count(*) FROM workout_logs
-                WHERE raw_source = :raw_source
-                  AND created_at >= now() - CAST(:window AS interval)
-                """
-            ),
-            params,
+            text(f"SELECT count(*) FROM workout_logs WHERE {where}"), params
         ).scalar_one()
         bodyweight = conn.execute(
-            text(
-                """
-                SELECT count(*) FROM bodyweight_logs
-                WHERE raw_source = :raw_source
-                  AND created_at >= now() - CAST(:window AS interval)
-                """
-            ),
-            params,
+            text(f"SELECT count(*) FROM bodyweight_logs WHERE {where}"), params
         ).scalar_one()
 
     if not sets and not bodyweight:
         return None
     return {"inserted_sets": int(sets), "inserted_bodyweight": int(bodyweight)}
+
+
+def describe_recent_submission(
+    engine: Engine,
+    raw_text: str,
+    window_minutes: int = DUPLICATE_WINDOW_MINUTES,
+    session_date: Optional[date] = None,
+) -> list[dict[str, Any]]:
+    """What the matched entry actually saved, per exercise.
+
+    A guard that says "duplicate" and shows nothing is impossible to argue with,
+    and impossible to trust when the sets it claims to have saved are not the
+    ones you meant to log. This is the evidence for the claim.
+    """
+    where, params = _submission_clauses(raw_text, window_minutes, session_date)
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                f"""
+                SELECT e.name AS exercise, count(*) AS sets, min(w.logged_at) AS first_logged
+                FROM workout_logs w
+                JOIN exercises e ON e.exercise_id = w.exercise_id
+                WHERE {where}
+                GROUP BY e.name
+                ORDER BY min(w.logged_at), e.name
+                """
+            ),
+            params,
+        ).all()
+    return [
+        {"exercise": row[0], "sets": int(row[1]), "first_logged": row[2]}
+        for row in rows
+    ]
 
 
 # --------------------------------------------------------------------------
@@ -1848,6 +1908,7 @@ def commit_draft(
     check_duplicates: bool = False,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     review_excluded: bool = False,
+    override_duplicate: bool = False,
 ) -> PipelineResult:
     """Write the ticked rows of a draft. The only function that inserts.
 
@@ -1864,6 +1925,13 @@ def commit_draft(
 
     Blank slots are skipped in silence. They are offers to add a row that nobody
     took up, so they are neither saved nor reported as left out.
+
+    `override_duplicate` is the answer to the duplicate guard rather than a way
+    around it. Re-pasting an entry to correct a bad parse is indistinguishable
+    from a double-tapped submit, so the guard asks instead of refusing, and this
+    carries the decision back. It is also what makes Replace work on a matched
+    entry: without it the delete-and-reinsert is stopped by the same guard and
+    the save appears to succeed while changing nothing.
     """
     if engine is None:
         engine = get_engine()
@@ -1873,14 +1941,19 @@ def commit_draft(
         result.error = draft.error
         return result
 
-    if check_duplicates:
-        prior = find_recent_submission(engine, draft.raw_text)
+    if check_duplicates and not override_duplicate:
+        prior = find_recent_submission(
+            engine, draft.raw_text, session_date=draft.session_date
+        )
         if prior is not None:
-            logger.info("Duplicate submission suppressed (%s)", prior)
+            logger.info("Duplicate submission held for a decision (%s)", prior)
             return PipelineResult(
                 inserted_sets=prior["inserted_sets"],
                 inserted_bodyweight=prior["inserted_bodyweight"],
                 duplicate_of_recent=True,
+                duplicate_evidence=describe_recent_submission(
+                    engine, draft.raw_text, session_date=draft.session_date
+                ),
             )
 
     # (model, confidence, the muscle group was chosen by the user not suggested,
@@ -2044,7 +2117,8 @@ def process_entry(
         engine = get_engine()
 
     if check_duplicates:
-        prior = find_recent_submission(engine, raw_text)
+        # The unattended path has nobody to ask, so it still refuses outright.
+        prior = find_recent_submission(engine, raw_text, session_date=session_date)
         if prior is not None:
             logger.info("Duplicate submission suppressed (%s)", prior)
             return PipelineResult(

--- a/review.py
+++ b/review.py
@@ -99,6 +99,12 @@ body { max-width: 60rem; }
 .actions button { margin-top: 0; width: auto; padding: .7rem 1.4rem; }
 .actions button.secondary { background: transparent; color: inherit; border: 1px solid #8886; }
 .actions button.secondary:active { background: #8882; }
+/* Replace deletes a day before it writes. The button that does it should not
+   look like the one that only adds. */
+.actions button.danger { background: #b3261e; color: #fff; border: 1px solid #b3261e; }
+.actions button.danger:active { background: #8c1d16; }
+.dup-evidence { margin: .5rem 0 0; padding-left: 1.1rem; }
+.dup-evidence li { margin: .15rem 0; }
 details.entry summary { cursor: pointer; font-weight: 600; }
 details.entry pre { margin: .6rem 0 0; font-size: .9rem; opacity: .85; }
 """
@@ -270,6 +276,40 @@ def _add_buttons(draft: EntryDraft, standalone: bool = True) -> str:
     return f'<div class="actions">{joined}</div>' if standalone else joined
 
 
+def _duplicate_banner(draft: EntryDraft, duplicate: Mapping[str, Any]) -> str:
+    """Why the save stopped, and what the earlier one actually put in the database.
+
+    Re-pasting an entry to correct a bad parse looks exactly like a
+    double-tapped submit, so this cannot refuse on its own judgement — it states
+    the case, shows the evidence, and lets the user decide.
+    """
+    sets = int(duplicate.get("inserted_sets", 0) or 0)
+    bodyweight = int(duplicate.get("inserted_bodyweight", 0) or 0)
+    evidence = duplicate.get("evidence") or []
+
+    if evidence:
+        items = "".join(
+            f"<li>{html.escape(str(row['exercise']))} &mdash; {int(row['sets'])} set(s)</li>"
+            for row in evidence
+        )
+        detail = f'<ul class="dup-evidence">{items}</ul>'
+    else:
+        # Bodyweight-only entries produce no exercise rows, so there is nothing
+        # to list. Say so rather than showing an empty box.
+        detail = ('<p class="evidence">That save recorded no exercise sets '
+                  "&mdash; a bodyweight reading only.</p>")
+
+    return (
+        '<div class="card warn"><strong>This looks like it was already saved.</strong> '
+        f"The same text was written to {html.escape(draft.session_date.isoformat())} "
+        f"within the last {pipeline.DUPLICATE_WINDOW_MINUTES} minutes, saving {sets} "
+        f"set(s) and {bodyweight} bodyweight entry/entries. Nothing has been written "
+        f"this time yet.{detail}"
+        "<p>If that was a double-tap, go back. If you are re-logging this to fix a "
+        "bad parse, choose how it should land.</p></div>"
+    )
+
+
 def _banner(draft: EntryDraft, existing: Optional[Mapping[str, int]]) -> str:
     parts: list[str] = []
 
@@ -320,17 +360,35 @@ def render_review_body(
     draft: EntryDraft,
     existing: Optional[Mapping[str, int]] = None,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    duplicate: Optional[Mapping[str, Any]] = None,
 ) -> str:
-    """The review form: every prospective row, editable, before anything is written."""
+    """The review form: every prospective row, editable, before anything is written.
+
+    `duplicate` turns the same form into the answer to the duplicate guard: the
+    rows are unchanged and still editable, but the save buttons become the two
+    ways forward. It is rendered from the draft the user just submitted, so
+    nothing they corrected is lost while they decide.
+    """
+    # With a decision pending the mode is carried by whichever button is pressed,
+    # so the hidden copy is left out rather than submitted alongside it.
+    mode_hidden = (
+        ""
+        if duplicate
+        else (f'<input type="hidden" name="mode" '
+              f'value="{"replace" if draft.replace_existing else "add"}">')
+    )
+    override_hidden = (
+        '<input type="hidden" name="override_duplicate" value="1">' if duplicate else ""
+    )
     hidden = (
         f'<input type="hidden" name="raw_text" value="{html.escape(draft.raw_text)}">'
         f'<input type="hidden" name="session_date" '
         f'value="{html.escape(draft.session_date.isoformat())}">'
-        f'<input type="hidden" name="mode" '
-        f'value="{"replace" if draft.replace_existing else "add"}">'
+        f'{mode_hidden}'
         f'<input type="hidden" name="set_count" value="{len(draft.sets)}">'
         f'<input type="hidden" name="has_bodyweight" '
         f'value="{"1" if draft.bodyweight is not None else ""}">'
+        f'{override_hidden}'
     )
 
     entry = (
@@ -378,14 +436,51 @@ def render_review_body(
     # baked in at render time would go stale the moment a box is unticked.
     total = len(draft.included)
 
+    if duplicate:
+        heading = "Already saved once"
+        intro = (
+            '<p class="muted">These rows are still exactly what would be written, '
+            "and still editable. Choose how this should land, or go back.</p>"
+        )
+        banner = _duplicate_banner(draft, duplicate)
+        # Each button carries its own mode, which is why the hidden copy is
+        # omitted above. Replace deletes the day first, so it is styled as the
+        # destructive action it is.
+        actions = (
+            '<button type="submit" name="mode" value="replace" class="danger">'
+            f"Replace {html.escape(draft.session_date.isoformat())} with this</button>"
+            '<button type="submit" name="mode" value="add" class="secondary">'
+            "Add as a second copy</button>"
+            '<a href="/">Go back &mdash; it was a double-tap</a>'
+        )
+    else:
+        heading = "Check before saving"
+        intro = (
+            '<p class="muted">This is exactly what will be written to the database for '
+            f"{html.escape(draft.session_date.isoformat())}. Correct anything that is "
+            "wrong, untick anything that should not be saved, then save. Nothing has "
+            "been stored yet. Muscle group is suggested from the exercise name, not "
+            "read from your entry &mdash; correcting one re-files that exercise for "
+            "good.</p>"
+        )
+        banner = _banner(draft, existing)
+        save_class = ' class="danger"' if draft.replace_existing else ""
+        save_label = (
+            f"Replace {html.escape(draft.session_date.isoformat())} and save"
+            if draft.replace_existing
+            else "Save to database"
+        )
+        actions = (
+            f'<button type="submit" name="action" value="save"{save_class}>'
+            f"{save_label}</button>"
+            f"{_add_buttons(draft, standalone=False)}"
+            '<a href="/">Discard and start over</a>'
+        )
+
     return f"""
-<h1>Check before saving</h1>
-<p class="muted">This is exactly what will be written to the database for
-{html.escape(draft.session_date.isoformat())}. Correct anything that is wrong,
-untick anything that should not be saved, then save. Nothing has been stored yet.
-Muscle group is suggested from the exercise name, not read from your entry &mdash;
-correcting one re-files that exercise for good.</p>
-{_banner(draft, existing)}
+<h1>{heading}</h1>
+{intro}
+{banner}
 {entry}
 <form method="post" action="/save">
 {hidden}{MUSCLE_GROUP_OPTIONS}
@@ -393,9 +488,7 @@ correcting one re-files that exercise for good.</p>
 {cards}
 {bodyweight}
 <div class="actions">
-  <button type="submit" name="action" value="save">Save to database</button>
-  {_add_buttons(draft, standalone=False)}
-  <a href="/">Discard and start over</a>
+  {actions}
 </div>
 <p class="muted">{total} row(s) drafted. Only the ticked ones are saved; an empty
 slot is ignored.</p>

--- a/tests/test_duplicate_guard.py
+++ b/tests/test_duplicate_guard.py
@@ -1,0 +1,351 @@
+"""Tests for the duplicate-submission guard.
+
+The guard exists because Render's free tier cold-starts for 30-50s, which is
+exactly when a user double-taps submit. But a double-tap and a deliberate
+re-paste to correct a bad parse are the same bytes arriving twice, so a guard
+that decides on its own is wrong about half the time it fires. These cover the
+three ways it used to be wrong: it ignored which day was being logged, it
+refused instead of asking, and it asserted a match without showing one.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from html.parser import HTMLParser
+from typing import Optional
+
+import pipeline
+import review
+
+SESSION = date(2026, 8, 22)
+RAW = "Chest bench press 28kg 11 reps. Was 82.4kg this morning."
+
+
+# --------------------------------------------------------------------------
+# Which rows count as "the same entry"
+# --------------------------------------------------------------------------
+
+
+class TestSubmissionClauses:
+    """The WHERE fragment that decides what a duplicate is."""
+
+    def test_matches_on_exact_text_and_a_time_window(self):
+        where, params = pipeline._submission_clauses(RAW, 5, None)
+        assert "raw_source = :raw_source" in where
+        assert "created_at >= now() - CAST(:window AS interval)" in where
+        assert params["raw_source"] == RAW and params["window"] == "5 minutes"
+
+    def test_without_a_date_it_is_not_scoped_to_a_day(self):
+        where, params = pipeline._submission_clauses(RAW, 5, None)
+        assert "logged_at" not in where
+        assert "day_start" not in params
+
+    def test_a_date_scopes_the_match_to_that_local_day(self):
+        where, params = pipeline._submission_clauses(RAW, 5, SESSION)
+        assert "logged_at >= :day_start AND logged_at < :day_end" in where
+        assert params["day_start"], params["day_end"]
+
+    def test_two_dates_produce_disjoint_windows(self):
+        """The defect: one short entry logged against two dates in one sitting.
+
+        "rest day, weighed 82.4" pasted for Saturday and again for Sunday is not
+        a double-tap, but without day scoping the second read as one and was
+        silently dropped.
+        """
+        _, saturday = pipeline._submission_clauses(RAW, 5, date(2026, 8, 22))
+        _, sunday = pipeline._submission_clauses(RAW, 5, date(2026, 8, 23))
+        assert saturday["day_start"] != sunday["day_start"]
+        # Disjoint, not merely different: Saturday ends where Sunday begins.
+        assert saturday["day_end"] == sunday["day_start"]
+
+
+# --------------------------------------------------------------------------
+# A fake engine that can be told what the database already holds
+# --------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, rows=(), scalar=0, rowcount=0):
+        self._rows, self._scalar = list(rows), scalar
+        self.rowcount = rowcount
+
+    def fetchall(self):
+        return self._rows
+
+    def all(self):
+        return self._rows
+
+    def fetchone(self):
+        return (1,)
+
+    def scalar_one(self):
+        return self._scalar
+
+
+class _Connection:
+    def __init__(self, engine):
+        self.engine = engine
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        sql = " ".join(str(statement).split())
+        self.engine.statements.append((sql, params or {}))
+
+        # Order matters: the evidence query also selects count(*) over
+        # raw_source, so it has to be matched before the counting branch.
+        if "GROUP BY e.name" in sql:
+            return _Result(rows=self.engine.evidence_rows)
+        if "count(*)" in sql and "raw_source" in sql:
+            return _Result(scalar=self.engine.prior_count)
+        if "FROM exercises" in sql:
+            return _Result(rows=[])
+        if sql.startswith("DELETE"):
+            self.engine.deletes.append(sql)
+            return _Result(scalar=0)
+        return _Result()
+
+
+class _Engine:
+    """Enough of an Engine for commit_draft, with a settable prior save."""
+
+    def __init__(self, prior_count=0, evidence_rows=()):
+        self.prior_count = prior_count
+        self.evidence_rows = list(evidence_rows)
+        self.statements: list = []
+        self.deletes: list = []
+
+    def begin(self):
+        return _Connection(self)
+
+    def connect(self):
+        return _Connection(self)
+
+    @property
+    def inserted(self):
+        return [p for _, p in self.statements if "extraction_confidence" in p]
+
+
+def draft_for(replace=False):
+    draft = pipeline.draft_from_payload(
+        {"sets": [{"exercise_name": "Chest Bench Press", "weight_kg": 28.0,
+                   "reps": 11, "raw_span": RAW}]},
+        RAW,
+        SESSION,
+    )
+    for row in draft.sets:
+        row.include = True
+    draft.replace_existing = replace
+    return draft
+
+
+# --------------------------------------------------------------------------
+# Asking instead of refusing
+# --------------------------------------------------------------------------
+
+
+class TestGuardHoldsForADecision:
+    def test_a_match_writes_nothing_and_reports_the_prior_save(self):
+        engine = _Engine(prior_count=3)
+        result = pipeline.commit_draft(draft_for(), engine=engine, check_duplicates=True)
+        assert result.duplicate_of_recent is True
+        assert result.inserted_sets == 3
+        assert engine.inserted == []
+
+    def test_no_match_saves_normally(self):
+        engine = _Engine(prior_count=0)
+        result = pipeline.commit_draft(draft_for(), engine=engine, check_duplicates=True)
+        assert result.duplicate_of_recent is False
+        assert result.inserted_sets == 1
+
+    def test_the_guard_is_scoped_to_the_day_being_logged(self):
+        engine = _Engine(prior_count=1)
+        pipeline.commit_draft(draft_for(), engine=engine, check_duplicates=True)
+        counts = [(sql, p) for sql, p in engine.statements if "count(*)" in sql]
+        assert counts, "the guard never ran"
+        assert all("logged_at" in sql for sql, _ in counts)
+        assert all("day_start" in p for _, p in counts)
+
+    def test_the_match_comes_with_evidence(self):
+        """A guard that shows nothing cannot be argued with, or trusted."""
+        engine = _Engine(prior_count=2, evidence_rows=[("Chest Bench Press", 2, None)])
+        result = pipeline.commit_draft(draft_for(), engine=engine, check_duplicates=True)
+        assert result.duplicate_evidence == [
+            {"exercise": "Chest Bench Press", "sets": 2, "first_logged": None}
+        ]
+
+    def test_evidence_is_empty_when_nothing_is_matched(self):
+        engine = _Engine(prior_count=0)
+        result = pipeline.commit_draft(draft_for(), engine=engine, check_duplicates=True)
+        assert result.duplicate_evidence == []
+
+
+class TestOverridingTheGuard:
+    def test_override_saves_despite_a_match(self):
+        engine = _Engine(prior_count=3)
+        result = pipeline.commit_draft(
+            draft_for(), engine=engine, check_duplicates=True, override_duplicate=True
+        )
+        assert result.duplicate_of_recent is False
+        assert result.inserted_sets == 1
+
+    def test_replace_on_a_matched_entry_actually_replaces(self):
+        """The defect: selecting Replace and re-submitting did nothing at all.
+
+        The delete-and-reinsert was stopped by the same guard, so the save
+        appeared to succeed while changing nothing.
+        """
+        engine = _Engine(prior_count=3)
+        result = pipeline.commit_draft(
+            draft_for(replace=True),
+            engine=engine,
+            check_duplicates=True,
+            override_duplicate=True,
+        )
+        assert engine.deletes, "replace never deleted the day"
+        assert result.inserted_sets == 1
+
+    def test_override_does_not_skip_the_guard_when_not_asked(self):
+        engine = _Engine(prior_count=3)
+        result = pipeline.commit_draft(
+            draft_for(), engine=engine, check_duplicates=True, override_duplicate=False
+        )
+        assert result.duplicate_of_recent is True
+
+
+# --------------------------------------------------------------------------
+# What the page offers
+# --------------------------------------------------------------------------
+
+
+DUPLICATE = {
+    "inserted_sets": 2,
+    "inserted_bodyweight": 1,
+    "evidence": [{"exercise": "Chest Bench Press", "sets": 2, "first_logged": None}],
+}
+
+
+class TestDuplicatePage:
+    def test_it_offers_both_ways_forward(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert 'name="mode" value="replace"' in body
+        assert 'name="mode" value="add"' in body
+
+    def test_it_carries_the_override_back(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert 'name="override_duplicate" value="1"' in body
+
+    def test_it_does_not_also_submit_a_hidden_mode(self):
+        """Both would post, and the form would carry two values for one field."""
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert '<input type="hidden" name="mode"' not in body
+
+    def test_it_shows_what_the_earlier_save_produced(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert "Chest Bench Press" in body and "2 set(s)" in body
+
+    def test_a_bodyweight_only_match_says_so_instead_of_an_empty_list(self):
+        body = review.render_review_body(
+            draft_for(), duplicate={**DUPLICATE, "evidence": []}
+        )
+        assert "bodyweight reading only" in body
+        assert '<ul class="dup-evidence">' not in body
+
+    def test_the_rows_are_still_there_and_still_editable(self):
+        """Deciding must not cost the user the corrections they just made."""
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert 'name="s0.exercise_name"' in body
+
+    def test_replace_is_marked_destructive(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert 'value="replace" class="danger"' in body
+
+
+class TestOrdinaryPageIsUnchanged:
+    def test_it_still_carries_a_hidden_mode(self):
+        body = review.render_review_body(draft_for())
+        assert '<input type="hidden" name="mode"' in body
+
+    def test_it_does_not_offer_an_override(self):
+        body = review.render_review_body(draft_for())
+        assert "override_duplicate" not in body
+
+    def test_a_plain_save_button_is_not_destructive(self):
+        body = review.render_review_body(draft_for())
+        assert "Save to database" in body
+        assert 'class="danger"' not in body
+
+    def test_replace_mode_marks_its_save_button_destructive(self):
+        """It deletes a day before it writes; it should not look like Add."""
+        body = review.render_review_body(draft_for(replace=True))
+        assert 'class="danger"' in body
+        assert "Replace 2026-08-22 and save" in body
+
+
+# --------------------------------------------------------------------------
+# The decision travelling back
+# --------------------------------------------------------------------------
+
+
+class _FormScraper(HTMLParser):
+    """Read the rendered form back as the browser would submit it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: dict[str, str] = {}
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if "name" not in attributes:
+            return
+        if tag == "input" and attributes.get("type") == "checkbox":
+            if "checked" in attributes:
+                self.data[attributes["name"]] = "on"
+        elif tag == "input":
+            self.data[attributes["name"]] = attributes.get("value", "")
+
+
+def _submit(body: str, pressed: Optional[tuple[str, str]] = None) -> dict[str, str]:
+    """The fields a browser would post, plus whichever button was pressed."""
+    scraper = _FormScraper()
+    scraper.feed(body)
+    data = scraper.data
+    if pressed:
+        data[pressed[0]] = pressed[1]
+    return data
+
+
+class TestDecisionRoundTrip:
+    """Pressing a button has to survive the trip back through the form.
+
+    The buttons carry `mode` because the hidden copy is dropped; if either end
+    of that arrangement broke, the save would silently fall back to Add.
+    """
+
+    def test_pressing_replace_comes_back_as_replace(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        form = _submit(body, pressed=("mode", "replace"))
+        assert review.draft_from_form(form).replace_existing is True
+
+    def test_pressing_add_comes_back_as_add(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        form = _submit(body, pressed=("mode", "add"))
+        assert review.draft_from_form(form).replace_existing is False
+
+    def test_the_override_survives_the_round_trip(self):
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        assert _submit(body)["override_duplicate"] == "1"
+
+    def test_the_rows_survive_the_round_trip(self):
+        """Whatever the user corrected before the guard fired must still be there."""
+        body = review.render_review_body(draft_for(), duplicate=DUPLICATE)
+        rebuilt = review.draft_from_form(_submit(body, pressed=("mode", "add")))
+        assert rebuilt.sets[0].values["exercise_name"] == "Chest Bench Press"
+        assert rebuilt.sets[0].values["weight_kg"] == 28.0
+
+    def test_an_ordinary_save_carries_no_override(self):
+        assert "override_duplicate" not in _submit(review.render_review_body(draft_for()))


### PR DESCRIPTION
## Summary

Ports the duplicate-guard fixes from the parallel preview branch (`claude/manual-overwrite-preview-missing-bo09b1`) onto `main`'s review screen.

That branch reimplemented preview-before-write as `prepare_entry`/`commit_entry`, which collides with the `build_draft`/`commit_draft` split already on `main` — a trial merge produced 13 conflict hunks across `app.py`, `pipeline.py` and `README.md`. The guard fixes are independent of that split, so **only they are taken**. The competing preview mechanism is left out: `main`'s review screen already previews, and does it with editable rows, per-field validation and the name flag.

## Three defects, all silent

**It refused rather than asking.** Re-pasting an entry to correct a bad parse is the same bytes arriving twice as a double-tapped submit, so the guard cannot tell them apart and no longer tries. On a match nothing is written and the review screen comes straight back — rows intact and still editable — with two ways forward: replace that day, or add a second copy. Selecting Replace previously did nothing at all, because the delete-and-reinsert was stopped by the same guard.

**It was not scoped to the date being logged.** One short entry ("rest day, weighed 82.4") logged against two dates in one sitting read as a double-tap, and the second date was silently dropped.

**It asserted a match and showed no evidence.** It now lists what that earlier save actually produced, exercise by exercise, so a match that looks wrong can be checked rather than believed.

Replace also gets the destructive styling its behaviour already earned; it already named the counts it would delete before the button could be pressed.

The unattended CLI path still refuses outright — there is nobody to ask — but it is day-scoped now too.

## Design note

`override_duplicate` is the answer to the guard, not a way around it: it is set only by the decision page, so a first save always passes through the guard. On that page the hidden `mode` field is omitted and each button carries its own `mode`, since submitting both would post two values for one field.

## Tests

**741 passing**, up from 713. `tests/test_duplicate_guard.py` is new — the guard had **no coverage at all** before this.

Mutation-checked; each of these fails the suite:

| Mutation | Result |
|---|---|
| day scoping removed | 3 failed |
| override ignored | 2 failed |
| evidence never gathered | 1 failed |
| hidden `mode` left in on the duplicate page | 1 failed |

The round trip is covered end to end: the rendered form is scraped as a browser would submit it, posted back through `draft_from_form`, and checked that the pressed button's mode and the user's corrections both survive.

Also removes a branch in `_render_result` that became unreachable — `/save` now intercepts duplicates before it, and the branch still described the old refusal behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_017iEauN9pPMfKg1ubfcyNNd)_