### PR TITLE
Add multi-user accounts with login sessions and per-user data isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,20 +32,35 @@ GROQ_MAX_RETRY_WAIT_SECONDS=20
 DATABASE_URL=postgresql://postgres:your_password@db.your-project.supabase.co:5432/postgres
 
 # --- Web app auth ---------------------------------------------------------
-# HTTP Basic Auth. Only safe over HTTPS — Render terminates TLS by default,
-# but confirm your deployed URL is https:// before relying on this.
-APP_USERNAME=change_me
-APP_PASSWORD=use_a_long_random_string
+# Accounts live in the `users` table, not here. Anyone can register at /signup,
+# and each account sees only its own training.
+#
+# APP_USERNAME / APP_PASSWORD are no longer how anyone logs in. They are read
+# in exactly two places, both one-off:
+#   * migrate_multi_user.py, to name the owner account that inherits everything
+#     an existing single-user database already holds;
+#   * the CLI scripts, as the default for --user.
+# On a fresh deployment you can leave both unset and register at /signup.
+APP_USERNAME=
+APP_PASSWORD=
+
+# PBKDF2-HMAC-SHA256 rounds for password hashing. Higher is slower to attack and
+# slower to log in with; the count is stored inside each hash, so raising this
+# re-hashes each user on their next login instead of locking them out.
+PBKDF2_ITERATIONS=600000
+# How long a login lasts before the password is asked for again, in days.
+SESSION_TTL_DAYS=30
 
 # --- Pipeline tuning ------------------------------------------------------
 # Entries scoring below this are surfaced for review instead of inserted.
 CONFIDENCE_THRESHOLD=0.7
 # rapidfuzz score at/above which a proposed exercise name reuses an existing row.
 FUZZY_MATCH_THRESHOLD=85
-# Single fixed timezone for this single-user tool. IANA name. This is what
-# decides which calendar day - and so which week - a session belongs to, so on
-# a host whose clock is UTC (Vercel, Render) leaving it unset dates anything
-# logged late at night a day early. Set it to where you actually train.
+# Default timezone for accounts that have not set their own (Account -> Timezone,
+# or `manage_users.py timezone <user> <zone>`). IANA name. This is what decides
+# which calendar day - and so which week - a session belongs to, so on a host
+# whose clock is UTC (Vercel, Render) leaving it unset dates anything logged
+# late at night a day early. Set it to where most of your users train.
 LOCAL_TIMEZONE=UTC
 # Assumed wall-clock hour when the journal text carries no time marker.
 DEFAULT_SESSION_HOUR=18

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Turns messy free-text gym journal entries into structured Postgres rows, and
 generates a weekly progress report on top of them.
 
+Several people can share one deployment. Everyone registers their own account
+at `/signup`, and every query the app makes is filtered by the account you are
+signed in as — training, exercises, bodyweight and reports are all private to
+the person who logged them.
+
 You keep logging in your phone's Notes app exactly as you do now — typos,
 voice-to-text run-ons, times like "6:20ish", commentary like "almost died" —
 then paste the text into a small web form. The pipeline extracts the sets,
@@ -17,6 +22,7 @@ here; the schema is just shaped for it.
 
 ```
 Notes app (unchanged)
+  -> sign in                                   app.py            POST /login
   -> paste into the mobile web form            app.py            POST /log
   -> Groq extraction, JSON mode, 1 retry       pipeline.extract_entities
   -> Pydantic validation + computed score      pipeline.build_draft
@@ -27,6 +33,7 @@ Notes app (unchanged)
   -> rescored against what you actually typed  review.draft_from_form
   -> fuzzy match against existing exercises    pipeline.find_matching_exercise
   -> parameterized INSERT into Postgres        pipeline.commit_draft
+       every row carries the user_id from your session cookie
   -> Power BI reads Postgres directly (later, not part of this build)
 ```
 
@@ -38,9 +45,12 @@ below the confidence threshold is reported rather than saved
 
 | File | What it is |
 |---|---|
-| `schema.sql` | Postgres schema: `exercises`, `workout_logs`, `bodyweight_logs`, `weekly_reports` |
+| `schema.sql` | Postgres schema: `users`, `user_sessions`, `exercises`, `workout_logs`, `bodyweight_logs`, `weekly_reports` |
+| `auth.py` | Accounts: password hashing, username rules, login sessions, rate limiting. No HTML, no FastAPI, opens no connections |
 | `pipeline.py` | All extraction / validation / insert logic. The CLI and web app both import this; neither reimplements any of it |
-| `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date>` |
+| `parse_workout_log.py` | CLI: `python parse_workout_log.py <file> <date> --user <name>` |
+| `manage_users.py` | Admin CLI: list / create / passwd / timezone / suspend / restore / delete accounts |
+| `migrate_multi_user.py` | One-off: upgrades a single-user database to accounts, moving what it already holds onto an owner account |
 | `app.py` | FastAPI web app — the phone-facing form, plus the weekly-report button |
 | `review.py` | The review screen: renders a draft as an editable form, reads the submission back, and adds empty slots on request |
 | `insights.py` | Weekly report. Stage A computes every number; Stage B only writes prose |
@@ -48,7 +58,7 @@ below the confidence threshold is reported rather than saved
 | `muscle_groups.py` | Static exercise-name -> primary muscle group tables and lookup |
 | `seed_sample_data.py` | Seeds three weeks of realistic data so the report can be tried out |
 | `backfill_muscle_groups.py` | One-off: fills `muscle_group` for exercises logged before the lookup existed |
-| `tests/` | Unit tests for the Stage A rules and the confidence / fuzzy-match logic |
+| `tests/` | Unit tests for the Stage A rules, the confidence / fuzzy-match logic, passwords and sessions, and per-account isolation |
 | `sample_entry.txt` | A messy journal entry in the real style, for trying the CLI |
 
 ## Setup
@@ -80,12 +90,30 @@ setup. They are additive and re-runnable:
 psql "$DATABASE_URL" -f migrations/001_add_cheat_reps.sql
 ```
 
-**Supabase:** enable RLS on all four tables. The app connects as the table owner
-so it bypasses RLS, but Supabase auto-exposes a REST API over the `public`
-schema to the anon key, and without RLS that key can read and delete your data.
-No policies are needed — RLS on with zero policies denies the API entirely:
+**Upgrading a database that predates accounts** — do *not* run `schema.sql` over
+it. Run the migration script instead, which needs Python because it has to hash
+the owner's password:
+
+```bash
+python migrate_multi_user.py --dry-run     # print the statements, change nothing
+python migrate_multi_user.py               # apply
+```
+
+It creates the tables and columns accounts need, then hands everything already
+logged to one owner account built from `APP_USERNAME` / `APP_PASSWORD` — so you
+carry on logging in with the credentials you already use, and your history is
+where you left it. Anyone else registers at `/signup`. Re-running it is a no-op.
+
+**Supabase:** enable RLS on every table. The app connects as the table owner so
+it bypasses RLS, but Supabase auto-exposes a REST API over the `public` schema to
+the anon key, and without RLS that key can read and delete your data. With
+accounts in the picture it would also expose password hashes and live session
+tokens, so `users` and `user_sessions` matter most of all. No policies are needed
+— RLS on with zero policies denies the API entirely:
 
 ```sql
+ALTER TABLE users           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_sessions   ENABLE ROW LEVEL SECURITY;
 ALTER TABLE exercises       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE workout_logs    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE bodyweight_logs ENABLE ROW LEVEL SECURITY;
@@ -95,12 +123,24 @@ ALTER TABLE weekly_reports  ENABLE ROW LEVEL SECURITY;
 ### Try it
 
 ```bash
-python parse_workout_log.py sample_entry.txt 2026-08-14 --dry-run   # no writes
-python parse_workout_log.py sample_entry.txt 2026-08-14
-
-python seed_sample_data.py --reset      # three weeks of sample data
 uvicorn app:app --reload                # then open http://127.0.0.1:8000
+                                        # and register at /signup
 ```
+
+Or from the command line, where every write has to say whose it is:
+
+```bash
+python manage_users.py create alice                                 # prompts for a password
+python manage_users.py list                                         # id, username, sets, timezone
+
+python parse_workout_log.py sample_entry.txt 2026-08-14 --dry-run   # no writes, no account needed
+python parse_workout_log.py sample_entry.txt 2026-08-14 --user alice
+
+python seed_sample_data.py --user alice --reset   # three weeks of sample data
+```
+
+`--reset` clears only that account's rows, so seeding a demo user cannot wipe
+real training. `--user` defaults to `$APP_USERNAME` when it is set.
 
 Stuck on configuration? `--check-config` reports where every setting is coming
 from and tests both connections, without printing a secret:
@@ -127,6 +167,63 @@ A leading `~` means the text carried no time marker and the default session hour
 was applied — which is how you spot a time the extraction missed.
 
 ## The decisions worth knowing about
+
+### Ownership comes from the session, never from the request
+
+There is no route anywhere that takes a user id from a query string, a form
+field or a header. Every route resolves the signed-in account from the session
+cookie, and that id is what reaches the data layer.
+
+This matters most at `POST /save`. The review screen round-trips the whole draft
+through hidden form fields, so everything the browser posts back is attacker-
+controlled by definition — you can edit it in devtools. If ownership travelled in
+that form, hand-editing one field would write into somebody else's account.
+So `commit_draft` takes `user_id` as an argument rather than reading it off the
+draft:
+
+```python
+result = pipeline.commit_draft(draft, user.user_id, engine=get_engine(), ...)
+```
+
+`user_id` is a **required positional** parameter on every function that reads or
+writes training data — no default, anywhere. A default would have to pick an
+account, and the account it picks is wrong for everyone else. Calling
+`commit_draft(draft)` is a `TypeError`, not a silent write to user 1.
+
+The sharpest edge is `delete_entries_for_date`, which backs the **Replace**
+option. Unscoped, one person correcting Tuesday's entry would clear Tuesday for
+every account on the deployment. `tests/test_multi_user.py` asserts that every
+statement touching an owned table names `user_id` in both the SQL and the bound
+parameters.
+
+### Exercises are per-user, not a shared catalogue
+
+`exercises` was `UNIQUE (name)`; it is now `UNIQUE (user_id, name)`.
+
+A shared catalogue looks tempting — one canonical "Bench Press" row, less
+duplication — but it breaks two things this app already does. Fuzzy matching
+compares a proposed name against everything known, so a shared table would let
+one person's typo merge into another person's lift. And the review screen lets
+you correct an exercise's muscle group, which with a shared row would silently
+refile it under everyone else's charts too.
+
+The cost is a duplicate row per person per lift. The benefit is that your filing
+decisions are yours.
+
+### Each account has its own timezone
+
+`LOCAL_TIMEZONE` decides which calendar day, and therefore which week, a session
+belongs to. With one user, one env var was the right answer. With several it
+would date a Karachi user's late-night session by London's midnight — and at a
+Sunday boundary that files it in the wrong week's volume entirely.
+
+So `users.timezone` overrides it per account, set at signup or under Account →
+Timezone, and `NULL` falls back to the deployment default. It is threaded to
+everything that converts between local and UTC: inserts, the day bounds behind
+Replace, the report window and the dashboard.
+
+Changing it does not move anything already logged. Stored timestamps are UTC and
+still mark the same instant; only the boundaries drawn around them move.
 
 ### The LLM does not produce any number in the report
 
@@ -542,17 +639,49 @@ A few decisions that are easy to get wrong:
 - **Parameterized SQL everywhere.** Every statement is `sqlalchemy.text()` with
   bound `:param` placeholders. No value — user-typed or model-generated — is ever
   formatted into a query string.
-- **Secrets are env vars only.** `GROQ_API_KEY`, `DATABASE_URL`, `APP_USERNAME`,
-  `APP_PASSWORD` are never hardcoded, never rendered to the page, never logged.
-  `.env` is gitignored; `.env.example` holds placeholders only.
-- **HTTP Basic Auth** on every route except `/healthz`, compared with
-  `secrets.compare_digest`. Basic Auth credentials are base64, not encrypted, so
-  this is **only safe over HTTPS** — Render terminates TLS by default, but confirm
-  your deployed URL is `https://` before relying on it. The app logs a warning on
-  any non-local request that arrives over plain HTTP.
+- **Secrets are env vars only.** `GROQ_API_KEY` and `DATABASE_URL` are never
+  hardcoded, never rendered to the page, never logged. `.env` is gitignored;
+  `.env.example` holds placeholders only. Account passwords are not env vars at
+  all — they live in `users.password_hash`, hashed.
+- **Passwords are PBKDF2-HMAC-SHA256**, 600,000 rounds by default, with a
+  16-byte salt per user. The cost factor is stored inside each hash, so raising
+  `PBKDF2_ITERATIONS` re-hashes people on their next login instead of locking
+  them out. A login attempt for a username that does not exist still runs one
+  full hash, so response time does not reveal which accounts are real.
+- **Sessions are opaque random tokens**, and only their SHA-256 is stored. A
+  database dump therefore cannot be replayed as a live login. The cookie is
+  `HttpOnly`, `SameSite=Lax`, and `Secure` whenever the request arrived over
+  HTTPS. Changing a password revokes every session for that account.
+- **`SameSite=Lax` is what stands in for a CSRF token.** Every form on the site
+  is a same-site POST, which Lax allows; the browser withholds the cookie on a
+  cross-site POST, so another origin cannot submit these forms on a signed-in
+  user's behalf.
+- **Login and signup are rate-limited** per client, 10 attempts per 5 minutes and
+  5 signups per hour. The counter is per-process, so a serverless deploy running
+  several instances allows a multiple of that — enough to make an unattended
+  guessing loop impractical, not enough to stop a targeted one.
+- **The login form does not say which half was wrong.** A wrong password and a
+  missing account give the same message, so the form cannot be used to test which
+  usernames exist.
+- **`?next=` is checked before redirecting.** Only a bare absolute path is
+  accepted, so the login page cannot be used to bounce someone to an attacker's
+  copy of it.
+- **HTTP Basic Auth still works for scripts**, checked against the `users` table
+  rather than an env var. Basic credentials are base64, not encrypted, so it is
+  **only safe over HTTPS** — Render terminates TLS by default, but confirm your
+  deployed URL is `https://` before relying on it. The app logs a warning on any
+  non-local Basic request that arrives over plain HTTP.
 - **Model output is escaped before it reaches the page.** Extracted exercise
   names are rendered through `html.escape`, so a name containing markup cannot
   inject anything.
+
+### What multi-user does not give you
+
+Isolation here is enforced in the application — every query filters on the
+`user_id` from the session — and by foreign keys, not by Postgres row-level
+security against a per-user database role. Anyone with the `DATABASE_URL` can
+read every account. That is the same trust boundary the single-user version had;
+it is worth saying out loud now that the data is no longer all yours.
 
 ## Deployment
 
@@ -565,13 +694,15 @@ first request after a long gap can be slow.
 `app` in `app.py`, so there is nothing to configure beyond environment variables.
 
 - Import the repo at vercel.com, accept the detected settings
-- Set `DATABASE_URL`, `GROQ_API_KEY`, `APP_USERNAME`, `APP_PASSWORD` and
-  `LOCAL_TIMEZONE` in Project Settings → Environment Variables (`.env` is
-  gitignored, so it is not deployed)
+- Set `DATABASE_URL`, `GROQ_API_KEY` and `LOCAL_TIMEZONE` in Project Settings →
+  Environment Variables (`.env` is gitignored, so it is not deployed).
+  `APP_USERNAME` / `APP_PASSWORD` are only needed if you are migrating an
+  existing single-user database; nobody logs in with them
 - `LOCAL_TIMEZONE` is not optional in practice. Vercel's containers run on UTC,
   and it is what decides which day — and therefore which week — a session is
   filed under. Leave it unset and a workout logged late at night is dated a day
-  early; on a Sunday night that puts it in the previous week's volume
+  early; on a Sunday night that puts it in the previous week's volume. It is now
+  only the *default*: each account can set its own under Account → Timezone
 - `vercel.json` pins `maxDuration` to 60s, which covers a Groq call plus inserts
 
 Use the Supabase **transaction pooler (port 6543)** rather than session mode
@@ -589,8 +720,8 @@ other serverless host.
 
 - Build: `pip install -r requirements.txt`
 - Start: `uvicorn app:app --host 0.0.0.0 --port $PORT`
-- Set `GROQ_API_KEY`, `DATABASE_URL`, `APP_USERNAME`, `APP_PASSWORD` in the
-  dashboard, plus any tuning vars from `.env.example`.
+- Set `GROQ_API_KEY` and `DATABASE_URL` in the dashboard, plus any tuning vars
+  from `.env.example`. Accounts are created at `/signup`, not here.
 
 Free instances spin down after 15 minutes idle and take 30–50s to wake. That is
 fine for personal use and is exactly why the duplicate-submission guard exists.
@@ -613,7 +744,7 @@ pip install -r requirements-dev.txt
 pytest -q
 ```
 
-697 tests, no network and no database required — they cover the Stage A
+815 tests, no network and no database required — they cover the Stage A
 rule branches (e1RM, plateau detection, the program-stagnation rollup, every
 increase/hold/deload branch, pain safeguard on and off, the escalation
 threshold), `pipeline.py`'s confidence heuristic, fuzzy matching, timestamp
@@ -626,6 +757,16 @@ functions, so they are cheap to cover, and they are exactly the code where a
 silent bug produces a wrong training recommendation, or a saved row that does
 not match what was on screen, and nobody notices.
 
+Two files cover accounts. `tests/test_auth.py` takes the password and session
+machinery — salting, the stored cost factor, malformed hashes never
+authenticating, username folding, the rate limiter's per-client keying.
+`tests/test_multi_user.py` takes isolation from both ends: it drives the
+database functions against a recording connection and asserts every statement
+touching an owned table names `user_id` in the SQL *and* binds it, then drives
+the app itself and asserts the id those functions receive always came from the
+session cookie — including that a `user_id` planted in the posted review form is
+ignored.
+
 ## Not built (by design)
 
 - **iOS Shortcut** posting from the Notes Share Sheet straight to `/log`. Listed
@@ -635,3 +776,13 @@ not match what was on screen, and nobody notices.
   later upgrade.
 - **Power BI dashboards.** The schema is shaped for them; building them is not
   part of this.
+- **Password reset by email.** There is no mail transport in this stack and
+  adding one for a handful of users is not worth it. A forgotten password is
+  reset from the CLI: `python manage_users.py passwd <username>`.
+- **Sharing training between accounts** — a coach view, a shared program, a
+  leaderboard. Isolation is currently absolute, which is the safe default and
+  the easy thing to relax later. Nothing here reads across accounts.
+- **Postgres row-level security per user.** Isolation is enforced in the
+  application and by foreign keys. Real RLS would need a database role per user
+  and a connection that assumes it, which the pooled free-tier setup does not
+  make easy.

--- a/app.py
+++ b/app.py
@@ -4,9 +4,18 @@ Routes:
     GET  /               mobile-friendly entry form
     POST /log            parse a pasted journal entry into an editable review form
     POST /save           write the reviewed rows to the database
+    GET  /progress       charts over this user's logged data
     GET  /weekly-report  report page with a "Generate weekly report" button
     POST /weekly-report  run Stage A + Stage B and upsert the report
+    GET/POST /login      sign in, issuing a session cookie
+    GET/POST /signup     register a new account
+    POST /logout         drop the session
+    GET/POST /account    change timezone or password
     GET  /healthz        unauthenticated liveness probe
+
+Every route except /healthz, /login and /signup requires a signed-in user and
+reads and writes only that user's rows. Ownership always comes from the session
+cookie, never from anything the browser posted.
 
 Saving is deliberately two steps. POST /log only extracts; it renders every
 prospective database row for editing, with anything missing or invalid marked in
@@ -20,20 +29,26 @@ reimplemented here.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import html
 import logging
-import os
 import re
-import secrets
 import sys
 import time
 from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Response,
+)
 
 # Serverless loaders import this file by path rather than as part of a package,
 # and do not necessarily put its own directory on sys.path. Without this the
@@ -49,7 +64,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # the reason instead.
 _STARTUP_ERROR: Optional[str] = None
 try:
-    import charts  # noqa: E402 - must follow the sys.path bootstrap above
+    import auth  # noqa: E402 - must follow the sys.path bootstrap above
+    import charts  # noqa: E402
     import insights  # noqa: E402
     import pipeline  # noqa: E402
     import review  # noqa: E402
@@ -57,7 +73,7 @@ except Exception:  # noqa: BLE001 - report anything that stops the app booting
     import traceback
 
     _STARTUP_ERROR = traceback.format_exc()
-    charts = insights = pipeline = review = None  # type: ignore[assignment]
+    auth = charts = insights = pipeline = review = None  # type: ignore[assignment]
 
 logging.basicConfig(
     level=pipeline.env("LOG_LEVEL", "INFO").upper() if pipeline else "INFO",
@@ -66,7 +82,6 @@ logging.basicConfig(
 logger = logging.getLogger("gym_tracker.app")
 
 app = FastAPI(title="Gym Tracker", docs_url=None, redoc_url=None)
-security = HTTPBasic()
 
 _engine = None
 
@@ -84,40 +99,157 @@ def get_engine():
 # --------------------------------------------------------------------------
 
 
-def require_auth(request: Request, credentials: HTTPBasicCredentials = Depends(security)) -> str:
-    """HTTP Basic Auth against env vars, compared in constant time.
+class LoginRequired(Exception):
+    """No usable session. Handled below by redirecting to /login.
 
-    Basic Auth credentials are base64, not encrypted, so this is only safe over
-    HTTPS. Render terminates TLS by default; the check below logs loudly if a
-    request ever arrives over plain HTTP so a misconfigured deployment is not
-    silently insecure.
+    A dependency cannot return a response, and a bare 401 would make the browser
+    pop its own Basic Auth box, which is exactly the experience the login page
+    replaces. Raising this instead lets the handler send a redirect that
+    remembers where the person was going.
     """
-    expected_user = os.getenv("APP_USERNAME")
-    expected_password = os.getenv("APP_PASSWORD")
-    if not expected_user or not expected_password:
-        logger.error("event=auth_misconfigured msg='APP_USERNAME/APP_PASSWORD not set'")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Server auth is not configured.",
-        )
 
-    forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
-    if forwarded_proto != "https" and request.client and request.client.host not in {"127.0.0.1", "::1"}:
+    def __init__(self, next_url: str = "/") -> None:
+        self.next_url = next_url
+
+
+@app.exception_handler(LoginRequired)
+async def _login_required_handler(request: Request, exc: LoginRequired) -> Response:
+    target = "/login"
+    if exc.next_url and exc.next_url != "/":
+        # safe='/' only: a path is all this ever carries, and leaving '&' or
+        # '=' unescaped would let one smuggle extra query parameters in.
+        target = f"/login?next={quote(exc.next_url, safe='/')}"
+    return RedirectResponse(target, status_code=status.HTTP_303_SEE_OTHER)
+
+
+def _is_https(request: Request) -> bool:
+    """Whether the browser's leg of the connection is TLS.
+
+    Render and Vercel both terminate TLS and forward over HTTP, so the scheme on
+    the request object is not the one the user saw; x-forwarded-proto is.
+    """
+    return request.headers.get("x-forwarded-proto", request.url.scheme) == "https"
+
+
+def _is_local(request: Request) -> bool:
+    return bool(request.client and request.client.host in {"127.0.0.1", "::1"})
+
+
+def _client_key(request: Request) -> str:
+    """Best available identifier for rate-limiting one caller.
+
+    Behind a proxy every request carries the proxy's address, so the first hop
+    in x-forwarded-for is used where present. A determined attacker can forge
+    that header and get a fresh bucket per request; the point of the limit is to
+    stop an unattended guessing loop, not a targeted one, and without it a
+    single shared bucket would let one attacker lock out every real user.
+    """
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+# Per-instance, so a serverless deploy running several instances allows a
+# multiple of these. Still enough to make credential stuffing impractical.
+_LOGIN_LIMITER = auth.RateLimiter(limit=10, window_seconds=300) if auth else None
+_SIGNUP_LIMITER = auth.RateLimiter(limit=5, window_seconds=3600) if auth else None
+
+
+def _set_session_cookie(response: Response, token: str, secure: bool) -> None:
+    response.set_cookie(
+        auth.SESSION_COOKIE,
+        token,
+        max_age=auth.session_cookie_max_age(),
+        httponly=True,
+        # Lax is what stands in for a CSRF token here: the browser withholds the
+        # cookie on a cross-site POST, so another origin cannot submit these
+        # forms on a logged-in user's behalf. Every form on the site is a
+        # same-site POST, which Lax still allows.
+        samesite="lax",
+        secure=secure,
+        path="/",
+    )
+
+
+def _clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(auth.SESSION_COOKIE, path="/")
+
+
+def _basic_auth_user(request: Request) -> Optional[auth.User]:
+    """Authenticate an `Authorization: Basic` header against the users table.
+
+    Kept so curl and scripts still work against a deployment. Credentials are
+    base64, not encrypted, so this is only safe over HTTPS; a request that
+    arrives without TLS is logged loudly rather than silently trusted.
+    """
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("basic "):
+        return None
+
+    if not _is_https(request) and not _is_local(request):
         logger.warning(
-            "event=insecure_transport proto=%s msg='Basic Auth credentials sent without TLS'",
-            forwarded_proto,
+            "event=insecure_transport msg='Basic Auth credentials sent without TLS'"
+        )
+    try:
+        decoded = base64.b64decode(header.split(" ", 1)[1], validate=True).decode("utf-8")
+        username, _, password = decoded.partition(":")
+    except (binascii.Error, UnicodeDecodeError, IndexError):
+        return None
+
+    if _LOGIN_LIMITER is not None and not _LOGIN_LIMITER.check(f"basic:{_client_key(request)}"):
+        logger.warning("event=auth_rate_limited scheme=basic")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many attempts. Wait a few minutes.",
         )
 
-    user_ok = secrets.compare_digest(credentials.username, expected_user)
-    password_ok = secrets.compare_digest(credentials.password, expected_password)
-    if not (user_ok and password_ok):
-        logger.warning("event=auth_failed path=%s", request.url.path)
+    with get_engine().begin() as conn:
+        user = auth.authenticate(conn, username, password)
+
+    # Successful calls do not count against the limit. A script polling this
+    # endpoint legitimately would otherwise lock itself out inside a minute.
+    if user is not None and _LOGIN_LIMITER is not None:
+        _LOGIN_LIMITER.reset(f"basic:{_client_key(request)}")
+    return user
+
+
+def current_user(request: Request) -> Optional[auth.User]:
+    """The signed-in user, or None. Never raises — for pages that work either way."""
+    basic_header = request.headers.get("authorization", "").lower().startswith("basic ")
+    if basic_header:
+        return _basic_auth_user(request)
+
+    token = request.cookies.get(auth.SESSION_COOKIE)
+    if not token:
+        return None
+    # begin() rather than connect(): resolving a session can extend it, or drop
+    # it if the account was suspended since the last request.
+    with get_engine().begin() as conn:
+        return auth.resolve_session(conn, token)
+
+
+def require_user(request: Request) -> auth.User:
+    """The signed-in user, or a redirect to the login page.
+
+    Every data route depends on this, and every query underneath it is filtered
+    by the id it returns. That is the whole of the isolation guarantee: there is
+    no route that takes a user id from the request.
+    """
+    user = current_user(request)
+    if user is not None:
+        return user
+
+    if request.headers.get("authorization", "").lower().startswith("basic "):
+        logger.warning("event=auth_failed scheme=basic path=%s", request.url.path)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials",
             headers={"WWW-Authenticate": "Basic"},
         )
-    return credentials.username
+
+    logger.info("event=login_required path=%s", request.url.path)
+    raise LoginRequired(request.url.path)
 
 
 # --------------------------------------------------------------------------
@@ -184,12 +316,49 @@ button:active { background: #1d4ed8; }
 .err { border-left: 4px solid #dc2626; }
 .muted { opacity: .75; font-size: .9rem; }
 ul { padding-left: 1.2rem; }
-nav a { display: inline-block; margin-right: 1rem; }
+nav { display: flex; flex-wrap: wrap; align-items: baseline; gap: 1rem;
+      margin-bottom: 1rem; }
+nav a { display: inline-block; }
+nav .who { margin-left: auto; font-size: .9rem; opacity: .8; }
+nav form { display: inline; }
+nav button.link { width: auto; margin: 0; padding: 0; background: none; color: #2563eb;
+      font: inherit; font-weight: 400; text-decoration: underline; cursor: pointer; }
 pre { white-space: pre-wrap; word-wrap: break-word; }
+input[type=text], input[type=password] { width: 100%; font-size: 1rem; padding: .7rem;
+      border-radius: .5rem; border: 1px solid #8884; font-family: inherit; }
+.auth { max-width: 24rem; margin-inline: auto; }
+.auth .muted a { white-space: nowrap; }
 """
 
 
-def _page(title: str, body: str, extra_css: str = "", extra_js: str = "") -> HTMLResponse:
+def _nav(user: Optional["auth.User"]) -> str:
+    """Site navigation. Signed out, the only things on it are the two doors in."""
+    if user is None:
+        return (
+            '<nav><a href="/login">Log in</a><a href="/signup">Create account</a></nav>'
+        )
+    return (
+        '<nav>'
+        '<a href="/">Log entry</a>'
+        '<a href="/progress">Progress</a>'
+        '<a href="/weekly-report">Weekly report</a>'
+        # A div, not a span: <form> is flow content and a span may only hold
+        # phrasing content, which browsers "fix" by relocating the form.
+        f'<div class="who">{html.escape(user.label)} &middot; '
+        '<a href="/account">Account</a> &middot; '
+        '<form method="post" action="/logout">'
+        '<button type="submit" class="link">Log out</button></form></div>'
+        '</nav>'
+    )
+
+
+def _page(
+    title: str,
+    body: str,
+    extra_css: str = "",
+    extra_js: str = "",
+    user: Optional["auth.User"] = None,
+) -> HTMLResponse:
     css = f"<style>{_STYLE}{extra_css}</style>"
     # Deferred so the markup the charts measure exists before the script runs.
     js = f"<script>{extra_js}</script>" if extra_js else ""
@@ -201,7 +370,7 @@ def _page(title: str, body: str, extra_css: str = "", extra_js: str = "") -> HTM
 <title>{html.escape(title)}</title>
 {css}
 </head><body>
-<nav><a href="/">Log entry</a><a href="/progress">Progress</a><a href="/weekly-report">Weekly report</a></nav>
+{_nav(user)}
 {body}
 {js}
 </body></html>"""
@@ -331,6 +500,284 @@ def _render_result(result: pipeline.PipelineResult, session_date: date) -> str:
 
 
 # --------------------------------------------------------------------------
+# Accounts
+# --------------------------------------------------------------------------
+
+
+def _safe_next(raw: Optional[str]) -> str:
+    """Where to send someone after login, if it is somewhere on this site.
+
+    Only a bare absolute path is accepted. "//evil.example" and
+    "https://evil.example" are both rejected: without this check the ?next=
+    parameter would be an open redirect, and a login page that can bounce you to
+    an attacker's copy of itself is worth more to them than no login page.
+    """
+    candidate = (raw or "").strip()
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return "/"
+    return candidate
+
+
+def _auth_form(
+    title: str,
+    action: str,
+    submit_label: str,
+    footer: str,
+    error: str = "",
+    username: str = "",
+    next_url: str = "",
+    extra_fields: str = "",
+) -> str:
+    """The login and signup forms differ by three strings, so they share a body."""
+    banner = f'<div class="card err">{html.escape(error)}</div>' if error else ""
+    hidden = (
+        f'<input type="hidden" name="next" value="{html.escape(next_url)}">'
+        if next_url else ""
+    )
+    return f"""
+<div class="auth">
+<h1>{html.escape(title)}</h1>
+{banner}
+<form method="post" action="{action}">
+  {hidden}
+  <label for="username">Username</label>
+  <input type="text" id="username" name="username" value="{html.escape(username)}"
+         autocomplete="username" autocapitalize="none" autocorrect="off" required>
+  <label for="password">Password</label>
+  <input type="password" id="password" name="password"
+         autocomplete="current-password" required>
+  {extra_fields}
+  <button type="submit">{html.escape(submit_label)}</button>
+</form>
+<p class="muted">{footer}</p>
+</div>
+"""
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request, next: str = "") -> Response:
+    if current_user(request) is not None:
+        return RedirectResponse(_safe_next(next), status_code=status.HTTP_303_SEE_OTHER)
+    return _page(
+        "Log in",
+        _auth_form(
+            "Log in", "/login", "Log in",
+            'No account yet? <a href="/signup">Create one</a>.',
+            next_url=_safe_next(next) if next else "",
+        ),
+    )
+
+
+@app.post("/login", response_class=HTMLResponse)
+async def login_submit(
+    request: Request,
+    username: str = Form(""),
+    password: str = Form(""),
+    next: str = Form(""),
+) -> Response:
+    target = _safe_next(next)
+
+    if _LOGIN_LIMITER is not None and not _LOGIN_LIMITER.check(f"login:{_client_key(request)}"):
+        logger.warning("event=auth_rate_limited scheme=form")
+        return _page(
+            "Log in",
+            _auth_form(
+                "Log in", "/login", "Log in",
+                'No account yet? <a href="/signup">Create one</a>.',
+                error="Too many attempts from here. Wait a few minutes and try again.",
+                username=username, next_url=target,
+            ),
+        )
+
+    with get_engine().begin() as conn:
+        user = auth.authenticate(conn, username, password)
+        # Issued inside the same transaction as the password check, so a session
+        # cookie can never outlive a login that did not commit.
+        token = auth.create_session(conn, user.user_id) if user else None
+
+    if user is None:
+        logger.warning("event=auth_failed scheme=form")
+        return _page(
+            "Log in",
+            _auth_form(
+                "Log in", "/login", "Log in",
+                'No account yet? <a href="/signup">Create one</a>.',
+                # Deliberately does not say which half was wrong: that would
+                # turn the form into a test for which usernames exist.
+                error="That username and password do not match an account.",
+                username=username, next_url=target,
+            ),
+        )
+
+    logger.info("event=login user_id=%d", user.user_id)
+    # A successful login clears the bucket, so someone who mistypes twice and
+    # then gets it right is not left one attempt from being locked out.
+    if _LOGIN_LIMITER is not None:
+        _LOGIN_LIMITER.reset(f"login:{_client_key(request)}")
+    response = RedirectResponse(target, status_code=status.HTTP_303_SEE_OTHER)
+    _set_session_cookie(response, token, secure=_is_https(request))
+    return response
+
+
+@app.get("/signup", response_class=HTMLResponse)
+async def signup_form(request: Request) -> Response:
+    if current_user(request) is not None:
+        return RedirectResponse("/", status_code=status.HTTP_303_SEE_OTHER)
+    return _page("Create account", _signup_body())
+
+
+def _signup_body(error: str = "", username: str = "", timezone_name: str = "") -> str:
+    zone_field = f"""
+  <label for="timezone">Timezone <span class="muted">(optional)</span></label>
+  <input type="text" id="timezone" name="timezone" value="{html.escape(timezone_name)}"
+         placeholder="{html.escape(pipeline.LOCAL_TIMEZONE)}"
+         autocapitalize="none" autocorrect="off">
+"""
+    return _auth_form(
+        "Create account", "/signup", "Create account",
+        'Already have one? <a href="/login">Log in</a>. Your training is yours '
+        'alone &mdash; nobody else using this app can see it.',
+        error=error, username=username, extra_fields=zone_field,
+    ).replace('autocomplete="current-password"', 'autocomplete="new-password"')
+
+
+@app.post("/signup", response_class=HTMLResponse)
+async def signup_submit(
+    request: Request,
+    username: str = Form(""),
+    password: str = Form(""),
+    timezone: str = Form(""),
+) -> Response:
+    def failed(message: str) -> HTMLResponse:
+        return _page("Create account", _signup_body(message, username, timezone))
+
+    if _SIGNUP_LIMITER is not None and not _SIGNUP_LIMITER.check(f"signup:{_client_key(request)}"):
+        logger.warning("event=signup_rate_limited")
+        return failed("Too many accounts created from here. Try again later.")
+
+    try:
+        with get_engine().begin() as conn:
+            user = auth.create_user(conn, username, password, timezone)
+            token = auth.create_session(conn, user.user_id)
+    except auth.AuthError as exc:
+        logger.info("event=signup_rejected reason=%s", exc)
+        return failed(str(exc))
+
+    logger.info("event=signup user_id=%d", user.user_id)
+    response = RedirectResponse("/", status_code=status.HTTP_303_SEE_OTHER)
+    _set_session_cookie(response, token, secure=_is_https(request))
+    return response
+
+
+@app.post("/logout")
+async def logout(request: Request) -> Response:
+    token = request.cookies.get(auth.SESSION_COOKIE)
+    if token:
+        with get_engine().begin() as conn:
+            auth.delete_session(conn, token)
+    response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+    _clear_session_cookie(response)
+    return response
+
+
+def _account_body(user: "auth.User", message: str = "", error: str = "") -> str:
+    banner = ""
+    if error:
+        banner = f'<div class="card err">{html.escape(error)}</div>'
+    elif message:
+        banner = f'<div class="card ok">{html.escape(message)}</div>'
+    zone = user.timezone or ""
+    return f"""
+<h1>Account</h1>
+{banner}
+<p class="muted">Signed in as <strong>{html.escape(user.label)}</strong>.</p>
+
+<h2>Timezone</h2>
+<form method="post" action="/account">
+  <input type="hidden" name="action" value="timezone">
+  <label for="timezone">IANA timezone name</label>
+  <input type="text" id="timezone" name="timezone" value="{html.escape(zone)}"
+         placeholder="{html.escape(pipeline.LOCAL_TIMEZONE)}"
+         autocapitalize="none" autocorrect="off">
+  <button type="submit">Save timezone</button>
+</form>
+<p class="muted">This decides which calendar day &mdash; and so which week &mdash; a
+session belongs to. Leave it blank to use the app default
+(<code>{html.escape(pipeline.LOCAL_TIMEZONE)}</code>). Changing it does not move
+anything already logged.</p>
+
+<h2>Password</h2>
+<form method="post" action="/account">
+  <input type="hidden" name="action" value="password">
+  <label for="current_password">Current password</label>
+  <input type="password" id="current_password" name="current_password"
+         autocomplete="current-password" required>
+  <label for="new_password">New password</label>
+  <input type="password" id="new_password" name="new_password"
+         autocomplete="new-password" required>
+  <button type="submit">Change password</button>
+</form>
+<p class="muted">Changing your password signs you out everywhere, including here.</p>
+"""
+
+
+@app.get("/account", response_class=HTMLResponse)
+async def account_page(user: "auth.User" = Depends(require_user)) -> HTMLResponse:
+    return _page("Account", _account_body(user), user=user)
+
+
+@app.post("/account", response_class=HTMLResponse)
+async def account_update(
+    request: Request,
+    action: str = Form(""),
+    timezone: str = Form(""),
+    current_password: str = Form(""),
+    new_password: str = Form(""),
+    user: "auth.User" = Depends(require_user),
+) -> Response:
+    if action == "timezone":
+        try:
+            with get_engine().begin() as conn:
+                zone = auth.set_timezone(conn, user.user_id, timezone)
+        except auth.AuthError as exc:
+            return _page("Account", _account_body(user, error=str(exc)), user=user)
+        logger.info("event=timezone_changed user_id=%d timezone=%s", user.user_id, zone)
+        refreshed = auth.User(user.user_id, user.username, user.display_name, zone,
+                              user.is_active)
+        return _page(
+            "Account",
+            _account_body(refreshed, message=f"Timezone set to {zone or pipeline.LOCAL_TIMEZONE}."),
+            user=refreshed,
+        )
+
+    if action == "password":
+        with get_engine().begin() as conn:
+            # Re-checked here rather than trusted from the session: a session
+            # cookie proves who was at this browser at login, not who is at it
+            # now, and a password change is what an unattended phone is worth.
+            confirmed = auth.authenticate(conn, user.username, current_password)
+            if confirmed is None:
+                return _page(
+                    "Account",
+                    _account_body(user, error="Current password is not correct."),
+                    user=user,
+                )
+            try:
+                auth.set_password(conn, user.user_id, new_password)
+            except auth.AuthError as exc:
+                return _page("Account", _account_body(user, error=str(exc)), user=user)
+
+        logger.info("event=password_changed user_id=%d", user.user_id)
+        # set_password revoked every session including this one, so the cookie
+        # in the browser is already dead; clear it and ask for the new password.
+        response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+        _clear_session_cookie(response)
+        return response
+
+    return _page("Account", _account_body(user, error="Unknown action."), user=user)
+
+
+# --------------------------------------------------------------------------
 # Routes
 # --------------------------------------------------------------------------
 
@@ -341,8 +788,8 @@ async def healthz() -> JSONResponse:
 
 
 @app.get("/", response_class=HTMLResponse)
-async def index(_user: str = Depends(require_auth)) -> HTMLResponse:
-    today = pipeline.local_today().isoformat()
+async def index(user: "auth.User" = Depends(require_user)) -> HTMLResponse:
+    today = pipeline.local_today(user.timezone).isoformat()
     return _page(
         "Log a workout",
         f"""
@@ -366,6 +813,7 @@ and pressed save. Bodyweight mentions in the same entry are picked up
 automatically. <strong>Replace</strong> deletes everything already logged on that
 date, so use it to correct a bad entry &mdash; not to add an evening session.</p>
 """,
+        user=user,
     )
 
 
@@ -376,48 +824,53 @@ def _parse_session_date(value: str) -> Optional[date]:
         return None
 
 
-def _invalid_date_page() -> HTMLResponse:
+def _invalid_date_page(user: Optional["auth.User"] = None) -> HTMLResponse:
     return _page(
         "Invalid date",
         '<h1>Result</h1><div class="card err">Session date must be YYYY-MM-DD.</div>'
         '<p><a href="/">Back</a></p>',
+        user=user,
     )
 
 
-def _known_groups() -> Optional[dict[str, Optional[str]]]:
-    """What each known exercise is already filed under, for the suggestion.
+def _known_groups(user: "auth.User") -> Optional[dict[str, Optional[str]]]:
+    """What this user already files each of their exercises under, for the suggestion.
 
     Best effort, like `_existing_counts`: without it the suggestion falls back
     to the static table, which is a worse answer but not a wrong one.
     """
     try:
         with get_engine().connect() as conn:
-            return pipeline.load_exercise_groups(conn)
+            return pipeline.load_exercise_groups(conn, user.user_id)
     except Exception:  # noqa: BLE001 - the save step will surface a real outage
-        logger.warning("event=known_groups_failed", exc_info=True)
+        logger.warning("event=known_groups_failed user_id=%d", user.user_id, exc_info=True)
         return None
 
 
-def _existing_counts(session_date: date) -> Optional[dict[str, int]]:
-    """What is already logged on that date, for the review banner.
+def _existing_counts(session_date: date, user: "auth.User") -> Optional[dict[str, int]]:
+    """What this user has already logged on that date, for the review banner.
 
     Best effort: this only decorates the page, so a database that is briefly
     unreachable should not cost the user the extraction they just paid for.
     """
     try:
-        return pipeline.count_entries_for_date(get_engine(), session_date)
+        return pipeline.count_entries_for_date(
+            get_engine(), session_date, user.user_id, user.timezone
+        )
     except Exception:  # noqa: BLE001 - the save step will surface a real outage
-        logger.warning("event=existing_counts_failed date=%s", session_date, exc_info=True)
+        logger.warning("event=existing_counts_failed date=%s user_id=%d",
+                       session_date, user.user_id, exc_info=True)
         return None
 
 
-def _review_page(draft: pipeline.EntryDraft) -> HTMLResponse:
+def _review_page(draft: pipeline.EntryDraft, user: "auth.User") -> HTMLResponse:
     return _page(
         "Check before saving",
         review.render_review_body(
-            draft, _existing_counts(draft.session_date), pipeline.CONFIDENCE_THRESHOLD
+            draft, _existing_counts(draft.session_date, user), pipeline.CONFIDENCE_THRESHOLD
         ),
         extra_css=review.REVIEW_CSS,
+        user=user,
     )
 
 
@@ -426,17 +879,19 @@ async def log_entry(
     session_date: str = Form(...),
     raw_text: str = Form(...),
     mode: str = Form("add"),
-    _user: str = Depends(require_auth),
+    user: "auth.User" = Depends(require_user),
 ) -> HTMLResponse:
     """Extract only. Nothing reaches the database until POST /save."""
     parsed_date = _parse_session_date(session_date)
     if parsed_date is None:
-        return _invalid_date_page()
+        return _invalid_date_page(user)
 
-    draft = pipeline.build_draft(raw_text, parsed_date, known_groups=_known_groups())
+    draft = pipeline.build_draft(raw_text, parsed_date, known_groups=_known_groups(user))
     draft.replace_existing = mode == "replace"
     logger.info(
-        "event=entry_drafted date=%s mode=%s sets=%d bodyweight=%s flagged=%d blocked=%d error=%s",
+        "event=entry_drafted user_id=%d date=%s mode=%s sets=%d bodyweight=%s "
+        "flagged=%d blocked=%d error=%s",
+        user.user_id,
         parsed_date,
         mode,
         len(draft.sets),
@@ -458,13 +913,16 @@ async def log_entry(
             '<p class="muted">Nothing was saved. Go back and try again — the entry '
             "is unchanged.</p>"
             '<p><a href="/">Back</a></p>',
+            user=user,
         )
 
-    return _review_page(draft)
+    return _review_page(draft, user)
 
 
 @app.post("/save", response_class=HTMLResponse)
-async def save_reviewed(request: Request, _user: str = Depends(require_auth)) -> HTMLResponse:
+async def save_reviewed(
+    request: Request, user: "auth.User" = Depends(require_user)
+) -> HTMLResponse:
     """Write the reviewed form, or hand it back with one more empty slot.
 
     The rows are rescored from the submitted values rather than from the
@@ -474,23 +932,33 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
     """
     form = await request.form()
     try:
-        draft = review.draft_from_form(form, known_groups=_known_groups())
+        draft = review.draft_from_form(form, known_groups=_known_groups(user))
     except ValueError:
-        return _invalid_date_page()
+        return _invalid_date_page(user)
 
     # "Add a set" posts the same form; it hands back the draft plus an empty slot
     # rather than saving, so a half-corrected row is not judged in passing.
     if review.add_row(draft, str(form.get("action", "save"))):
-        return _review_page(draft)
+        return _review_page(draft, user)
 
     if not draft.ready:
-        logger.info("event=save_blocked date=%s blocked=%d", draft.session_date, draft.blocked_count)
-        return _review_page(draft)
+        logger.info("event=save_blocked user_id=%d date=%s blocked=%d",
+                    user.user_id, draft.session_date, draft.blocked_count)
+        return _review_page(draft, user)
 
-    result = pipeline.commit_draft(draft, engine=get_engine(), check_duplicates=True)
+    # The owning user comes from the session, not from the form that was just
+    # posted back — the draft's hidden fields are whatever the browser sent.
+    result = pipeline.commit_draft(
+        draft,
+        user.user_id,
+        engine=get_engine(),
+        check_duplicates=True,
+        timezone_name=user.timezone,
+    )
     logger.info(
-        "event=entry_saved date=%s replace=%s inserted_sets=%d inserted_bodyweight=%d "
-        "skipped=%d review=%d duplicate=%s replaced=%s",
+        "event=entry_saved user_id=%d date=%s replace=%s inserted_sets=%d "
+        "inserted_bodyweight=%d skipped=%d review=%d duplicate=%s replaced=%s",
+        user.user_id,
         draft.session_date,
         draft.replace_existing,
         result.inserted_sets,
@@ -504,27 +972,32 @@ async def save_reviewed(request: Request, _user: str = Depends(require_auth)) ->
         "Saved",
         f'<h1>Saved</h1>{_render_result(result, draft.session_date)}'
         '<p><a href="/">Log another</a></p>',
+        user=user,
     )
 
 
 @app.get("/progress", response_class=HTMLResponse)
-async def progress(_user: str = Depends(require_auth)) -> HTMLResponse:
-    """Charts over the logged data. Every figure is computed in code, as in the
-    weekly report - this page plots the same Stage A numbers."""
+async def progress(user: "auth.User" = Depends(require_user)) -> HTMLResponse:
+    """Charts over this user's logged data. Every figure is computed in code, as
+    in the weekly report - this page plots the same Stage A numbers."""
     weeks = insights.ANALYSIS_WEEKS if insights.ANALYSIS_WEEKS >= 8 else 12
-    data = insights.build_dashboard(get_engine(), weeks=weeks)
-    logger.info("event=progress_rendered weeks=%d has_data=%s", weeks, data["has_data"])
+    data = insights.build_dashboard(
+        get_engine(), user.user_id, weeks=weeks, timezone_name=user.timezone
+    )
+    logger.info("event=progress_rendered user_id=%d weeks=%d has_data=%s",
+                user.user_id, weeks, data["has_data"])
     return _page(
         "Progress",
         charts.render_progress_body(data),
         extra_css=charts.PROGRESS_CSS,
         extra_js=charts.PROGRESS_JS,
+        user=user,
     )
 
 
 @app.get("/weekly-report", response_class=HTMLResponse)
-async def weekly_report_form(_user: str = Depends(require_auth)) -> HTMLResponse:
-    current_week = insights.week_start_for(pipeline.local_today())
+async def weekly_report_form(user: "auth.User" = Depends(require_user)) -> HTMLResponse:
+    current_week = insights.week_start_for(pipeline.local_today(user.timezone))
     return _page(
         "Weekly report",
         f"""
@@ -539,13 +1012,14 @@ the prose around them.</p>
 <p class="muted">Regenerating a week overwrites that week's stored report.
 Pain safeguard is currently <strong>{'on' if insights.PAIN_SAFEGUARD_ENABLED else 'OFF'}</strong>.</p>
 """,
+        user=user,
     )
 
 
 @app.post("/weekly-report", response_class=HTMLResponse)
 async def weekly_report_generate(
     week_start: Optional[str] = Form(None),
-    _user: str = Depends(require_auth),
+    user: "auth.User" = Depends(require_user),
 ) -> HTMLResponse:
     parsed_week: Optional[date] = None
     if week_start and week_start.strip():
@@ -556,11 +1030,15 @@ async def weekly_report_generate(
                 "Invalid date",
                 '<h1>Weekly report</h1><div class="card err">Week start must be YYYY-MM-DD.</div>'
                 '<p><a href="/weekly-report">Back</a></p>',
+                user=user,
             )
 
-    report = insights.generate_weekly_report(get_engine(), week_start=parsed_week)
+    report = insights.generate_weekly_report(
+        get_engine(), user.user_id, week_start=parsed_week, timezone_name=user.timezone
+    )
     logger.info(
-        "event=report_generated week_start=%s records=%d narration_error=%s",
+        "event=report_generated user_id=%d week_start=%s records=%d narration_error=%s",
+        user.user_id,
         report["week_start_date"],
         report["record_count"],
         bool(report["narration_error"]),
@@ -593,4 +1071,5 @@ async def weekly_report_generate(
 <div class="card">{_render_markdown(report['summary_text'])}</div>
 <p class="muted">Saved to <code>weekly_reports</code> ({report['record_count']} sets analysed).</p>
 <p><a href="/weekly-report">Generate another</a></p>""",
+        user=user,
     )

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,520 @@
+"""Accounts, passwords and login sessions.
+
+The app was single-user: one username and password in env vars, checked with
+HTTP Basic on every route. This module replaces that with real accounts stored
+in Postgres, so several people can use the same deployment without seeing each
+other's training.
+
+Three pieces:
+
+  * **Passwords** are stored as PBKDF2-HMAC-SHA256 with a per-user salt. No new
+    dependency — `hashlib` ships with Python, and the cost factor is stored
+    inside the hash string so it can be raised later without locking anyone out.
+  * **Sessions** are opaque random tokens. Only the SHA-256 of a token is
+    stored, so a leaked database dump does not hand out live logins. The raw
+    token lives in an HttpOnly cookie and nowhere else.
+  * **Users** are looked up by a lowercased username, so "Sohaib" and "sohaib"
+    are the same account and cannot both be registered.
+
+Nothing here renders HTML or touches FastAPI; app.py owns that. Nothing here
+opens a connection either — every function takes one, so the caller decides the
+transaction boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import IntegrityError
+
+# --------------------------------------------------------------------------
+# Tuning
+# --------------------------------------------------------------------------
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    try:
+        return int(raw) if raw else default
+    except ValueError:
+        return default
+
+
+# Django's current default is in this range. Verification always uses the count
+# stored in the hash, so raising this only affects passwords set from now on;
+# existing users keep working and are re-hashed on their next successful login.
+PBKDF2_ITERATIONS = _int_env("PBKDF2_ITERATIONS", 600_000)
+
+# How long a login lasts without re-entering the password. Phone users should
+# not be asked again every week, and there is nothing high-value behind it.
+SESSION_TTL_DAYS = _int_env("SESSION_TTL_DAYS", 30)
+
+SESSION_COOKIE = "gt_session"
+
+USERNAME_MIN = 3
+USERNAME_MAX = 32
+PASSWORD_MIN = 8
+# Not a security bound — a bound on how much text we are willing to run 600k
+# rounds of PBKDF2 over, since that work happens before authentication.
+PASSWORD_MAX = 200
+
+_USERNAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+
+# Names that would collide with a route or read as official.
+_RESERVED_USERNAMES = frozenset(
+    {"admin", "root", "login", "logout", "signup", "account", "healthz",
+     "progress", "log", "save", "static", "api", "me", "system"}
+)
+
+
+class AuthError(ValueError):
+    """A registration or login input the user can fix, with a message for them."""
+
+
+@dataclass(frozen=True)
+class User:
+    user_id: int
+    username: str
+    display_name: str
+    timezone: Optional[str] = None
+    is_active: bool = True
+
+    @property
+    def label(self) -> str:
+        """What to show in the page header."""
+        return self.display_name or self.username
+
+
+# --------------------------------------------------------------------------
+# Passwords
+# --------------------------------------------------------------------------
+
+
+def hash_password(password: str, iterations: int = PBKDF2_ITERATIONS) -> str:
+    """`pbkdf2_sha256$<iterations>$<salt>$<hash>`, all base64 without padding.
+
+    The iteration count travels with the hash so `verify_password` never has to
+    guess it, which is what makes the cost factor safe to raise later.
+    """
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return "pbkdf2_sha256${}${}${}".format(
+        iterations, _b64(salt), _b64(digest)
+    )
+
+
+def verify_password(password: str, stored: str) -> bool:
+    """Constant-time check of a password against a stored hash.
+
+    A malformed or unrecognised hash is a failed login, not an exception: a row
+    written by some future scheme must never authenticate by accident.
+    """
+    try:
+        scheme, iterations_text, salt_text, digest_text = (stored or "").split("$")
+        if scheme != "pbkdf2_sha256":
+            return False
+        iterations = int(iterations_text)
+        salt = _unb64(salt_text)
+        expected = _unb64(digest_text)
+    except (ValueError, TypeError):
+        return False
+    if iterations < 1:
+        return False
+    candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return hmac.compare_digest(candidate, expected)
+
+
+def needs_rehash(stored: str) -> bool:
+    """True when a stored hash uses fewer rounds than we now ask for."""
+    try:
+        scheme, iterations_text, _, _ = (stored or "").split("$")
+    except ValueError:
+        return True
+    return scheme != "pbkdf2_sha256" or int(iterations_text) < PBKDF2_ITERATIONS
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _unb64(encoded: str) -> bytes:
+    return base64.b64decode(encoded + "=" * (-len(encoded) % 4))
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+def normalize_username(raw: str) -> str:
+    """Fold a typed username to its stored form, or explain why it cannot be one."""
+    candidate = (raw or "").strip().lower()
+    if not candidate:
+        raise AuthError("Pick a username.")
+    if len(candidate) < USERNAME_MIN or len(candidate) > USERNAME_MAX:
+        raise AuthError(
+            f"Username must be {USERNAME_MIN}-{USERNAME_MAX} characters."
+        )
+    if not _USERNAME_RE.match(candidate):
+        raise AuthError(
+            "Username can use letters, numbers, dots, dashes and underscores, "
+            "and must start and end with a letter or number."
+        )
+    if candidate in _RESERVED_USERNAMES:
+        raise AuthError("That username is reserved. Pick another.")
+    return candidate
+
+
+def validate_password(password: str) -> str:
+    """Check a new password meets the floor. Returns it unchanged."""
+    password = password or ""
+    if len(password) < PASSWORD_MIN:
+        raise AuthError(f"Password must be at least {PASSWORD_MIN} characters.")
+    if len(password) > PASSWORD_MAX:
+        raise AuthError(f"Password must be at most {PASSWORD_MAX} characters.")
+    return password
+
+
+def validate_timezone(name: Optional[str]) -> Optional[str]:
+    """An IANA zone the host can actually load, or None to use the app default."""
+    candidate = (name or "").strip()
+    if not candidate:
+        return None
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    try:
+        ZoneInfo(candidate)
+    except (ZoneInfoNotFoundError, ValueError, KeyError):
+        raise AuthError(f"{candidate!r} is not an IANA timezone name (e.g. Asia/Karachi).")
+    return candidate
+
+
+# --------------------------------------------------------------------------
+# Users
+# --------------------------------------------------------------------------
+
+_USER_COLUMNS = "user_id, username, display_name, timezone, is_active"
+
+
+def _row_to_user(row) -> User:
+    return User(
+        user_id=int(row[0]),
+        username=row[1],
+        display_name=row[2],
+        timezone=row[3],
+        is_active=bool(row[4]),
+    )
+
+
+def create_user(
+    conn: Connection,
+    username: str,
+    password: str,
+    timezone_name: Optional[str] = None,
+) -> User:
+    """Register an account. Raises AuthError if the name is taken or invalid."""
+    display_name = (username or "").strip()
+    normalized = normalize_username(display_name)
+    validate_password(password)
+    zone = validate_timezone(timezone_name)
+
+    try:
+        row = conn.execute(
+            text(
+                f"""
+                INSERT INTO users (username, display_name, password_hash, timezone)
+                VALUES (:username, :display_name, :password_hash, :timezone)
+                RETURNING {_USER_COLUMNS}
+                """
+            ),
+            {
+                "username": normalized,
+                "display_name": display_name,
+                "password_hash": hash_password(password),
+                "timezone": zone,
+            },
+        ).fetchone()
+    except IntegrityError as exc:
+        # The unique index is the authority, not a prior SELECT: two people can
+        # submit the same name in the same instant and only one row can win.
+        raise AuthError("That username is already taken.") from exc
+    return _row_to_user(row)
+
+
+def get_user_by_username(conn: Connection, username: str) -> Optional[User]:
+    try:
+        normalized = normalize_username(username)
+    except AuthError:
+        return None
+    row = conn.execute(
+        text(f"SELECT {_USER_COLUMNS} FROM users WHERE username = :username"),
+        {"username": normalized},
+    ).fetchone()
+    return _row_to_user(row) if row else None
+
+
+def get_user(conn: Connection, user_id: int) -> Optional[User]:
+    row = conn.execute(
+        text(f"SELECT {_USER_COLUMNS} FROM users WHERE user_id = :user_id"),
+        {"user_id": user_id},
+    ).fetchone()
+    return _row_to_user(row) if row else None
+
+
+def authenticate(conn: Connection, username: str, password: str) -> Optional[User]:
+    """Check a username/password pair. None means "no", with no detail as to why.
+
+    A missing user still costs one PBKDF2 run, so the response time does not
+    tell an attacker which usernames exist.
+    """
+    try:
+        normalized = normalize_username(username)
+    except AuthError:
+        normalized = ""
+
+    row = conn.execute(
+        text(
+            f"SELECT {_USER_COLUMNS}, password_hash FROM users "
+            "WHERE username = :username"
+        ),
+        {"username": normalized},
+    ).fetchone()
+
+    if row is None:
+        verify_password(password or "", _dummy_hash())
+        return None
+
+    stored = row[5]
+    if not verify_password(password or "", stored):
+        return None
+    if not bool(row[4]):
+        return None
+
+    if needs_rehash(stored):
+        conn.execute(
+            text("UPDATE users SET password_hash = :hash WHERE user_id = :user_id"),
+            {"hash": hash_password(password), "user_id": int(row[0])},
+        )
+    conn.execute(
+        text("UPDATE users SET last_login_at = now() WHERE user_id = :user_id"),
+        {"user_id": int(row[0])},
+    )
+    return _row_to_user(row)
+
+
+def set_password(conn: Connection, user_id: int, password: str) -> None:
+    """Replace a password. Every existing session for that user is revoked."""
+    validate_password(password)
+    conn.execute(
+        text("UPDATE users SET password_hash = :hash WHERE user_id = :user_id"),
+        {"hash": hash_password(password), "user_id": user_id},
+    )
+    delete_sessions_for_user(conn, user_id)
+
+
+def set_timezone(conn: Connection, user_id: int, timezone_name: Optional[str]) -> Optional[str]:
+    zone = validate_timezone(timezone_name)
+    conn.execute(
+        text("UPDATE users SET timezone = :timezone WHERE user_id = :user_id"),
+        {"timezone": zone, "user_id": user_id},
+    )
+    return zone
+
+
+def set_active(conn: Connection, user_id: int, active: bool) -> None:
+    """Suspend or restore an account. Suspending also drops its sessions."""
+    conn.execute(
+        text("UPDATE users SET is_active = :active WHERE user_id = :user_id"),
+        {"active": active, "user_id": user_id},
+    )
+    if not active:
+        delete_sessions_for_user(conn, user_id)
+
+
+def list_users(conn: Connection) -> list[User]:
+    rows = conn.execute(
+        text(f"SELECT {_USER_COLUMNS} FROM users ORDER BY user_id")
+    ).fetchall()
+    return [_row_to_user(row) for row in rows]
+
+
+def user_count(conn: Connection) -> int:
+    return int(conn.execute(text("SELECT count(*) FROM users")).scalar_one())
+
+
+_DUMMY_HASH: Optional[str] = None
+
+
+def _dummy_hash() -> str:
+    """A real hash of a random secret, verified against when no user matches.
+
+    It has to cost exactly what a genuine hash costs, or the response time
+    would tell an attacker which usernames exist. Built on first use rather
+    than at import so a cold start does not pay for 600k rounds before it can
+    serve anything.
+    """
+    global _DUMMY_HASH
+    if _DUMMY_HASH is None:
+        _DUMMY_HASH = hash_password(secrets.token_urlsafe(16))
+    return _DUMMY_HASH
+
+
+# --------------------------------------------------------------------------
+# Sessions
+# --------------------------------------------------------------------------
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256((token or "").encode("utf-8")).hexdigest()
+
+
+def create_session(conn: Connection, user_id: int, ttl_days: int = SESSION_TTL_DAYS) -> str:
+    """Issue a login token. The raw token is returned once and never stored."""
+    token = secrets.token_urlsafe(32)
+    conn.execute(
+        text(
+            """
+            INSERT INTO user_sessions (token_hash, user_id, expires_at)
+            VALUES (:token_hash, :user_id, now() + CAST(:ttl AS interval))
+            """
+        ),
+        {"token_hash": _token_hash(token), "user_id": user_id, "ttl": f"{int(ttl_days)} days"},
+    )
+    return token
+
+
+def resolve_session(conn: Connection, token: Optional[str]) -> Optional[User]:
+    """The live user behind a cookie, or None if it is unknown, expired or suspended.
+
+    A session more than halfway through its life is extended, so someone who
+    opens the app most weeks is never logged out; one nobody touches still
+    expires on schedule.
+    """
+    if not token:
+        return None
+    token_hash = _token_hash(token)
+    row = conn.execute(
+        text(
+            f"""
+            SELECT {', '.join('u.' + c for c in _USER_COLUMNS.split(', '))},
+                   s.expires_at, s.created_at
+            FROM user_sessions s
+            JOIN users u ON u.user_id = s.user_id
+            WHERE s.token_hash = :token_hash AND s.expires_at > now()
+            """
+        ),
+        {"token_hash": token_hash},
+    ).fetchone()
+    if row is None:
+        return None
+    if not bool(row[4]):
+        # Suspended between requests: drop the session rather than serve it.
+        delete_session(conn, token)
+        return None
+
+    expires_at, created_at = row[5], row[6]
+    if _past_halfway(created_at, expires_at):
+        conn.execute(
+            text(
+                """
+                UPDATE user_sessions
+                   SET expires_at = now() + CAST(:ttl AS interval),
+                       last_seen_at = now()
+                 WHERE token_hash = :token_hash
+                """
+            ),
+            {"ttl": f"{int(SESSION_TTL_DAYS)} days", "token_hash": token_hash},
+        )
+    return _row_to_user(row)
+
+
+def _past_halfway(created_at: datetime, expires_at: datetime) -> bool:
+    """Whether a session has used more than half its life, so it is worth a write."""
+    if created_at is None or expires_at is None:
+        return True
+    now = datetime.now(timezone.utc)
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return now >= created_at + (expires_at - created_at) / 2
+
+
+def delete_session(conn: Connection, token: Optional[str]) -> None:
+    if not token:
+        return
+    conn.execute(
+        text("DELETE FROM user_sessions WHERE token_hash = :token_hash"),
+        {"token_hash": _token_hash(token)},
+    )
+
+
+def delete_sessions_for_user(conn: Connection, user_id: int) -> int:
+    count = conn.execute(
+        text("DELETE FROM user_sessions WHERE user_id = :user_id"),
+        {"user_id": user_id},
+    ).rowcount
+    return int(count or 0)
+
+
+def purge_expired_sessions(conn: Connection) -> int:
+    count = conn.execute(
+        text("DELETE FROM user_sessions WHERE expires_at <= now()")
+    ).rowcount
+    return int(count or 0)
+
+
+def session_cookie_max_age(ttl_days: int = SESSION_TTL_DAYS) -> int:
+    return int(timedelta(days=ttl_days).total_seconds())
+
+
+# --------------------------------------------------------------------------
+# Rate limiting
+#
+# In-process and therefore per-instance: on a serverless deploy several
+# instances each keep their own counter. That is a weaker guarantee than a
+# shared store, but it still turns an unattended password-guessing loop into a
+# slow one, and it costs no round trips.
+# --------------------------------------------------------------------------
+
+
+class RateLimiter:
+    """Fixed-window attempt counter keyed by whatever the caller considers a client."""
+
+    def __init__(self, limit: int, window_seconds: float) -> None:
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._hits: dict[str, list[float]] = {}
+
+    def check(self, key: str, now: Optional[float] = None) -> bool:
+        """Record an attempt. False once the key is over its limit for the window."""
+        import time as _time
+
+        now = _time.monotonic() if now is None else now
+        cutoff = now - self.window_seconds
+        recent = [stamp for stamp in self._hits.get(key, []) if stamp > cutoff]
+        recent.append(now)
+        self._hits[key] = recent
+        if len(self._hits) > 4096:
+            self._prune(cutoff)
+        return len(recent) <= self.limit
+
+    def reset(self, key: str) -> None:
+        self._hits.pop(key, None)
+
+    def _prune(self, cutoff: float) -> None:
+        self._hits = {
+            key: stamps
+            for key, stamps in self._hits.items()
+            if any(stamp > cutoff for stamp in stamps)
+        }

--- a/backfill_muscle_groups.py
+++ b/backfill_muscle_groups.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Fill in `exercises.muscle_group` for rows created before it was resolved.
 
-    python backfill_muscle_groups.py --dry-run   # show what would change
-    python backfill_muscle_groups.py             # apply
+    python backfill_muscle_groups.py --dry-run       # show what would change
+    python backfill_muscle_groups.py                 # apply, every account
+    python backfill_muscle_groups.py --user alice    # apply, one account
 
 Every exercise logged before the static lookup existed was inserted with a NULL
 muscle group, which `insights.volume_by_muscle_group` reports as "Unassigned" -
@@ -14,25 +15,36 @@ table, from `seed_sample_data.py`, or from a hand-written correction - is left
 exactly as it is, so re-running this can never overwrite a deliberate value.
 Names the table does not recognize stay NULL and are listed at the end, which is
 the signal for what to add to `muscle_groups.EXERCISE_MUSCLE_GROUPS`.
+
+Without `--user` this runs across every account. That is safe in a way most
+cross-account operations are not: the value written comes from a static lookup
+table, not from anybody's data, and only NULLs are filled. `--user` narrows it
+anyway, for when you only want to fix up one person's history.
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
 
 from sqlalchemy import text
 
+import auth
 import pipeline
 
 
-def backfill(engine, dry_run: bool = False) -> tuple[int, list[str]]:
+def backfill(engine, dry_run: bool = False, user_id: int | None = None) -> tuple[int, list[str]]:
     """Resolve NULL muscle groups. Returns (updated_count, unresolved_names)."""
+    scope = "" if user_id is None else " AND user_id = :user_id"
+    params = {} if user_id is None else {"user_id": user_id}
+
     with engine.begin() as conn:
         rows = conn.execute(
             text(
                 "SELECT exercise_id, name FROM exercises "
-                "WHERE muscle_group IS NULL ORDER BY name"
-            )
+                f"WHERE muscle_group IS NULL{scope} ORDER BY name"
+            ),
+            params,
         ).fetchall()
 
         updated = 0
@@ -59,17 +71,32 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true",
                         help="Print the resolutions without writing them")
+    parser.add_argument("--user", help="Limit to one account (default: all accounts)")
     args = parser.parse_args()
 
-    updated, unresolved = backfill(pipeline.get_engine(), dry_run=args.dry_run)
+    engine = pipeline.get_engine()
+
+    user_id = None
+    if args.user:
+        with engine.connect() as conn:
+            user = auth.get_user_by_username(conn, args.user)
+        if user is None:
+            print(f"No account named {args.user!r}.", file=sys.stderr)
+            return 2
+        user_id = user.user_id
+
+    updated, unresolved = backfill(engine, dry_run=args.dry_run, user_id=user_id)
 
     verb = "Would update" if args.dry_run else "Updated"
     print(f"\n{verb} {updated} exercise(s).")
 
     if unresolved:
-        print(f"\n{len(unresolved)} name(s) the table does not recognize; these stay "
+        # Deduplicated: the same unrecognized name can sit in several accounts,
+        # and the fix - one entry in the lookup table - is the same for all.
+        distinct = sorted(set(unresolved))
+        print(f"\n{len(distinct)} name(s) the table does not recognize; these stay "
               f"NULL and show as 'Unassigned':")
-        for name in unresolved:
+        for name in distinct:
             print(f"  {name}")
         print("\nAdd them to muscle_groups.EXERCISE_MUSCLE_GROUPS and re-run.")
     return 0

--- a/insights.py
+++ b/insights.py
@@ -733,26 +733,41 @@ def fallback_summary(stage_a: dict[str, Any]) -> str:
 # --------------------------------------------------------------------------
 
 
-def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord]:
-    """Load logged sets in [since, until), converting UTC timestamps to local dates."""
+def load_set_records(
+    engine: Engine,
+    since: date,
+    until: date,
+    user_id: int,
+    timezone_name: Optional[str] = None,
+) -> list[SetRecord]:
+    """Load one user's logged sets in [since, until), as local dates.
+
+    The join to `exercises` is filtered on the same user_id as the logs, not
+    just on exercise_id: the two tables are both per-user, and stating it on
+    both sides means a mistake in one cannot leak a name from another account.
+    """
     query = text(
         """
         SELECT e.name, e.muscle_group, w.logged_at, w.weight_kg, w.reps,
                w.cheat_reps, w.is_warmup, w.pain_flag
         FROM workout_logs w
-        JOIN exercises e ON e.exercise_id = w.exercise_id
-        WHERE w.logged_at >= :since AND w.logged_at < :until
+        JOIN exercises e ON e.exercise_id = w.exercise_id AND e.user_id = w.user_id
+        WHERE w.user_id = :user_id
+          AND w.logged_at >= :since AND w.logged_at < :until
         ORDER BY w.logged_at
         """
     )
-    since_utc = pipeline.local_to_utc(datetime.combine(since, datetime.min.time()))
-    until_utc = pipeline.local_to_utc(datetime.combine(until, datetime.min.time()))
+    zone_name = timezone_name or pipeline.LOCAL_TIMEZONE
+    since_utc = pipeline.local_to_utc(datetime.combine(since, datetime.min.time()), zone_name)
+    until_utc = pipeline.local_to_utc(datetime.combine(until, datetime.min.time()), zone_name)
 
     from zoneinfo import ZoneInfo
 
-    local_zone = ZoneInfo(pipeline.LOCAL_TIMEZONE)
+    local_zone = ZoneInfo(zone_name)
     with engine.connect() as conn:
-        rows = conn.execute(query, {"since": since_utc, "until": until_utc}).fetchall()
+        rows = conn.execute(
+            query, {"since": since_utc, "until": until_utc, "user_id": user_id}
+        ).fetchall()
 
     records = []
     for (name, muscle_group, logged_at, weight_kg, reps, cheat_reps,
@@ -774,24 +789,28 @@ def load_set_records(engine: Engine, since: date, until: date) -> list[SetRecord
 
 def save_report(
     engine: Engine,
+    user_id: int,
     week_start: date,
     summary_text: str,
     recommendations: dict[str, Any],
 ) -> None:
-    """Upsert on week_start_date so regenerating a week overwrites it."""
+    """Upsert on (user, week) so regenerating a week overwrites only that user's."""
     with engine.begin() as conn:
         conn.execute(
             text(
                 """
-                INSERT INTO weekly_reports (week_start_date, summary_text, recommendations)
-                VALUES (:week_start_date, :summary_text, CAST(:recommendations AS jsonb))
-                ON CONFLICT (week_start_date) DO UPDATE
+                INSERT INTO weekly_reports (user_id, week_start_date, summary_text,
+                                            recommendations)
+                VALUES (:user_id, :week_start_date, :summary_text,
+                        CAST(:recommendations AS jsonb))
+                ON CONFLICT (user_id, week_start_date) DO UPDATE
                     SET summary_text    = EXCLUDED.summary_text,
                         recommendations = EXCLUDED.recommendations,
                         created_at      = now()
                 """
             ),
             {
+                "user_id": user_id,
                 "week_start_date": week_start,
                 "summary_text": summary_text,
                 "recommendations": json.dumps(recommendations, default=str),
@@ -801,19 +820,21 @@ def save_report(
 
 def generate_weekly_report(
     engine: Engine,
+    user_id: int,
     week_start: Optional[date] = None,
     client: Any = None,
     use_llm: bool = True,
     persist: bool = True,
+    timezone_name: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Stage A, then Stage B, then upsert into weekly_reports."""
+    """Stage A, then Stage B, then upsert into weekly_reports, for one user."""
     if week_start is None:
-        week_start = week_start_for(pipeline.local_today())
+        week_start = week_start_for(pipeline.local_today(timezone_name))
     week_start = week_start_for(week_start)
 
     since = week_start - timedelta(weeks=ANALYSIS_WEEKS)
     until = week_start + timedelta(days=7)
-    records = load_set_records(engine, since, until)
+    records = load_set_records(engine, since, until, user_id, timezone_name)
 
     stage_a = build_stage_a(records, week_start)
 
@@ -841,7 +862,7 @@ def generate_weekly_report(
     }
 
     if persist:
-        save_report(engine, week_start, summary_text, payload)
+        save_report(engine, user_id, week_start, summary_text, payload)
 
     return {
         "week_start_date": week_start,
@@ -861,22 +882,32 @@ def generate_weekly_report(
 # --------------------------------------------------------------------------
 
 
-def load_bodyweight(engine: Engine, since: date, until: date) -> list[tuple[date, float]]:
-    """Bodyweight readings in [since, until), oldest first, as local dates."""
+def load_bodyweight(
+    engine: Engine,
+    since: date,
+    until: date,
+    user_id: int,
+    timezone_name: Optional[str] = None,
+) -> list[tuple[date, float]]:
+    """One user's bodyweight readings in [since, until), oldest first, as local dates."""
     from zoneinfo import ZoneInfo
 
     query = text(
         """
         SELECT logged_at, weight_kg FROM bodyweight_logs
-        WHERE logged_at >= :since AND logged_at < :until
+        WHERE user_id = :user_id
+          AND logged_at >= :since AND logged_at < :until
         ORDER BY logged_at
         """
     )
-    since_utc = pipeline.local_to_utc(datetime.combine(since, datetime.min.time()))
-    until_utc = pipeline.local_to_utc(datetime.combine(until, datetime.min.time()))
-    zone = ZoneInfo(pipeline.LOCAL_TIMEZONE)
+    zone_name = timezone_name or pipeline.LOCAL_TIMEZONE
+    since_utc = pipeline.local_to_utc(datetime.combine(since, datetime.min.time()), zone_name)
+    until_utc = pipeline.local_to_utc(datetime.combine(until, datetime.min.time()), zone_name)
+    zone = ZoneInfo(zone_name)
     with engine.connect() as conn:
-        rows = conn.execute(query, {"since": since_utc, "until": until_utc}).fetchall()
+        rows = conn.execute(
+            query, {"since": since_utc, "until": until_utc, "user_id": user_id}
+        ).fetchall()
     return [(logged_at.astimezone(zone).date(), float(weight)) for logged_at, weight in rows]
 
 
@@ -1022,15 +1053,21 @@ def pain_summary(records: Iterable[SetRecord]) -> list[dict[str, Any]]:
     return summary
 
 
-def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = None) -> dict[str, Any]:
-    """Everything the progress page plots. No LLM anywhere in here."""
-    today = today or pipeline.local_today()
+def build_dashboard(
+    engine: Engine,
+    user_id: int,
+    weeks: int = 12,
+    today: Optional[date] = None,
+    timezone_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Everything one user's progress page plots. No LLM anywhere in here."""
+    today = today or pipeline.local_today(timezone_name)
     this_week = week_start_for(today)
     since = this_week - timedelta(weeks=weeks - 1)
     until = this_week + timedelta(days=7)
 
-    records = load_set_records(engine, since, until)
-    bodyweight = load_bodyweight(engine, since, until)
+    records = load_set_records(engine, since, until, user_id, timezone_name)
+    bodyweight = load_bodyweight(engine, since, until, user_id, timezone_name)
 
     week_starts = [since + timedelta(weeks=offset) for offset in range(weeks)]
     current = [r for r in records if r.session_date >= this_week]
@@ -1051,7 +1088,7 @@ def build_dashboard(engine: Engine, weeks: int = 12, today: Optional[date] = Non
     return {
         "week_start": this_week.isoformat(),
         "weeks": weeks,
-        "timezone": pipeline.LOCAL_TIMEZONE,
+        "timezone": timezone_name or pipeline.LOCAL_TIMEZONE,
         "kpis": {
             "volume_this_week": volume_now,
             "volume_delta_pct": volume_delta,

--- a/manage_users.py
+++ b/manage_users.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Account administration from the command line.
+
+    python manage_users.py list
+    python manage_users.py create alice [--timezone Asia/Karachi]
+    python manage_users.py passwd alice
+    python manage_users.py timezone alice Europe/London
+    python manage_users.py suspend alice
+    python manage_users.py restore alice
+    python manage_users.py delete alice
+    python manage_users.py purge-sessions
+
+Anyone can register at /signup, so this is not how accounts are normally made.
+It exists for the things a web form cannot do: resetting a password for someone
+who has forgotten theirs, suspending an account, and deleting one along with its
+training.
+
+Passwords are read from a prompt, never from an argument — a password passed on
+the command line ends up in the shell history and in the process list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import auth  # noqa: E402
+import pipeline  # noqa: E402
+
+
+def _prompt_password(label: str = "Password") -> str:
+    """Ask twice and compare, so a typo does not become the new password."""
+    first = getpass.getpass(f"{label}: ")
+    second = getpass.getpass(f"{label} (again): ")
+    if first != second:
+        raise auth.AuthError("The two entries do not match.")
+    return auth.validate_password(first)
+
+
+def _require_user(conn, username: str) -> auth.User:
+    user = auth.get_user_by_username(conn, username)
+    if user is None:
+        raise auth.AuthError(f"No account named {username!r}.")
+    return user
+
+
+def cmd_list(engine, args) -> int:
+    with engine.connect() as conn:
+        users = auth.list_users(conn)
+        counts = dict(
+            conn.execute(
+                text(
+                    "SELECT user_id, count(*) FROM workout_logs GROUP BY user_id"
+                )
+            ).fetchall()
+        )
+    if not users:
+        print("No accounts yet. Anyone can register at /signup, or use "
+              "`manage_users.py create <username>`.")
+        return 0
+
+    print(f"{'id':>4}  {'username':<24} {'sets':>7}  {'timezone':<20} status")
+    for user in users:
+        status = "active" if user.is_active else "SUSPENDED"
+        print(
+            f"{user.user_id:>4}  {user.username:<24} "
+            f"{counts.get(user.user_id, 0):>7}  "
+            f"{(user.timezone or '(default)'):<20} {status}"
+        )
+    return 0
+
+
+def cmd_create(engine, args) -> int:
+    # Validate everything that can be validated before asking for a password,
+    # so a rejected username does not cost the operator two blind prompts.
+    auth.normalize_username(args.username)
+    auth.validate_timezone(args.timezone)
+
+    password = _prompt_password()
+    with engine.begin() as conn:
+        user = auth.create_user(conn, args.username, password, args.timezone)
+    print(f"Created {user.username!r} (id {user.user_id}).")
+    return 0
+
+
+def cmd_passwd(engine, args) -> int:
+    # Look the account up first: prompting twice for a password and only then
+    # reporting a typo in the username wastes the operator's time.
+    with engine.connect() as conn:
+        user = _require_user(conn, args.username)
+
+    password = _prompt_password(f"New password for {user.username}")
+    with engine.begin() as conn:
+        auth.set_password(conn, user.user_id, password)
+    print(f"Password changed for {user.username!r}. Existing sessions were signed out.")
+    return 0
+
+
+def cmd_timezone(engine, args) -> int:
+    with engine.begin() as conn:
+        user = _require_user(conn, args.username)
+        zone = auth.set_timezone(conn, user.user_id, args.timezone)
+    print(f"{user.username!r} timezone set to {zone or '(app default)'}.")
+    return 0
+
+
+def cmd_suspend(engine, args) -> int:
+    with engine.begin() as conn:
+        user = _require_user(conn, args.username)
+        auth.set_active(conn, user.user_id, False)
+    print(f"Suspended {user.username!r}. Their data is untouched; they cannot log in.")
+    return 0
+
+
+def cmd_restore(engine, args) -> int:
+    with engine.begin() as conn:
+        user = _require_user(conn, args.username)
+        auth.set_active(conn, user.user_id, True)
+    print(f"Restored {user.username!r}.")
+    return 0
+
+
+def cmd_delete(engine, args) -> int:
+    with engine.connect() as conn:
+        user = _require_user(conn, args.username)
+        sets = conn.execute(
+            text("SELECT count(*) FROM workout_logs WHERE user_id = :user_id"),
+            {"user_id": user.user_id},
+        ).scalar_one()
+
+    print(
+        f"This deletes {user.username!r} and {sets} logged set(s), permanently. "
+        "Suspending instead keeps the data (`manage_users.py suspend`)."
+    )
+    if not args.yes:
+        typed = input(f"Type the username to confirm [{user.username}]: ").strip()
+        if typed != user.username:
+            print("Not confirmed; nothing was deleted.")
+            return 1
+
+    # Every data table references users(user_id) ON DELETE CASCADE, so one
+    # delete takes the exercises, logs, reports and sessions with it.
+    with engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM users WHERE user_id = :user_id"), {"user_id": user.user_id}
+        )
+    print(f"Deleted {user.username!r} and everything they logged.")
+    return 0
+
+
+def cmd_purge_sessions(engine, args) -> int:
+    with engine.begin() as conn:
+        removed = auth.purge_expired_sessions(conn)
+    print(f"Removed {removed} expired session(s).")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="\n".join(__doc__.splitlines()[2:11]),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="Show every account and how much it has logged")
+
+    create = sub.add_parser("create", help="Create an account (prompts for a password)")
+    create.add_argument("username")
+    create.add_argument("--timezone", help="IANA name, e.g. Asia/Karachi")
+
+    passwd = sub.add_parser("passwd", help="Set a new password (prompts)")
+    passwd.add_argument("username")
+
+    zone = sub.add_parser("timezone", help="Set or clear an account's timezone")
+    zone.add_argument("username")
+    zone.add_argument("timezone", nargs="?", default="",
+                      help="IANA name; omit to fall back to LOCAL_TIMEZONE")
+
+    suspend = sub.add_parser("suspend", help="Block login, keep the data")
+    suspend.add_argument("username")
+
+    restore = sub.add_parser("restore", help="Undo a suspend")
+    restore.add_argument("username")
+
+    delete = sub.add_parser("delete", help="Delete an account AND all its training")
+    delete.add_argument("username")
+    delete.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
+
+    sub.add_parser("purge-sessions", help="Delete expired login sessions")
+    return parser
+
+
+_COMMANDS = {
+    "list": cmd_list,
+    "create": cmd_create,
+    "passwd": cmd_passwd,
+    "timezone": cmd_timezone,
+    "suspend": cmd_suspend,
+    "restore": cmd_restore,
+    "delete": cmd_delete,
+    "purge-sessions": cmd_purge_sessions,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return _COMMANDS[args.command](pipeline.get_engine(), args)
+    except auth.AuthError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except (KeyboardInterrupt, EOFError):
+        # EOFError is what a password prompt raises when stdin is not a
+        # terminal, which is how this gets run by mistake from a script.
+        print("\nCancelled.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migrate_multi_user.py
+++ b/migrate_multi_user.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""One-time upgrade of a single-user database to accounts.
+
+    python migrate_multi_user.py                 # owner from APP_USERNAME/APP_PASSWORD
+    python migrate_multi_user.py --username me --password '...'
+    python migrate_multi_user.py --dry-run       # show what would run, change nothing
+
+Everything already logged is assigned to one owner account, created here
+because hashing a password needs Python and the SQL file cannot do it. After
+that the owner logs in with the same credentials as before, and anyone else can
+register their own account at /signup.
+
+The statements themselves live in migrations/002_multi_user.sql, which is the
+single source of truth for the shape of the change; this script only supplies
+the owner id, runs each statement in its own transaction, and skips the ones
+already applied so a re-run is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import auth  # noqa: E402
+import pipeline  # noqa: E402
+
+MIGRATION = Path(__file__).resolve().parent / "migrations" / "002_multi_user.sql"
+
+_ADD_CONSTRAINT = re.compile(
+    r"ALTER TABLE\s+(?P<table>\w+)\s+ADD CONSTRAINT\s+(?P<name>\w+)", re.IGNORECASE
+)
+
+
+def statements(sql: str) -> list[str]:
+    """Split the migration into executable statements, comments removed."""
+    without_comments = "\n".join(
+        line for line in sql.splitlines() if not line.lstrip().startswith("--")
+    )
+    return [part.strip() for part in without_comments.split(";") if part.strip()]
+
+
+def constraint_exists(conn, table: str, name: str) -> bool:
+    return bool(
+        conn.execute(
+            text(
+                """
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class t ON t.oid = c.conrelid
+                WHERE t.relname = :table AND c.conname = :name
+                """
+            ),
+            {"table": table, "name": name},
+        ).scalar()
+    )
+
+
+def table_exists(conn, table: str) -> bool:
+    return bool(
+        conn.execute(
+            text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"}
+        ).scalar()
+    )
+
+
+def ensure_owner(engine, username: str, password: str) -> auth.User:
+    """The account everything existing is handed to. Re-running finds it again."""
+    with engine.begin() as conn:
+        existing = auth.get_user_by_username(conn, username)
+        if existing is not None:
+            print(f"Owner account {existing.username!r} already exists (id {existing.user_id}).")
+            return existing
+        user = auth.create_user(conn, username, password, os.getenv("LOCAL_TIMEZONE"))
+        print(f"Created owner account {user.username!r} (id {user.user_id}).")
+        return user
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--username", help="Owner username (default: $APP_USERNAME)")
+    parser.add_argument("--password", help="Owner password (default: $APP_PASSWORD)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the statements that would run, change nothing")
+    args = parser.parse_args(argv)
+
+    username = args.username or os.getenv("APP_USERNAME") or ""
+    password = args.password or os.getenv("APP_PASSWORD") or ""
+    if not username or not password:
+        print(
+            "No owner credentials. Pass --username/--password, or set "
+            "APP_USERNAME and APP_PASSWORD in the environment.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        auth.normalize_username(username)
+        auth.validate_password(password)
+    except auth.AuthError as exc:
+        print(f"Owner credentials rejected: {exc}", file=sys.stderr)
+        return 2
+
+    sql = MIGRATION.read_text(encoding="utf-8")
+    parts = statements(sql)
+
+    if args.dry_run:
+        print(f"{len(parts)} statement(s) from {MIGRATION.name}:\n")
+        for part in parts:
+            print(f"  {' '.join(part.split())[:110]}")
+        print("\nNothing was executed (--dry-run).")
+        return 0
+
+    engine = pipeline.get_engine()
+
+    with engine.connect() as conn:
+        if not table_exists(conn, "workout_logs"):
+            print(
+                "This database has no workout_logs table, so there is nothing to "
+                "migrate. Run schema.sql against a fresh database instead - it "
+                "already has accounts.",
+                file=sys.stderr,
+            )
+            return 2
+
+    owner = None
+    applied = skipped = 0
+    for part in parts:
+        match = _ADD_CONSTRAINT.search(part)
+        if match:
+            with engine.connect() as conn:
+                if constraint_exists(conn, match["table"], match["name"]):
+                    skipped += 1
+                    continue
+
+        # The owner is created the moment a statement first needs its id, which
+        # is the backfill. It cannot be created any earlier: the CREATE TABLE
+        # that gives it somewhere to live is one of the statements above it.
+        if ":owner_id" in part and owner is None:
+            owner = ensure_owner(engine, username, password)
+
+        # One transaction per statement: a step that has already been applied
+        # must not roll back the ones before it.
+        with engine.begin() as conn:
+            conn.execute(text(part), {"owner_id": owner.user_id if owner else None})
+        applied += 1
+
+    if owner is None:
+        # Every backfill statement was a no-op, which means a previous run
+        # already did them. Find the account so the summary can still report.
+        owner = ensure_owner(engine, username, password)
+
+    with engine.connect() as conn:
+        counts = {
+            table: conn.execute(
+                text(f"SELECT count(*) FROM {table} WHERE user_id = :owner_id"),
+                {"owner_id": owner.user_id},
+            ).scalar_one()
+            for table in ("exercises", "workout_logs", "bodyweight_logs", "weekly_reports")
+        }
+
+    print(f"\nApplied {applied} statement(s), skipped {skipped} already in place.")
+    print(f"Owned by {owner.username!r}:")
+    for table, count in counts.items():
+        print(f"  {table:<16} {count}")
+    print(
+        "\nDone. Log in as that user; everyone else can register at /signup.\n"
+        "APP_USERNAME / APP_PASSWORD are no longer used for login and can be "
+        "removed from the environment."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migrations/002_multi_user.sql
+++ b/migrations/002_multi_user.sql
@@ -1,0 +1,108 @@
+-- 002: accounts, and one owner for everything already logged.
+--
+-- Turns the single-user database into a multi-user one. Every existing row is
+-- assigned to one owner account, which the runner creates from APP_USERNAME /
+-- APP_PASSWORD (or --username/--password) before this file's backfill step.
+--
+-- Do not run this file by hand unless you have already inserted that owner row
+-- and know its user_id: the statements below reference :owner_id. Run
+-- `python migrate_multi_user.py` instead, which creates the owner (password
+-- hashing needs Python), runs these statements in order, and is safe to re-run.
+--
+-- Ordering matters. Columns go on as nullable, are backfilled, and only then
+-- become NOT NULL - the other way round would fail on the first existing row.
+
+-- --- 1. Accounts ----------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id       SERIAL PRIMARY KEY,
+    username      TEXT NOT NULL UNIQUE,
+    display_name  TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    timezone      TEXT,
+    is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_login_at TIMESTAMPTZ,
+
+    CONSTRAINT users_username_lowercase CHECK (username = lower(username))
+);
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+    token_hash   TEXT PRIMARY KEY,
+    user_id      INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at   TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at ON user_sessions (expires_at);
+
+-- --- 2. Ownership columns, nullable for now -------------------------------
+
+ALTER TABLE exercises       ADD COLUMN IF NOT EXISTS user_id INTEGER;
+ALTER TABLE workout_logs    ADD COLUMN IF NOT EXISTS user_id INTEGER;
+ALTER TABLE bodyweight_logs ADD COLUMN IF NOT EXISTS user_id INTEGER;
+ALTER TABLE weekly_reports  ADD COLUMN IF NOT EXISTS user_id INTEGER;
+
+-- --- 3. Backfill ----------------------------------------------------------
+-- Everything that exists today was logged by one person, so it all goes to the
+-- owner. Only NULLs are touched, which is what makes a re-run a no-op.
+
+UPDATE exercises       SET user_id = :owner_id WHERE user_id IS NULL;
+UPDATE workout_logs    SET user_id = :owner_id WHERE user_id IS NULL;
+UPDATE bodyweight_logs SET user_id = :owner_id WHERE user_id IS NULL;
+UPDATE weekly_reports  SET user_id = :owner_id WHERE user_id IS NULL;
+
+-- --- 4. Lock it down ------------------------------------------------------
+
+ALTER TABLE exercises       ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE workout_logs    ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE bodyweight_logs ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE weekly_reports  ALTER COLUMN user_id SET NOT NULL;
+
+-- --- 5. Foreign keys ------------------------------------------------------
+-- Named so the runner can check for them before adding; Postgres has no
+-- ADD CONSTRAINT IF NOT EXISTS.
+
+ALTER TABLE exercises
+    ADD CONSTRAINT exercises_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
+ALTER TABLE workout_logs
+    ADD CONSTRAINT workout_logs_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
+ALTER TABLE bodyweight_logs
+    ADD CONSTRAINT bodyweight_logs_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
+ALTER TABLE weekly_reports
+    ADD CONSTRAINT weekly_reports_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
+
+-- --- 6. Uniqueness becomes per-user ---------------------------------------
+-- An exercise name is unique within an account, not across the deployment;
+-- likewise a weekly report is unique per user per week. Dropping the old
+-- global constraints is the step that lets a second person log a "Bench Press".
+
+ALTER TABLE exercises DROP CONSTRAINT IF EXISTS exercises_name_key;
+ALTER TABLE exercises
+    ADD CONSTRAINT exercises_user_name_unique UNIQUE (user_id, name);
+
+ALTER TABLE weekly_reports DROP CONSTRAINT IF EXISTS weekly_reports_week_start_date_key;
+ALTER TABLE weekly_reports
+    ADD CONSTRAINT weekly_reports_user_week_unique UNIQUE (user_id, week_start_date);
+
+-- --- 7. Indexes, now user-first -------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_workout_logs_user_exercise_logged_at
+    ON workout_logs (user_id, exercise_id, logged_at);
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_user_logged_at
+    ON bodyweight_logs (user_id, logged_at);
+CREATE INDEX IF NOT EXISTS idx_workout_logs_user_created_at
+    ON workout_logs (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_user_created_at
+    ON bodyweight_logs (user_id, created_at);
+
+DROP INDEX IF EXISTS idx_workout_logs_exercise_logged_at;
+DROP INDEX IF EXISTS idx_bodyweight_logs_logged_at;
+DROP INDEX IF EXISTS idx_workout_logs_created_at;
+DROP INDEX IF EXISTS idx_bodyweight_logs_created_at;

--- a/parse_workout_log.py
+++ b/parse_workout_log.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """CLI entry point: parse a journal text file into Postgres.
 
-    python parse_workout_log.py <file> <date>
+    python parse_workout_log.py <file> <date> --user <username>
 
-`<date>` is the session date in YYYY-MM-DD. All extraction, validation and
-insert logic lives in pipeline.py — this script only handles argument parsing
-and printing.
+`<date>` is the session date in YYYY-MM-DD. `--user` says whose training this
+is; the database is multi-user, so there is no default account and every row
+written here belongs to exactly one of them. Times are resolved in that user's
+timezone, falling back to LOCAL_TIMEZONE.
+
+All extraction, validation and insert logic lives in pipeline.py — this script
+only handles argument parsing and printing.
 """
 
 from __future__ import annotations
@@ -28,6 +32,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         help="Text file containing the journal entry")
     parser.add_argument("date", nargs="?", help="Session date, YYYY-MM-DD")
     parser.add_argument(
+        "--user",
+        help="Username to log against (default: $APP_USERNAME). "
+             "List accounts with: python manage_users.py list",
+    )
+    parser.add_argument(
         "--check-config",
         action="store_true",
         help="Report where each setting comes from, test the connections, and exit",
@@ -46,8 +55,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _local_time_label(workout_set, session_date: date) -> str:
-    """Resolved wall-clock time for a set, in LOCAL_TIMEZONE.
+def _local_time_label(workout_set, session_date: date, zone_name: str = "") -> str:
+    """Resolved wall-clock time for a set, in the user's zone.
 
     Prefixed with "~" when the text carried no usable time marker and the
     default session hour was applied, so a missed "4:35" is visible.
@@ -56,7 +65,7 @@ def _local_time_label(workout_set, session_date: date) -> str:
 
     # Read the zone once and use it for both the resolve and the display, so the
     # two can never disagree.
-    zone_name = pipeline.LOCAL_TIMEZONE
+    zone_name = zone_name or pipeline.LOCAL_TIMEZONE
     resolved = pipeline.resolve_logged_at(
         workout_set.logged_at_local, session_date, zone_name
     )
@@ -65,7 +74,9 @@ def _local_time_label(workout_set, session_date: date) -> str:
     return f"{prefix}{local:%H:%M}"
 
 
-def format_set_line(workout_set, confidence: float, session_date: date) -> str:
+def format_set_line(
+    workout_set, confidence: float, session_date: date, zone_name: str = ""
+) -> str:
     """One dry-run line: verdict, confidence, resolved time, load, reps, flags."""
     verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
     weight = f"{workout_set.weight_kg:g}kg" if workout_set.weight_kg is not None else "?kg"
@@ -85,7 +96,7 @@ def format_set_line(workout_set, confidence: float, session_date: date) -> str:
         flags += "  (PAIN)"
 
     return (
-        f"  [{verdict}] {confidence:.2f}  {_local_time_label(workout_set, session_date):>6}  "
+        f"  [{verdict}] {confidence:.2f}  {_local_time_label(workout_set, session_date, zone_name):>6}  "
         f"{workout_set.exercise_name:<28} {detail}{flags}"
     )
 
@@ -98,6 +109,8 @@ def _parse_date(value: str) -> date:
         raise SystemExit(2)
 
 
+# APP_USERNAME / APP_PASSWORD are still listed because the migration and the
+# --user default read them, but nobody logs into the web app with them any more.
 SETTINGS = [
     ("DATABASE_URL", True),
     ("GROQ_API_KEY", True),
@@ -209,6 +222,22 @@ def check_config() -> int:
         except Exception as exc:  # noqa: BLE001 - surface whatever failed
             report("database connection", False, str(exc).strip().splitlines()[0])
 
+        # Accounts are the thing most likely to be missing on a database that
+        # was set up before this app had them.
+        try:
+            import auth as _auth
+
+            with pipeline.get_engine().connect() as conn:
+                accounts = _auth.user_count(conn)
+            report("accounts table", True, f"{accounts} account(s)")
+            if accounts == 0:
+                print("         note: nobody has registered yet - open /signup, or "
+                      "run: python manage_users.py create <username>")
+        except Exception as exc:  # noqa: BLE001
+            report("accounts table", False,
+                   f"{str(exc).strip().splitlines()[0]} "
+                   "- run: python migrate_multi_user.py")
+
     api_key = os.getenv("GROQ_API_KEY")
     if not api_key:
         report("GROQ_API_KEY set", False, "not set")
@@ -239,6 +268,40 @@ def check_config() -> int:
     return 0 if ok else 1
 
 
+def _resolve_user(username: str | None):
+    """Look up the account to log against, or explain what to do instead.
+
+    There is no implicit account: writing a set without saying whose it is would
+    have to pick one, and picking the wrong one files somebody else's training
+    under your name.
+    """
+    username = username or os.getenv("APP_USERNAME") or ""
+    if not username:
+        print(
+            "Which user? Pass --user <username>, or set APP_USERNAME.\n"
+            "List accounts with: python manage_users.py list",
+            file=sys.stderr,
+        )
+        return None
+
+    import auth
+
+    with pipeline.get_engine().connect() as conn:
+        user = auth.get_user_by_username(conn, username)
+
+    if user is None:
+        print(
+            f"No account named {username!r}. "
+            "List accounts with: python manage_users.py list",
+            file=sys.stderr,
+        )
+        return None
+    if not user.is_active:
+        print(f"Account {user.username!r} is suspended.", file=sys.stderr)
+        return None
+    return user
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     logging.basicConfig(
@@ -257,20 +320,27 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No such file: {args.file}", file=sys.stderr)
         return 2
 
+    user = _resolve_user(args.user)
+    if user is None:
+        return 2
+
     session_date = _parse_date(args.date)
     raw_text = args.file.read_text(encoding="utf-8").strip()
     if not raw_text:
         print(f"{args.file} is empty — nothing to parse.", file=sys.stderr)
         return 2
 
+    zone = user.timezone or pipeline.LOCAL_TIMEZONE
+
     if args.dry_run:
         payload = pipeline.extract_entities(raw_text, session_date)
         scored_sets, scored_bodyweight, review = pipeline.validate_extraction(payload, raw_text)
         print(f"Dry run — nothing inserted. Session date: {session_date}")
-        print(f"Times shown in {pipeline.LOCAL_TIMEZONE}; \"~\" means no time marker "
+        print(f"User: {user.username}")
+        print(f"Times shown in {zone}; \"~\" means no time marker "
               f"in the text, so the default hour was used.\n")
         for workout_set, confidence in scored_sets:
-            print(format_set_line(workout_set, confidence, session_date))
+            print(format_set_line(workout_set, confidence, session_date, zone))
         if scored_bodyweight:
             entry, confidence = scored_bodyweight
             verdict = "INSERT" if confidence >= pipeline.CONFIDENCE_THRESHOLD else "REVIEW"
@@ -279,11 +349,18 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  [REVIEW] {item.kind}: {item.reason}")
         return 0
 
-    result = pipeline.process_entry(raw_text, session_date, replace_existing=args.replace)
+    result = pipeline.process_entry(
+        raw_text,
+        session_date,
+        user.user_id,
+        replace_existing=args.replace,
+        timezone_name=user.timezone,
+    )
 
     if result.error:
         print(f"Error: {result.error}", file=sys.stderr)
 
+    print(f"User         : {user.username}")
     print(f"Session date : {session_date}")
     if result.replaced:
         print(f"Replaced     : removed {result.replaced['sets']} set(s), "

--- a/pipeline.py
+++ b/pipeline.py
@@ -1557,9 +1557,16 @@ def draft_bodyweight_row(
     return row
 
 
-def load_exercise_groups(conn: Connection) -> dict[str, Optional[str]]:
-    """Every known exercise name and the muscle group it is filed under."""
-    rows = conn.execute(text("SELECT name, muscle_group FROM exercises")).fetchall()
+def load_exercise_groups(conn: Connection, user_id: int) -> dict[str, Optional[str]]:
+    """One user's exercise names and the muscle group each is filed under.
+
+    Scoped like `load_exercise_names`: a suggestion must reflect how this person
+    files their own training, not how somebody else files theirs.
+    """
+    rows = conn.execute(
+        text("SELECT name, muscle_group FROM exercises WHERE user_id = :user_id"),
+        {"user_id": user_id},
+    ).fetchall()
     return {row[0]: row[1] for row in rows}
 
 
@@ -1676,13 +1683,18 @@ def get_engine(database_url: Optional[str] = None, serverless: Optional[bool] = 
     return create_engine(url, pool_pre_ping=True, future=True)
 
 
-def load_exercise_names(conn: Connection) -> dict[str, int]:
-    rows = conn.execute(text("SELECT name, exercise_id FROM exercises")).fetchall()
+def load_exercise_names(conn: Connection, user_id: int) -> dict[str, int]:
+    """One user's exercise names. Fuzzy matching only ever sees their own."""
+    rows = conn.execute(
+        text("SELECT name, exercise_id FROM exercises WHERE user_id = :user_id"),
+        {"user_id": user_id},
+    ).fetchall()
     return {row[0]: row[1] for row in rows}
 
 
 def get_or_create_exercise(
     conn: Connection,
+    user_id: int,
     proposed_name: str,
     muscle_group: Optional[str],
     known: dict[str, int],
@@ -1691,6 +1703,10 @@ def get_or_create_exercise(
     """Resolve an exercise name to an id, fuzzy-matching before inserting.
 
     Returns (exercise_id, matched_existing_name_or_None, created).
+
+    The exercise table is per-user: `known` holds only this user's names, and
+    both the update and the insert below are scoped to `user_id`. Two people can
+    each have a "Lat Pulldown", filed however each of them wants.
 
     `chosen_group` says the muscle group came from a person on the review
     screen rather than from the table. Only then is an existing exercise's group
@@ -1704,9 +1720,10 @@ def get_or_create_exercise(
         if chosen_group:
             conn.execute(
                 text("UPDATE exercises SET muscle_group = :muscle_group "
-                     "WHERE exercise_id = :exercise_id "
+                     "WHERE exercise_id = :exercise_id AND user_id = :user_id "
                      "AND muscle_group IS DISTINCT FROM :muscle_group"),
-                {"muscle_group": muscle_group, "exercise_id": exercise_id},
+                {"muscle_group": muscle_group, "exercise_id": exercise_id,
+                 "user_id": user_id},
             )
         return exercise_id, matched, False
 
@@ -1719,15 +1736,15 @@ def get_or_create_exercise(
     row = conn.execute(
         text(
             """
-            INSERT INTO exercises (name, muscle_group)
-            VALUES (:name, :muscle_group)
-            ON CONFLICT (name) DO UPDATE
+            INSERT INTO exercises (user_id, name, muscle_group)
+            VALUES (:user_id, :name, :muscle_group)
+            ON CONFLICT (user_id, name) DO UPDATE
                 SET muscle_group = COALESCE(exercises.muscle_group,
                                             EXCLUDED.muscle_group)
             RETURNING exercise_id
             """
         ),
-        {"name": proposed_name, "muscle_group": muscle_group},
+        {"user_id": user_id, "name": proposed_name, "muscle_group": muscle_group},
     ).fetchone()
     exercise_id = int(row[0])
     known[proposed_name] = exercise_id
@@ -1737,10 +1754,10 @@ def get_or_create_exercise(
 _INSERT_WORKOUT_SET = text(
     """
     INSERT INTO workout_logs (
-        exercise_id, logged_at, weight_kg, reps, cheat_reps, set_number,
+        user_id, exercise_id, logged_at, weight_kg, reps, cheat_reps, set_number,
         is_warmup, is_dropset, pain_flag, notes, raw_source, extraction_confidence
     ) VALUES (
-        :exercise_id, :logged_at, :weight_kg, :reps, :cheat_reps, :set_number,
+        :user_id, :exercise_id, :logged_at, :weight_kg, :reps, :cheat_reps, :set_number,
         :is_warmup, :is_dropset, :pain_flag, :notes, :raw_source, :extraction_confidence
     )
     """
@@ -1749,52 +1766,75 @@ _INSERT_WORKOUT_SET = text(
 _INSERT_BODYWEIGHT = text(
     """
     INSERT INTO bodyweight_logs (
-        logged_at, weight_kg, body_fat_pct, notes, raw_source, extraction_confidence
+        user_id, logged_at, weight_kg, body_fat_pct, notes, raw_source,
+        extraction_confidence
     ) VALUES (
-        :logged_at, :weight_kg, :body_fat_pct, :notes, :raw_source, :extraction_confidence
+        :user_id, :logged_at, :weight_kg, :body_fat_pct, :notes, :raw_source,
+        :extraction_confidence
     )
     """
 )
 
 
-def _local_day_bounds(session_date: date) -> tuple[datetime, datetime]:
-    """The UTC window covering one local calendar day."""
-    start = local_to_utc(datetime.combine(session_date, time.min))
-    end = local_to_utc(datetime.combine(session_date + timedelta(days=1), time.min))
+def _local_day_bounds(
+    session_date: date, timezone_name: Optional[str] = None
+) -> tuple[datetime, datetime]:
+    """The UTC window covering one local calendar day, in the user's own zone."""
+    start = local_to_utc(datetime.combine(session_date, time.min), timezone_name)
+    end = local_to_utc(
+        datetime.combine(session_date + timedelta(days=1), time.min), timezone_name
+    )
     return start, end
 
 
-def count_entries_for_date(engine: Engine, session_date: date) -> dict[str, int]:
-    """How much is already logged against a local date."""
-    start, end = _local_day_bounds(session_date)
-    params = {"start": start, "end": end}
+def count_entries_for_date(
+    engine: Engine,
+    session_date: date,
+    user_id: int,
+    timezone_name: Optional[str] = None,
+) -> dict[str, int]:
+    """How much this user has already logged against a local date."""
+    start, end = _local_day_bounds(session_date, timezone_name)
+    params = {"start": start, "end": end, "user_id": user_id}
     with engine.connect() as conn:
         sets = conn.execute(
-            text("SELECT count(*) FROM workout_logs WHERE logged_at >= :start AND logged_at < :end"),
+            text("SELECT count(*) FROM workout_logs WHERE user_id = :user_id "
+                 "AND logged_at >= :start AND logged_at < :end"),
             params,
         ).scalar_one()
         bodyweight = conn.execute(
-            text("SELECT count(*) FROM bodyweight_logs "
-                 "WHERE logged_at >= :start AND logged_at < :end"),
+            text("SELECT count(*) FROM bodyweight_logs WHERE user_id = :user_id "
+                 "AND logged_at >= :start AND logged_at < :end"),
             params,
         ).scalar_one()
     return {"sets": int(sets), "bodyweight": int(bodyweight)}
 
 
-def delete_entries_for_date(conn: Connection, session_date: date) -> dict[str, int]:
-    """Remove every log row on a local date. Caller owns the transaction.
+def delete_entries_for_date(
+    conn: Connection,
+    session_date: date,
+    user_id: int,
+    timezone_name: Optional[str] = None,
+) -> dict[str, int]:
+    """Remove one user's log rows on a local date. Caller owns the transaction.
 
     Takes a Connection rather than an Engine so the delete and the insert that
     replaces it commit together: a failure mid-way must never leave the day
     emptied with nothing put back.
+
+    `user_id` is not optional and is not defaulted anywhere up the call chain.
+    This is the one destructive statement in the codebase; an unscoped version
+    of it would clear that date for every account on the deployment.
     """
-    start, end = _local_day_bounds(session_date)
-    params = {"start": start, "end": end}
+    start, end = _local_day_bounds(session_date, timezone_name)
+    params = {"start": start, "end": end, "user_id": user_id}
     sets = conn.execute(
-        text("DELETE FROM workout_logs WHERE logged_at >= :start AND logged_at < :end"), params
+        text("DELETE FROM workout_logs WHERE user_id = :user_id "
+             "AND logged_at >= :start AND logged_at < :end"), params
     ).rowcount
     bodyweight = conn.execute(
-        text("DELETE FROM bodyweight_logs WHERE logged_at >= :start AND logged_at < :end"), params
+        text("DELETE FROM bodyweight_logs WHERE user_id = :user_id "
+             "AND logged_at >= :start AND logged_at < :end"), params
     ).rowcount
     return {"sets": int(sets or 0), "bodyweight": int(bodyweight or 0)}
 
@@ -1802,20 +1842,30 @@ def delete_entries_for_date(conn: Connection, session_date: date) -> dict[str, i
 def find_recent_submission(
     engine: Engine,
     raw_text: str,
+    user_id: int,
     window_minutes: int = DUPLICATE_WINDOW_MINUTES,
 ) -> Optional[dict[str, int]]:
     """Return counts for an identical entry inserted within the window, else None.
 
     Backs the /log duplicate-submission guard: Render's free tier cold-starts for
     30-50s, which is exactly when a user double-taps submit.
+
+    Scoped to one account, so two people pasting the same template entry on the
+    same evening each get their own saved, rather than the second being told it
+    was a duplicate of the first.
     """
     with engine.connect() as conn:
-        params = {"raw_source": raw_text, "window": f"{int(window_minutes)} minutes"}
+        params = {
+            "raw_source": raw_text,
+            "window": f"{int(window_minutes)} minutes",
+            "user_id": user_id,
+        }
         sets = conn.execute(
             text(
                 """
                 SELECT count(*) FROM workout_logs
-                WHERE raw_source = :raw_source
+                WHERE user_id = :user_id
+                  AND raw_source = :raw_source
                   AND created_at >= now() - CAST(:window AS interval)
                 """
             ),
@@ -1825,7 +1875,8 @@ def find_recent_submission(
             text(
                 """
                 SELECT count(*) FROM bodyweight_logs
-                WHERE raw_source = :raw_source
+                WHERE user_id = :user_id
+                  AND raw_source = :raw_source
                   AND created_at >= now() - CAST(:window AS interval)
                 """
             ),
@@ -1844,12 +1895,20 @@ def find_recent_submission(
 
 def commit_draft(
     draft: EntryDraft,
+    user_id: int,
     engine: Optional[Engine] = None,
     check_duplicates: bool = False,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     review_excluded: bool = False,
+    timezone_name: Optional[str] = None,
 ) -> PipelineResult:
-    """Write the ticked rows of a draft. The only function that inserts.
+    """Write the ticked rows of a draft for one user. The only function that inserts.
+
+    `user_id` is an argument rather than a field on the draft on purpose. The
+    draft round-trips through a hidden-field HTML form on the review screen, and
+    anything carried there is whatever the browser posted back; ownership is
+    taken from the session instead, so a tampered form cannot write into
+    somebody else's account.
 
     A row that reaches here has either been looked at on the review screen or
     cleared the threshold unattended, so the threshold is not applied again —
@@ -1874,7 +1933,7 @@ def commit_draft(
         return result
 
     if check_duplicates:
-        prior = find_recent_submission(engine, draft.raw_text)
+        prior = find_recent_submission(engine, draft.raw_text, user_id)
         if prior is not None:
             logger.info("Duplicate submission suppressed (%s)", prior)
             return PipelineResult(
@@ -1944,13 +2003,15 @@ def commit_draft(
         if draft.replace_existing:
             # Only reached when there is something to put back - the early
             # return above means a failed extraction never empties the day.
-            result.replaced = delete_entries_for_date(conn, draft.session_date)
+            result.replaced = delete_entries_for_date(
+                conn, draft.session_date, user_id, timezone_name
+            )
             logger.info("Replaced %s on %s", result.replaced, draft.session_date)
-        known = load_exercise_names(conn)
+        known = load_exercise_names(conn, user_id)
         for workout_set, confidence, chosen_group, name_typed in accepted_sets:
             exercise_id, matched_name, created = get_or_create_exercise(
-                conn, workout_set.exercise_name, workout_set.muscle_group, known,
-                chosen_group=chosen_group,
+                conn, user_id, workout_set.exercise_name, workout_set.muscle_group,
+                known, chosen_group=chosen_group,
             )
             if created:
                 result.exercises_created.append(workout_set.exercise_name)
@@ -1986,8 +2047,11 @@ def commit_draft(
             conn.execute(
                 _INSERT_WORKOUT_SET,
                 {
+                    "user_id": user_id,
                     "exercise_id": exercise_id,
-                    "logged_at": resolve_logged_at(workout_set.logged_at_local, draft.session_date),
+                    "logged_at": resolve_logged_at(
+                        workout_set.logged_at_local, draft.session_date, timezone_name
+                    ),
                     "weight_kg": workout_set.weight_kg,
                     "reps": workout_set.reps,
                     "cheat_reps": workout_set.cheat_reps,
@@ -2007,7 +2071,10 @@ def commit_draft(
             conn.execute(
                 _INSERT_BODYWEIGHT,
                 {
-                    "logged_at": resolve_logged_at(entry.logged_at_local, draft.session_date),
+                    "user_id": user_id,
+                    "logged_at": resolve_logged_at(
+                        entry.logged_at_local, draft.session_date, timezone_name
+                    ),
                     "weight_kg": entry.weight_kg,
                     "body_fat_pct": entry.body_fat_pct,
                     "notes": entry.notes,
@@ -2023,13 +2090,15 @@ def commit_draft(
 def process_entry(
     raw_text: str,
     session_date: date,
+    user_id: int,
     engine: Optional[Engine] = None,
     client: Any = None,
     check_duplicates: bool = False,
     confidence_threshold: float = CONFIDENCE_THRESHOLD,
     replace_existing: bool = False,
+    timezone_name: Optional[str] = None,
 ) -> PipelineResult:
-    """Extract and insert one journal entry with nobody watching.
+    """Extract and insert one journal entry for one user, with nobody watching.
 
     The CLI path: no review screen, so the confidence threshold does the
     deciding and anything under it is reported rather than saved. The web app
@@ -2044,7 +2113,7 @@ def process_entry(
         engine = get_engine()
 
     if check_duplicates:
-        prior = find_recent_submission(engine, raw_text)
+        prior = find_recent_submission(engine, raw_text, user_id)
         if prior is not None:
             logger.info("Duplicate submission suppressed (%s)", prior)
             return PipelineResult(
@@ -2064,7 +2133,9 @@ def process_entry(
 
     return commit_draft(
         draft,
+        user_id,
         engine=engine,
         confidence_threshold=confidence_threshold,
         review_excluded=True,
+        timezone_name=timezone_name,
     )

--- a/render.yaml
+++ b/render.yaml
@@ -12,6 +12,8 @@ services:
         sync: false
       - key: DATABASE_URL
         sync: false
+      # Only read by migrate_multi_user.py and the CLI scripts. Logins go
+      # through the `users` table; nobody authenticates against these.
       - key: APP_USERNAME
         sync: false
       - key: APP_PASSWORD
@@ -22,3 +24,7 @@ services:
         value: UTC
       - key: PAIN_SAFEGUARD_ENABLED
         value: "true"
+      - key: PBKDF2_ITERATIONS
+        value: "600000"
+      - key: SESSION_TTL_DAYS
+        value: "30"

--- a/schema.sql
+++ b/schema.sql
@@ -1,9 +1,16 @@
 -- Gym Tracker schema (Postgres / Supabase free tier)
 --
 -- Design notes:
+--   * Every row of training data belongs to exactly one row in `users`. There
+--     is no shared data and no global view: the application always filters by
+--     the logged-in user_id, and the foreign keys below make an orphaned row
+--     impossible. Deleting a user deletes their training with it.
+--   * `exercises` is per-user, not a shared catalogue. Two people can both have
+--     a "Lat Pulldown" filed under different muscle groups, and one person
+--     correcting their own filing cannot touch anyone else's.
 --   * All `logged_at` columns are timestamptz. The application converts local
---     wall-clock time (LOCAL_TIMEZONE env var) to UTC at insert time. This is a
---     single-user personal tool, so one fixed timezone is assumed throughout.
+--     wall-clock time to UTC at insert time, using the user's own timezone
+--     (users.timezone) and falling back to the LOCAL_TIMEZONE env var.
 --   * `raw_source` keeps the original journal text for every row so any parse
 --     can be audited or re-run later.
 --   * `extraction_confidence` is computed by the pipeline from checkable
@@ -11,19 +18,63 @@
 --     the LLM. Rows below CONFIDENCE_THRESHOLD are not inserted at all, so in
 --     practice stored values are >= that threshold.
 --   * Schema is shaped for direct Power BI consumption: narrow fact tables
---     (workout_logs, bodyweight_logs), one dimension table (exercises), and a
---     precomputed report table (weekly_reports).
+--     (workout_logs, bodyweight_logs), dimension tables (exercises, users), and
+--     a precomputed report table (weekly_reports).
 --
 -- Safe to re-run: every object is created IF NOT EXISTS.
+--
+-- Upgrading a database that predates accounts? Do not run this file — run
+-- `python migrate_multi_user.py`, which adds the tables and columns below to
+-- the existing one and moves the data you already have onto an owner account.
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id       SERIAL PRIMARY KEY,
+    -- Lowercased. `display_name` keeps the capitalisation the person typed;
+    -- this column is what logins and the unique index compare against, so
+    -- "Sohaib" and "sohaib" cannot both be registered.
+    username      TEXT NOT NULL UNIQUE,
+    display_name  TEXT NOT NULL,
+    -- PBKDF2-HMAC-SHA256, `pbkdf2_sha256$iterations$salt$hash`. See auth.py.
+    password_hash TEXT NOT NULL,
+    -- IANA name. NULL means "use the deployment's LOCAL_TIMEZONE", which is
+    -- what decides the calendar day - and so the week - a session falls in.
+    timezone      TEXT,
+    is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_login_at TIMESTAMPTZ,
+
+    CONSTRAINT users_username_lowercase CHECK (username = lower(username))
+);
+
+-- Login sessions. Only the SHA-256 of each token is stored, so a database dump
+-- cannot be replayed as a live login.
+CREATE TABLE IF NOT EXISTS user_sessions (
+    token_hash   TEXT PRIMARY KEY,
+    user_id      INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at   TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id
+    ON user_sessions (user_id);
+-- Supports the expiry sweep.
+CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at
+    ON user_sessions (expires_at);
 
 CREATE TABLE IF NOT EXISTS exercises (
     exercise_id  SERIAL PRIMARY KEY,
-    name         TEXT NOT NULL UNIQUE,
-    muscle_group TEXT
+    user_id      INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+    name         TEXT NOT NULL,
+    muscle_group TEXT,
+
+    -- Per-user, not global: the same lift name may exist once for each person.
+    CONSTRAINT exercises_user_name_unique UNIQUE (user_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS workout_logs (
     log_id                BIGSERIAL PRIMARY KEY,
+    user_id               INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
     exercise_id           INTEGER NOT NULL REFERENCES exercises (exercise_id),
     logged_at             TIMESTAMPTZ NOT NULL,
     weight_kg             NUMERIC(6, 2),
@@ -52,6 +103,7 @@ CREATE TABLE IF NOT EXISTS workout_logs (
 
 CREATE TABLE IF NOT EXISTS bodyweight_logs (
     log_id                BIGSERIAL PRIMARY KEY,
+    user_id               INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
     logged_at             TIMESTAMPTZ NOT NULL,
     weight_kg             NUMERIC(5, 2) NOT NULL,
     body_fat_pct          NUMERIC(4, 1),
@@ -68,27 +120,31 @@ CREATE TABLE IF NOT EXISTS bodyweight_logs (
                OR (extraction_confidence >= 0 AND extraction_confidence <= 1))
 );
 
--- week_start_date is UNIQUE so regenerating a report for an already-computed
--- week is an upsert (ON CONFLICT ... DO UPDATE), never a duplicate row.
+-- (user_id, week_start_date) is UNIQUE so regenerating a report for an
+-- already-computed week is an upsert (ON CONFLICT ... DO UPDATE), never a
+-- duplicate row - and one person regenerating never overwrites another's.
 CREATE TABLE IF NOT EXISTS weekly_reports (
     report_id       SERIAL PRIMARY KEY,
-    week_start_date DATE NOT NULL UNIQUE,
+    user_id         INTEGER NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+    week_start_date DATE NOT NULL,
     summary_text    TEXT,
     recommendations JSONB,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT weekly_reports_user_week_unique UNIQUE (user_id, week_start_date)
 );
 
--- Progress queries are always "this exercise, over time".
-CREATE INDEX IF NOT EXISTS idx_workout_logs_exercise_logged_at
-    ON workout_logs (exercise_id, logged_at);
+-- Progress queries are always "this user, this exercise, over time".
+CREATE INDEX IF NOT EXISTS idx_workout_logs_user_exercise_logged_at
+    ON workout_logs (user_id, exercise_id, logged_at);
 
--- Bodyweight trend is a straight time series.
-CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_logged_at
-    ON bodyweight_logs (logged_at);
+-- Bodyweight trend is a straight per-user time series.
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_user_logged_at
+    ON bodyweight_logs (user_id, logged_at);
 
 -- Supports the /log duplicate-submission guard, which looks up recent rows by
--- their originating journal text.
-CREATE INDEX IF NOT EXISTS idx_workout_logs_created_at
-    ON workout_logs (created_at);
-CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_created_at
-    ON bodyweight_logs (created_at);
+-- their originating journal text within one account.
+CREATE INDEX IF NOT EXISTS idx_workout_logs_user_created_at
+    ON workout_logs (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_bodyweight_logs_user_created_at
+    ON bodyweight_logs (user_id, created_at);

--- a/seed_sample_data.py
+++ b/seed_sample_data.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Seed a few weeks of realistic sample data so the weekly report can be tried out.
 
-    python seed_sample_data.py            # seed
-    python seed_sample_data.py --reset    # wipe logs first, then seed
+    python seed_sample_data.py --user alice            # seed
+    python seed_sample_data.py --user alice --reset    # wipe alice's logs, then seed
+
+The data belongs to one account. `--reset` clears only that account's rows -
+never the whole table - so seeding a demo user cannot wipe real training.
 
 The generated pattern deliberately exercises every recommendation branch:
   Chest Bench Press  - progressing, tops out the rep range  -> increase
@@ -17,10 +20,13 @@ also trips the program-level stagnation flag.
 from __future__ import annotations
 
 import argparse
+import os
+import sys
 from datetime import date, datetime, time, timedelta
 
 from sqlalchemy import text
 
+import auth
 import insights
 import pipeline
 
@@ -41,30 +47,35 @@ PLAN = [
 BODYWEIGHTS = [83.1, 82.8, 82.4]
 
 
-def seed(engine, week_start: date) -> None:
+def seed(engine, week_start: date, user_id: int, timezone_name: str | None = None) -> None:
     # Sessions land in the three weeks ending with `week_start`'s week.
     session_days = [week_start - timedelta(weeks=2), week_start - timedelta(weeks=1), week_start]
 
     with engine.begin() as conn:
-        known = pipeline.load_exercise_names(conn)
+        known = pipeline.load_exercise_names(conn, user_id)
 
         for name, muscle_group, warmup_kg, sessions, pain_sessions in PLAN:
-            exercise_id, _, _ = pipeline.get_or_create_exercise(conn, name, muscle_group, known)
+            exercise_id, _, _ = pipeline.get_or_create_exercise(
+                conn, user_id, name, muscle_group, known
+            )
             # Backfill the muscle group when the row already existed without one.
             conn.execute(
                 text("UPDATE exercises SET muscle_group = :mg WHERE exercise_id = :id "
-                     "AND muscle_group IS NULL"),
-                {"mg": muscle_group, "id": exercise_id},
+                     "AND user_id = :user_id AND muscle_group IS NULL"),
+                {"mg": muscle_group, "id": exercise_id, "user_id": user_id},
             )
 
             for index, (weight, reps_list) in enumerate(sessions):
                 day = session_days[index]
-                logged_at = pipeline.local_to_utc(datetime.combine(day, time(hour=18)))
+                logged_at = pipeline.local_to_utc(
+                    datetime.combine(day, time(hour=18)), timezone_name
+                )
                 pain = index in pain_sessions
                 raw = f"[seed] {name} session {index + 1} on {day.isoformat()}"
 
                 rows = [
                     {
+                        "user_id": user_id,
                         "exercise_id": exercise_id, "logged_at": logged_at,
                         "weight_kg": warmup_kg, "reps": 12, "cheat_reps": 0, "set_number": 1,
                         "is_warmup": True, "is_dropset": False, "pain_flag": False,
@@ -76,6 +87,7 @@ def seed(engine, week_start: date) -> None:
                     # lift, so the clean-rep path is exercised by seeded data too.
                     cheat = 2 if (name == "Lateral Raise" and set_number == len(reps_list) + 1) else 0
                     rows.append({
+                        "user_id": user_id,
                         "exercise_id": exercise_id, "logged_at": logged_at,
                         "weight_kg": weight, "reps": reps, "cheat_reps": cheat,
                         "set_number": set_number,
@@ -91,7 +103,10 @@ def seed(engine, week_start: date) -> None:
             conn.execute(
                 pipeline._INSERT_BODYWEIGHT,
                 {
-                    "logged_at": pipeline.local_to_utc(datetime.combine(day, time(hour=7))),
+                    "user_id": user_id,
+                    "logged_at": pipeline.local_to_utc(
+                        datetime.combine(day, time(hour=7)), timezone_name
+                    ),
                     "weight_kg": weight, "body_fat_pct": None, "notes": None,
                     "raw_source": f"[seed] bodyweight {day.isoformat()}",
                     "extraction_confidence": 1.0,
@@ -101,26 +116,43 @@ def seed(engine, week_start: date) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user", help="Account to seed (default: $APP_USERNAME)")
     parser.add_argument("--reset", action="store_true",
-                        help="Delete all workout/bodyweight/report rows first")
+                        help="Delete that user's workout/bodyweight/report rows first")
     parser.add_argument("--week-start", help="Monday of the most recent seeded week (YYYY-MM-DD)")
     args = parser.parse_args()
 
+    username = args.user or os.getenv("APP_USERNAME") or ""
+    if not username:
+        print("Which user? Pass --user <username>, or set APP_USERNAME.", file=sys.stderr)
+        return 2
+
     engine = pipeline.get_engine()
+    with engine.connect() as conn:
+        user = auth.get_user_by_username(conn, username)
+    if user is None:
+        print(f"No account named {username!r}. Create one with: "
+              f"python manage_users.py create {username}", file=sys.stderr)
+        return 2
+
     if args.reset:
+        # Scoped to this user. An unscoped DELETE here would clear every
+        # account's training to make room for one account's demo data.
         with engine.begin() as conn:
-            conn.execute(text("DELETE FROM workout_logs"))
-            conn.execute(text("DELETE FROM bodyweight_logs"))
-            conn.execute(text("DELETE FROM weekly_reports"))
-        print("Cleared workout_logs, bodyweight_logs and weekly_reports.")
+            for table in ("workout_logs", "bodyweight_logs", "weekly_reports"):
+                conn.execute(
+                    text(f"DELETE FROM {table} WHERE user_id = :user_id"),
+                    {"user_id": user.user_id},
+                )
+        print(f"Cleared {user.username}'s workout_logs, bodyweight_logs and weekly_reports.")
 
     week_start = (
         datetime.strptime(args.week_start, "%Y-%m-%d").date()
         if args.week_start
         else insights.week_start_for(date.today())
     )
-    seed(engine, insights.week_start_for(week_start))
-    print(f"Seeded 3 weeks of sample data ending the week of "
+    seed(engine, insights.week_start_for(week_start), user.user_id, user.timezone)
+    print(f"Seeded 3 weeks of sample data for {user.username} ending the week of "
           f"{insights.week_start_for(week_start).isoformat()}.")
     return 0
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,227 @@
+"""Passwords, usernames, sessions and rate limiting.
+
+Everything here is the part of auth.py that does not need a database. The SQL
+side is covered by tests/test_multi_user.py, which drives it through the app.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import auth  # noqa: E402
+
+# Real hashing at 600k rounds costs about a third of a second a call, and these
+# tests call it a lot. The cost factor is what is being kept out of the test, not
+# the algorithm: every assertion below still runs the genuine PBKDF2 path.
+FAST = 1_000
+
+
+class TestPasswordHashing:
+    def test_a_password_verifies_against_its_own_hash(self):
+        stored = auth.hash_password("correct horse battery", FAST)
+        assert auth.verify_password("correct horse battery", stored)
+
+    def test_a_wrong_password_does_not(self):
+        stored = auth.hash_password("correct horse battery", FAST)
+        assert not auth.verify_password("correct horse batteru", stored)
+
+    def test_the_password_is_not_recoverable_from_the_hash(self):
+        assert "hunter2hunter2" not in auth.hash_password("hunter2hunter2", FAST)
+
+    def test_two_hashes_of_one_password_differ(self):
+        """Per-hash salt: identical passwords must not produce identical rows,
+        or the table itself would show which accounts share a password."""
+        first = auth.hash_password("same password", FAST)
+        second = auth.hash_password("same password", FAST)
+        assert first != second
+        assert auth.verify_password("same password", first)
+        assert auth.verify_password("same password", second)
+
+    def test_the_cost_factor_travels_with_the_hash(self):
+        stored = auth.hash_password("a password here", 2_000)
+        assert stored.split("$")[1] == "2000"
+        # Verifying does not need to be told the count - which is what makes it
+        # safe to raise the default later without locking anyone out.
+        assert auth.verify_password("a password here", stored)
+
+    @pytest.mark.parametrize(
+        "stored",
+        [
+            "",
+            "not-a-hash",
+            "pbkdf2_sha256$notanumber$c2FsdA$aGFzaA",
+            "pbkdf2_sha256$0$c2FsdA$aGFzaA",
+            "bcrypt$12$c2FsdA$aGFzaA",
+            "pbkdf2_sha256$1000$!!!$aGFzaA",
+        ],
+    )
+    def test_a_malformed_hash_never_authenticates(self, stored):
+        """A row this function cannot read is a failed login, not an exception -
+        and never an accidental success."""
+        assert not auth.verify_password("anything at all", stored)
+
+    def test_rehash_is_asked_for_when_the_cost_factor_has_risen(self):
+        assert auth.needs_rehash(auth.hash_password("password!", FAST))
+        assert not auth.needs_rehash(
+            auth.hash_password("password!", auth.PBKDF2_ITERATIONS)
+        )
+
+    def test_rehash_is_asked_for_on_an_unreadable_hash(self):
+        assert auth.needs_rehash("bcrypt$12$whatever")
+
+
+class TestUsernames:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("alice", "alice"),
+            ("  Alice  ", "alice"),
+            ("SOHAIB", "sohaib"),
+            ("a.b_c-d", "a.b_c-d"),
+            ("lifter99", "lifter99"),
+        ],
+    )
+    def test_accepted_names_fold_to_lowercase(self, raw, expected):
+        assert auth.normalize_username(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "  ",
+            "ab",                       # too short
+            "x" * 33,                   # too long
+            "has space",
+            "has@sign",
+            ".leading",
+            "trailing-",
+            "admin",                    # reserved
+            "LOGIN",                    # reserved, whatever the case
+        ],
+    )
+    def test_rejected_names_explain_themselves(self, raw):
+        with pytest.raises(auth.AuthError):
+            auth.normalize_username(raw)
+
+    def test_case_folding_is_what_stops_a_lookalike_account(self):
+        """'Alice' and 'alice' normalize to one stored name, so the unique index
+        rejects the second - the impersonation this is really guarding against."""
+        assert auth.normalize_username("Alice") == auth.normalize_username("alice")
+
+
+class TestPasswordRules:
+    def test_a_long_enough_password_is_returned_unchanged(self):
+        assert auth.validate_password("longenough") == "longenough"
+
+    @pytest.mark.parametrize("raw", ["", "short", "1234567"])
+    def test_a_short_password_is_rejected(self, raw):
+        with pytest.raises(auth.AuthError):
+            auth.validate_password(raw)
+
+    def test_an_absurdly_long_password_is_rejected(self):
+        """Not a security rule - a bound on how much text we will run 600k
+        rounds of PBKDF2 over before the caller has authenticated."""
+        with pytest.raises(auth.AuthError):
+            auth.validate_password("x" * (auth.PASSWORD_MAX + 1))
+
+
+class TestTimezones:
+    def test_a_real_zone_is_kept(self):
+        assert auth.validate_timezone("Asia/Karachi") == "Asia/Karachi"
+
+    @pytest.mark.parametrize("raw", ["", "   ", None])
+    def test_blank_means_use_the_app_default(self, raw):
+        assert auth.validate_timezone(raw) is None
+
+    @pytest.mark.parametrize("raw", ["Mars/Olympus", "GMT+5", "not a zone"])
+    def test_an_unloadable_zone_is_rejected(self, raw):
+        with pytest.raises(auth.AuthError):
+            auth.validate_timezone(raw)
+
+
+class TestSessionTokens:
+    def test_the_raw_token_is_never_what_gets_stored(self):
+        token = "a-token-value"
+        assert auth._token_hash(token) != token
+        assert len(auth._token_hash(token)) == 64
+
+    def test_hashing_is_stable(self):
+        assert auth._token_hash("abc") == auth._token_hash("abc")
+
+    def test_different_tokens_hash_differently(self):
+        assert auth._token_hash("abc") != auth._token_hash("abd")
+
+    def test_cookie_lifetime_matches_the_session_lifetime(self):
+        assert auth.session_cookie_max_age(30) == 30 * 24 * 3600
+
+
+class TestSessionRefreshWindow:
+    """`resolve_session` only writes once a session is half spent, so an active
+    user is never logged out and an idle one still expires on time."""
+
+    def _window(self, age_days: float, ttl_days: int = 30):
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(days=age_days)
+        return created, created + timedelta(days=ttl_days)
+
+    def test_a_fresh_session_is_not_rewritten(self):
+        created, expires = self._window(age_days=1)
+        assert not auth._past_halfway(created, expires)
+
+    def test_a_session_past_the_midpoint_is_extended(self):
+        created, expires = self._window(age_days=20)
+        assert auth._past_halfway(created, expires)
+
+    def test_missing_timestamps_extend_rather_than_crash(self):
+        assert auth._past_halfway(None, None)
+
+    def test_naive_timestamps_are_read_as_utc(self):
+        """Some drivers hand back naive datetimes; comparing one against an
+        aware `now` would raise, and this path runs on every request."""
+        created = datetime.utcnow() - timedelta(days=20)
+        assert auth._past_halfway(created, created + timedelta(days=30))
+
+
+class TestRateLimiter:
+    def test_attempts_up_to_the_limit_are_allowed(self):
+        limiter = auth.RateLimiter(limit=3, window_seconds=60)
+        assert [limiter.check("ip", now=100.0) for _ in range(3)] == [True] * 3
+
+    def test_the_next_attempt_is_refused(self):
+        limiter = auth.RateLimiter(limit=3, window_seconds=60)
+        for _ in range(3):
+            limiter.check("ip", now=100.0)
+        assert limiter.check("ip", now=100.0) is False
+
+    def test_the_window_moves_on(self):
+        limiter = auth.RateLimiter(limit=2, window_seconds=60)
+        limiter.check("ip", now=100.0)
+        limiter.check("ip", now=100.0)
+        assert limiter.check("ip", now=100.0) is False
+        assert limiter.check("ip", now=200.0) is True
+
+    def test_one_caller_being_limited_does_not_limit_another(self):
+        """The whole point of keying by client: an attacker hammering the login
+        form must not lock everyone else out of their own account."""
+        limiter = auth.RateLimiter(limit=1, window_seconds=60)
+        assert limiter.check("attacker", now=100.0) is True
+        assert limiter.check("attacker", now=100.0) is False
+        assert limiter.check("someone-else", now=100.0) is True
+
+    def test_a_successful_login_can_clear_the_count(self):
+        limiter = auth.RateLimiter(limit=1, window_seconds=60)
+        limiter.check("ip", now=100.0)
+        limiter.reset("ip")
+        assert limiter.check("ip", now=100.0) is True
+
+    def test_old_keys_do_not_accumulate_forever(self):
+        limiter = auth.RateLimiter(limit=1, window_seconds=1)
+        for index in range(5000):
+            limiter.check(f"ip-{index}", now=float(index))
+        assert len(limiter._hits) < 5000

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -1,0 +1,648 @@
+"""Isolation: one account's training must never reach another's screen.
+
+Two halves.
+
+`TestQueriesAreScoped` drives the database functions against a recording
+connection and asserts that every statement they emit names `user_id`, in the
+SQL and in the bound parameters. An unscoped SELECT is the failure that shows
+somebody else's lifts on your progress page; an unscoped DELETE is the one that
+wipes them.
+
+`TestRoutes` drives the app itself and asserts the id it hands those functions
+always comes from the session cookie - never from the form that was posted, and
+never from a query parameter.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import auth  # noqa: E402
+import insights  # noqa: E402
+import pipeline  # noqa: E402
+
+USER_ID = 7
+OTHER_USER_ID = 8
+
+# The tables a person's training lives in. A statement touching one of these
+# without naming user_id is the bug this whole module exists to catch.
+OWNED_TABLES = ("workout_logs", "bodyweight_logs", "exercises", "weekly_reports")
+
+
+# --------------------------------------------------------------------------
+# Recording fakes
+# --------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, rows=()):
+        self._rows = list(rows)
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar_one(self):
+        return 0
+
+    def scalar(self):
+        return None
+
+    @property
+    def rowcount(self):
+        return 0
+
+
+class RecordingConnection:
+    """Records every statement and its parameters, returns nothing useful."""
+
+    def __init__(self, rows=(), calls=None):
+        self.rows = list(rows)
+        self.calls = calls if calls is not None else []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        sql = " ".join(str(statement).split())
+        self.calls.append((sql, dict(params or {})))
+        # The only rows any caller here actually reads back are the exercise id
+        # from an upsert's RETURNING clause; everything else just needs to be
+        # empty and not raise.
+        if "RETURNING" in sql:
+            return _Result([(1,)])
+        return _Result(self.rows)
+
+
+class RecordingEngine:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+        self.calls: list = []
+
+    def begin(self):
+        return RecordingConnection(self.rows, self.calls)
+
+    def connect(self):
+        return RecordingConnection(self.rows, self.calls)
+
+
+def assert_scoped(calls, user_id=USER_ID):
+    """Every statement touching an owned table must name user_id and bind it."""
+    assert calls, "expected at least one statement"
+    for sql, params in calls:
+        if not any(table in sql for table in OWNED_TABLES):
+            continue
+        assert "user_id" in sql, f"statement is not scoped to a user: {sql}"
+        assert params.get("user_id") == user_id, f"wrong or missing user_id: {sql}"
+
+
+# --------------------------------------------------------------------------
+# The database layer
+# --------------------------------------------------------------------------
+
+
+class TestQueriesAreScoped:
+    def test_counting_a_days_entries(self):
+        engine = RecordingEngine()
+        pipeline.count_entries_for_date(engine, date(2026, 8, 22), USER_ID)
+        assert_scoped(engine.calls)
+
+    def test_deleting_a_day(self):
+        """The one destructive statement in the codebase. Unscoped, a single
+        'Replace' would clear that date for every account on the deployment."""
+        conn = RecordingConnection()
+        pipeline.delete_entries_for_date(conn, date(2026, 8, 22), USER_ID)
+        assert_scoped(conn.calls)
+        assert len([sql for sql, _ in conn.calls if sql.startswith("DELETE")]) == 2
+
+    def test_the_duplicate_guard(self):
+        """Scoped so two people pasting the same template entry on the same
+        evening each get theirs saved, rather than the second being swallowed."""
+        engine = RecordingEngine()
+        pipeline.find_recent_submission(engine, "bench 60x8", USER_ID)
+        assert_scoped(engine.calls)
+
+    def test_loading_exercise_names(self):
+        conn = RecordingConnection()
+        pipeline.load_exercise_names(conn, USER_ID)
+        assert_scoped(conn.calls)
+
+    def test_loading_exercise_groups(self):
+        conn = RecordingConnection()
+        pipeline.load_exercise_groups(conn, USER_ID)
+        assert_scoped(conn.calls)
+
+    def test_creating_an_exercise(self):
+        conn = RecordingConnection()
+        pipeline.get_or_create_exercise(conn, USER_ID, "Bench Press", "Chest", {})
+        assert_scoped(conn.calls)
+
+    def test_revising_the_group_of_an_existing_exercise(self):
+        conn = RecordingConnection()
+        pipeline.get_or_create_exercise(
+            conn, USER_ID, "Bench Press", "Chest", {"Bench Press": 3}, chosen_group=True
+        )
+        assert_scoped(conn.calls)
+
+    def test_two_users_can_each_own_the_same_exercise_name(self):
+        """Uniqueness moved from (name) to (user_id, name), so the upsert has to
+        conflict on both - otherwise the second person to log a Bench Press
+        silently adopts the first person's row, muscle group and all."""
+        conn = RecordingConnection()
+        pipeline.get_or_create_exercise(conn, USER_ID, "Bench Press", "Chest", {})
+        insert = next(sql for sql, _ in conn.calls if "INSERT INTO exercises" in sql)
+        assert "ON CONFLICT (user_id, name)" in insert
+
+    def test_loading_sets_for_the_report(self):
+        engine = RecordingEngine()
+        insights.load_set_records(engine, date(2026, 7, 1), date(2026, 8, 1), USER_ID)
+        assert_scoped(engine.calls)
+
+    def test_the_join_to_exercises_is_scoped_on_both_sides(self):
+        """Belt and braces: the logs and the names are both per-user, so a
+        mistake in one table's filter cannot leak a name from another account."""
+        engine = RecordingEngine()
+        insights.load_set_records(engine, date(2026, 7, 1), date(2026, 8, 1), USER_ID)
+        sql = engine.calls[0][0]
+        assert "e.user_id = w.user_id" in sql and "w.user_id = :user_id" in sql
+
+    def test_loading_bodyweight(self):
+        engine = RecordingEngine()
+        insights.load_bodyweight(engine, date(2026, 7, 1), date(2026, 8, 1), USER_ID)
+        assert_scoped(engine.calls)
+
+    def test_saving_a_weekly_report(self):
+        engine = RecordingEngine()
+        insights.save_report(engine, USER_ID, date(2026, 8, 17), "summary", {})
+        assert_scoped(engine.calls)
+
+    def test_regenerating_a_week_overwrites_only_that_users_report(self):
+        engine = RecordingEngine()
+        insights.save_report(engine, USER_ID, date(2026, 8, 17), "summary", {})
+        sql = engine.calls[0][0]
+        assert "ON CONFLICT (user_id, week_start_date)" in sql
+
+    def test_a_whole_entry_is_written_against_one_user(self):
+        """The end-to-end write path: every insert it emits carries the owner."""
+        draft = pipeline.draft_from_payload(
+            {"sets": [{"exercise_name": "Bench Press", "weight_kg": 60.0, "reps": 8,
+                       "raw_span": "bench 60x8"}],
+             "bodyweight": {"weight_kg": 82.0, "raw_span": "bw 82"}},
+            "bench 60x8, bw 82",
+            date(2026, 8, 22),
+        )
+        for row in draft.rows:
+            row.include = True
+
+        engine = RecordingEngine()
+        result = pipeline.commit_draft(draft, USER_ID, engine=engine)
+        assert result.inserted_sets == 1 and result.inserted_bodyweight == 1
+        assert_scoped(engine.calls)
+
+    def test_replacing_a_day_deletes_only_that_users_rows(self):
+        draft = pipeline.draft_from_payload(
+            {"sets": [{"exercise_name": "Bench Press", "weight_kg": 60.0, "reps": 8,
+                       "raw_span": "bench 60x8"}]},
+            "bench 60x8",
+            date(2026, 8, 22),
+        )
+        draft.sets[0].include = True
+        draft.replace_existing = True
+
+        engine = RecordingEngine()
+        pipeline.commit_draft(draft, USER_ID, engine=engine)
+
+        deletes = [sql for sql, _ in engine.calls if sql.startswith("DELETE")]
+        assert deletes, "replace should have deleted the day"
+        assert_scoped(engine.calls)
+
+    def test_the_same_draft_writes_to_whichever_user_is_named(self):
+        """`user_id` is an argument, not a field on the draft. The draft comes
+        back from a hidden-field form; ownership must not."""
+        def fresh_draft():
+            draft = pipeline.draft_from_payload(
+                {"sets": [{"exercise_name": "Bench Press", "weight_kg": 60.0,
+                           "reps": 8, "raw_span": "bench 60x8"}]},
+                "bench 60x8",
+                date(2026, 8, 22),
+            )
+            draft.sets[0].include = True
+            return draft
+
+        mine = RecordingEngine()
+        theirs = RecordingEngine()
+        pipeline.commit_draft(fresh_draft(), USER_ID, engine=mine)
+        pipeline.commit_draft(fresh_draft(), OTHER_USER_ID, engine=theirs)
+
+        assert_scoped(mine.calls, USER_ID)
+        assert_scoped(theirs.calls, OTHER_USER_ID)
+
+
+class TestOwnershipIsNotOptional:
+    """A write with no owner has to be impossible to express, not merely
+    discouraged: a default would pick somebody, and it would pick wrong."""
+
+    def test_commit_draft_demands_a_user(self):
+        draft = pipeline.EntryDraft("bench 60x8", date(2026, 8, 22))
+        with pytest.raises(TypeError):
+            pipeline.commit_draft(draft, engine=RecordingEngine())
+
+    def test_process_entry_demands_a_user(self):
+        with pytest.raises(TypeError):
+            pipeline.process_entry("bench 60x8", date(2026, 8, 22))
+
+    def test_deleting_a_day_demands_a_user(self):
+        with pytest.raises(TypeError):
+            pipeline.delete_entries_for_date(RecordingConnection(), date(2026, 8, 22))
+
+    def test_the_dashboard_demands_a_user(self):
+        with pytest.raises(TypeError):
+            insights.build_dashboard(RecordingEngine())
+
+
+# --------------------------------------------------------------------------
+# The web layer
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A TestClient over an app whose database and account store are fakes.
+
+    The auth functions are replaced with an in-memory store so these tests can
+    run without Postgres. What is under test is the app's wiring - which user id
+    reaches the data layer - not the SQL, which the half above covers.
+    """
+    from fastapi.testclient import TestClient
+
+    import app as app_module
+
+    state = {
+        "users": {
+            "alice": auth.User(USER_ID, "alice", "alice", "Asia/Karachi"),
+            "bob": auth.User(OTHER_USER_ID, "bob", "bob", None),
+        },
+        "passwords": {"alice": "alicepassword", "bob": "bobpassword"},
+        "sessions": {},          # token -> username
+        "calls": [],             # (what, user_id) seen by the data layer
+    }
+
+    def fake_authenticate(conn, username, password):
+        name = (username or "").strip().lower()
+        if state["passwords"].get(name) != password:
+            return None
+        return state["users"][name]
+
+    def fake_create_session(conn, user_id, ttl_days=30):
+        token = f"token-for-{user_id}"
+        name = next(u.username for u in state["users"].values() if u.user_id == user_id)
+        state["sessions"][token] = name
+        return token
+
+    def fake_resolve_session(conn, token):
+        name = state["sessions"].get(token)
+        return state["users"][name] if name else None
+
+    def fake_delete_session(conn, token):
+        state["sessions"].pop(token, None)
+
+    def fake_create_user(conn, username, password, timezone_name=None):
+        name = auth.normalize_username(username)
+        if name in state["users"]:
+            raise auth.AuthError("That username is already taken.")
+        auth.validate_password(password)
+        user = auth.User(100 + len(state["users"]), name, username.strip(),
+                         auth.validate_timezone(timezone_name))
+        state["users"][name] = user
+        state["passwords"][name] = password
+        return user
+
+    def fake_set_timezone(conn, user_id, timezone_name):
+        return auth.validate_timezone(timezone_name)
+
+    def fake_set_password(conn, user_id, password):
+        auth.validate_password(password)
+        state["sessions"].clear()
+
+    monkeypatch.setattr(auth, "authenticate", fake_authenticate)
+    monkeypatch.setattr(auth, "create_session", fake_create_session)
+    monkeypatch.setattr(auth, "resolve_session", fake_resolve_session)
+    monkeypatch.setattr(auth, "delete_session", fake_delete_session)
+    monkeypatch.setattr(auth, "create_user", fake_create_user)
+    monkeypatch.setattr(auth, "set_timezone", fake_set_timezone)
+    monkeypatch.setattr(auth, "set_password", fake_set_password)
+
+    monkeypatch.setattr(app_module, "get_engine", lambda: RecordingEngine())
+
+    # Data-layer stubs that record whose id they were handed.
+    def record(what):
+        def recorder(*args, **kwargs):
+            state["calls"].append((what, args, kwargs))
+            return _stub_return(what)
+        return recorder
+
+    def _stub_return(what):
+        if what == "build_dashboard":
+            return {"has_data": False, "week_start": "2026-08-17", "weeks": 12,
+                    "timezone": "UTC", "kpis": {}, "weekly_volume": [],
+                    "exercise_e1rm": [], "bodyweight": [], "muscle_volume": [],
+                    "pain": []}
+        if what == "generate_weekly_report":
+            return {"week_start_date": date(2026, 8, 17), "summary_text": "ok",
+                    "recommendations": {"program_note": {"stagnation_flagged": False,
+                                                         "detail": {"reason": ""}}},
+                    "stage_a": {}, "narration_error": None, "record_count": 0}
+        if what == "commit_draft":
+            return pipeline.PipelineResult(inserted_sets=1)
+        if what == "count_entries_for_date":
+            return {"sets": 0, "bodyweight": 0}
+        return {}
+
+    monkeypatch.setattr(insights, "build_dashboard", record("build_dashboard"))
+    monkeypatch.setattr(insights, "generate_weekly_report", record("generate_weekly_report"))
+    monkeypatch.setattr(pipeline, "commit_draft", record("commit_draft"))
+    monkeypatch.setattr(pipeline, "count_entries_for_date", record("count_entries_for_date"))
+    monkeypatch.setattr(pipeline, "load_exercise_groups", lambda conn, user_id: {})
+
+    for limiter in (app_module._LOGIN_LIMITER, app_module._SIGNUP_LIMITER):
+        limiter._hits.clear()
+
+    test_client = TestClient(app_module.app, follow_redirects=False)
+    test_client.state = state
+    return test_client
+
+
+def login(client, username="alice", password=None):
+    password = password or client.state["passwords"][username]
+    response = client.post("/login", data={"username": username, "password": password})
+    assert response.status_code == 303, response.text
+    return response
+
+
+class TestSignedOut:
+    @pytest.mark.parametrize("path", ["/", "/progress", "/weekly-report", "/account"])
+    def test_every_data_page_sends_you_to_the_login_form(self, client, path):
+        response = client.get(path)
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/login")
+
+    def test_the_login_form_remembers_where_you_were_going(self, client):
+        response = client.get("/progress")
+        assert response.headers["location"] == "/login?next=/progress"
+
+    def test_posting_an_entry_signed_out_writes_nothing(self, client):
+        response = client.post(
+            "/log", data={"session_date": "2026-08-22", "raw_text": "bench 60x8"}
+        )
+        assert response.status_code == 303
+        assert client.state["calls"] == []
+
+    def test_the_health_probe_stays_open(self, client):
+        assert client.get("/healthz").status_code == 200
+
+    def test_the_login_page_renders(self, client):
+        body = client.get("/login").text
+        assert "Log in" in body and 'name="password"' in body
+
+    def test_the_signup_page_renders(self, client):
+        body = client.get("/signup").text
+        assert "Create account" in body
+
+
+class TestLoggingIn:
+    def test_correct_credentials_issue_a_session_cookie(self, client):
+        response = login(client)
+        assert auth.SESSION_COOKIE in response.cookies
+        assert response.headers["location"] == "/"
+
+    def test_the_cookie_is_not_readable_by_scripts(self, client):
+        header = login(client).headers["set-cookie"]
+        assert "HttpOnly" in header
+        # Lax is what stands in for a CSRF token: the browser withholds this
+        # cookie on a POST from another origin.
+        assert "SameSite=lax" in header.lower().replace("samesite=lax", "SameSite=lax")
+
+    def test_a_wrong_password_does_not(self, client):
+        response = client.post(
+            "/login", data={"username": "alice", "password": "not the password"}
+        )
+        assert response.status_code == 200
+        assert auth.SESSION_COOKIE not in response.cookies
+
+    def test_the_error_does_not_say_which_half_was_wrong(self, client):
+        """Otherwise the form doubles as a test for which usernames exist."""
+        missing = client.post(
+            "/login", data={"username": "nobody", "password": "whatever12"}
+        ).text
+        wrong = client.post(
+            "/login", data={"username": "alice", "password": "whatever12"}
+        ).text
+        assert "do not match an account" in missing
+        assert "do not match an account" in wrong
+
+    def test_you_land_back_where_you_were_going(self, client):
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "alicepassword", "next": "/progress"},
+        )
+        assert response.headers["location"] == "/progress"
+
+    @pytest.mark.parametrize(
+        "hostile", ["https://evil.example/phish", "//evil.example", "http://evil.example"]
+    )
+    def test_you_cannot_be_bounced_off_the_site(self, client, hostile):
+        """An open redirect on the login page is worth more to an attacker than
+        no login page: it lands you on their copy of it, from a real link."""
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "alicepassword", "next": hostile},
+        )
+        assert response.headers["location"] == "/"
+
+    def test_repeated_failures_are_slowed_down(self, client):
+        for _ in range(10):
+            client.post("/login", data={"username": "alice", "password": "wrong-one"})
+        blocked = client.post("/login", data={"username": "alice", "password": "wrong-one"})
+        assert "Too many attempts" in blocked.text
+
+    def test_the_limit_does_not_stop_a_different_caller(self, client):
+        for _ in range(12):
+            client.post(
+                "/login",
+                data={"username": "alice", "password": "wrong-one"},
+                headers={"x-forwarded-for": "10.0.0.1"},
+            )
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "alicepassword"},
+            headers={"x-forwarded-for": "10.0.0.2"},
+        )
+        assert response.status_code == 303
+
+
+class TestSigningUp:
+    def test_a_new_account_is_created_and_signed_in(self, client):
+        response = client.post(
+            "/signup", data={"username": "carol", "password": "carolpassword"}
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/"
+        assert "carol" in client.state["users"]
+
+    def test_a_taken_username_is_refused(self, client):
+        response = client.post(
+            "/signup", data={"username": "alice", "password": "somepassword"}
+        )
+        assert response.status_code == 200
+        assert "already taken" in response.text
+
+    def test_a_short_password_is_refused(self, client):
+        response = client.post("/signup", data={"username": "carol", "password": "short"})
+        assert "at least" in response.text
+        assert "carol" not in client.state["users"]
+
+    def test_a_bad_timezone_is_refused(self, client):
+        response = client.post(
+            "/signup",
+            data={"username": "carol", "password": "carolpassword",
+                  "timezone": "Mars/Olympus"},
+        )
+        assert "not an IANA timezone" in response.text
+        assert "carol" not in client.state["users"]
+
+    def test_a_lookalike_username_cannot_be_registered(self, client):
+        response = client.post(
+            "/signup", data={"username": "ALICE", "password": "somepassword"}
+        )
+        assert "already taken" in response.text
+
+
+class TestSignedIn:
+    def test_the_entry_form_names_who_is_signed_in(self, client):
+        login(client)
+        body = client.get("/").text
+        assert "alice" in body and "Log out" in body
+
+    def test_the_dashboard_is_built_for_the_signed_in_user(self, client):
+        login(client)
+        client.get("/progress")
+        what, args, kwargs = client.state["calls"][-1]
+        assert what == "build_dashboard"
+        assert args[1] == USER_ID
+
+    def test_the_weekly_report_is_generated_for_the_signed_in_user(self, client):
+        login(client)
+        client.post("/weekly-report", data={"week_start": "2026-08-17"})
+        what, args, kwargs = client.state["calls"][-1]
+        assert what == "generate_weekly_report"
+        assert args[1] == USER_ID
+
+    def test_a_different_user_gets_their_own_data(self, client):
+        login(client, "bob")
+        client.get("/progress")
+        _, args, _ = client.state["calls"][-1]
+        assert args[1] == OTHER_USER_ID
+
+    def test_the_users_own_timezone_is_used(self, client):
+        """alice trains in Asia/Karachi; her week must not be cut on the
+        deployment's UTC midnight."""
+        login(client)
+        client.get("/progress")
+        _, _, kwargs = client.state["calls"][-1]
+        assert kwargs["timezone_name"] == "Asia/Karachi"
+
+    def test_logging_out_drops_the_session(self, client):
+        login(client)
+        client.post("/logout")
+        assert client.get("/progress").status_code == 303
+
+    def test_a_stale_cookie_is_not_honoured(self, client):
+        client.cookies.set(auth.SESSION_COOKIE, "token-for-999")
+        assert client.get("/").status_code == 303
+
+
+class TestSavingBelongsToTheSession:
+    """The review form round-trips through the browser, so nothing it carries
+    can decide who the rows belong to."""
+
+    def _form(self, **extra):
+        form = {
+            "session_date": "2026-08-22",
+            "raw_text": "bench 60x8",
+            "action": "save",
+            "set_count": "1",
+            "set_0_include": "on",
+            "set_0_exercise_name": "Bench Press",
+            "set_0_weight_kg": "60",
+            "set_0_reps": "8",
+            "bodyweight_present": "0",
+        }
+        form.update(extra)
+        return form
+
+    def test_the_owner_comes_from_the_cookie(self, client):
+        login(client)
+        client.post("/save", data=self._form())
+        saved = [call for call in client.state["calls"] if call[0] == "commit_draft"]
+        assert saved, "nothing was saved"
+        assert saved[-1][1][1] == USER_ID
+
+    def test_a_user_id_in_the_form_is_ignored(self, client):
+        """The attack this closes: hand-edit the posted form to write into
+        somebody else's account."""
+        login(client)
+        client.post("/save", data=self._form(user_id=str(OTHER_USER_ID)))
+        saved = [call for call in client.state["calls"] if call[0] == "commit_draft"]
+        assert saved[-1][1][1] == USER_ID
+
+    def test_saving_signed_out_writes_nothing(self, client):
+        response = client.post("/save", data=self._form())
+        assert response.status_code == 303
+        assert [c for c in client.state["calls"] if c[0] == "commit_draft"] == []
+
+
+class TestAccountPage:
+    def test_the_timezone_can_be_changed(self, client):
+        login(client)
+        response = client.post(
+            "/account", data={"action": "timezone", "timezone": "Europe/London"}
+        )
+        assert "Timezone set to Europe/London" in response.text
+
+    def test_a_bad_timezone_is_refused(self, client):
+        login(client)
+        response = client.post(
+            "/account", data={"action": "timezone", "timezone": "Mars/Olympus"}
+        )
+        assert "not an IANA timezone" in response.text
+
+    def test_changing_the_password_needs_the_current_one(self, client):
+        login(client)
+        response = client.post(
+            "/account",
+            data={"action": "password", "current_password": "wrong",
+                  "new_password": "a-new-password"},
+        )
+        assert "Current password is not correct" in response.text
+
+    def test_changing_the_password_signs_you_out(self, client):
+        login(client)
+        response = client.post(
+            "/account",
+            data={"action": "password", "current_password": "alicepassword",
+                  "new_password": "a-new-password"},
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/login"
+        assert client.get("/progress").status_code == 303

--- a/tests/test_name_flags.py
+++ b/tests/test_name_flags.py
@@ -266,6 +266,11 @@ class _Engine:
         return _Connection(self.existing)
 
 
+# Any id works against the fakes above; what matters is that commit_draft now
+# demands one, so a caller cannot write a row without saying whose it is.
+USER_ID = 1
+
+
 def commit_one(name, raw_text, existing=(), edited_fields=frozenset(), added=False):
     """Save a single set through the real insert path and return the result."""
     draft = pipeline.draft_from_payload(
@@ -278,7 +283,7 @@ def commit_one(name, raw_text, existing=(), edited_fields=frozenset(), added=Fal
     row.include = True
     row.edited_fields = edited_fields
     row.added = added
-    return pipeline.commit_draft(draft, engine=_Engine(existing))
+    return pipeline.commit_draft(draft, USER_ID, engine=_Engine(existing))
 
 
 class TestFlagsReachTheResult:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -728,7 +728,7 @@ class TestReplaceIsOptIn:
 
     def test_empty_entry_never_reports_a_replace(self):
         """Nothing to insert means nothing should have been deleted."""
-        result = pipeline.process_entry("   ", date(2026, 8, 20))
+        result = pipeline.process_entry("   ", date(2026, 8, 20), user_id=1)
         assert result.replaced is None and result.error
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -569,9 +569,14 @@ class FakeEngine:
         return [params for params in self.log if "extraction_confidence" in params]
 
 
-def commit(draft, engine=None, **kwargs):
+# Any id works against FakeEngine; what matters is that the write path now
+# demands one, so no row can be inserted without an owner.
+USER_ID = 1
+
+
+def commit(draft, engine=None, user_id=USER_ID, **kwargs):
     engine = engine or FakeEngine()
-    result = pipeline.commit_draft(draft, engine=engine, **kwargs)
+    result = pipeline.commit_draft(draft, user_id, engine=engine, **kwargs)
     return result, engine
 
 
@@ -675,9 +680,9 @@ class TestUnattendedPathIsUnchanged:
 
     def test_a_low_score_is_held_back_for_review(self, monkeypatch):
         monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: PAYLOAD)
-        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn, user_id: {})
         engine = FakeEngine()
-        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=engine)
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, USER_ID, engine=engine)
         assert result.inserted_sets == 1
         assert len(result.review_items) == 2
         assert all("below threshold" in item.reason for item in result.review_items)
@@ -685,6 +690,6 @@ class TestUnattendedPathIsUnchanged:
     def test_an_invalid_row_is_reported_the_same_way_as_before(self, monkeypatch):
         payload = {"sets": [{"exercise_name": "Bench", "reps": "eleven"}], "bodyweight": None}
         monkeypatch.setattr(pipeline, "extract_entities", lambda *a, **k: payload)
-        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn: {})
-        result = pipeline.process_entry(RAW_ENTRY, SESSION, engine=FakeEngine())
+        monkeypatch.setattr(pipeline, "load_exercise_names", lambda conn, user_id: {})
+        result = pipeline.process_entry(RAW_ENTRY, SESSION, USER_ID, engine=FakeEngine())
         assert result.review_items[0].reason.startswith("failed validation:")


### PR DESCRIPTION
## Summary

Converts the app from single-user (HTTP Basic Auth with env vars) to multi-user with account registration, login sessions, and complete data isolation. Every user registers their own account, logs in via a session cookie, and can only see their own training data.

## Key Changes

**Authentication & Sessions**
- New `auth.py` module: password hashing (PBKDF2-HMAC-SHA256), username validation, session token management, and rate limiting
- Replaces HTTP Basic Auth with session cookies (HttpOnly, SameSite=Lax, secure)
- Session tokens stored as SHA-256 hashes in database; raw token only in cookie
- Rate limiting on login (10 attempts/5min) and signup (5 attempts/1hr)

**Database Schema**
- New `users` table: username (lowercased, unique), display_name, password_hash, timezone, is_active
- New `user_sessions` table: token_hash, user_id, created_at with TTL (default 30 days)
- All training tables (`exercises`, `workout_logs`, `bodyweight_logs`, `weekly_reports`) now have `user_id` foreign key
- `exercises` uniqueness changed from `(name)` to `(user_id, name)` — two users can each have a "Bench Press"

**Web Routes**
- New `/login`, `/signup`, `/logout`, `/account` routes with HTML forms
- All existing routes (`/log`, `/save`, `/progress`, `/weekly-report`) now require login
- User ID always comes from session cookie, never from form data or query parameters
- Timezone per-user: times resolved in user's own timezone, falling back to LOCAL_TIMEZONE env var

**Data Isolation**
- Every database query touching user data is scoped by `user_id` parameter
- New test suite (`test_multi_user.py`) verifies every statement names `user_id` in SQL and bound params
- Destructive operations (DELETE) are scoped to prevent one user wiping another's data

**CLI & Admin Tools**
- `manage_users.py`: list/create/passwd/timezone/suspend/restore/delete accounts
- `migrate_multi_user.py`: one-time upgrade script that creates owner account and backfills existing data
- `parse_workout_log.py` now requires `--user` flag to specify which account owns the logged data
- `seed_sample_data.py` requires `--user` flag; `--reset` only clears that user's rows

**Implementation Details**
- Passwords validated: 8-200 characters, stored with iteration count in hash string for future cost increases
- Usernames: 3-32 chars, alphanumeric + dots/dashes/underscores, must start/end with letter/number, lowercased
- Reserved usernames (admin, root, login, etc.) cannot be registered
- `LoginRequired` exception raised by dependency functions, caught by exception handler to redirect to `/login?next=...`
- Basic Auth still works for scripts/curl (reads from users table, rate-limited, logged if over HTTP)

**Testing**
- `test_auth.py`: password hashing, username validation, session management, rate limiting
- `test_multi_user.py`: database query scoping, route ownership verification, multi-user isolation
- Existing tests updated to pass `user_id` to functions that now require it

https://claude.ai/code/session_018XTNCmw7E87qEoEgSq1ZDe