### PR TITLE
Make multi-user migration idempotent and pasteable into SQL consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ psql "$DATABASE_URL" -f migrations/001_add_cheat_reps.sql
 ```
 
 **Upgrading a database that predates accounts** — do *not* run `schema.sql` over
-it. Run the migration script instead, which needs Python because it has to hash
-the owner's password:
+it. Run the migration script instead, which creates the owner account for you
+(Python, because the password has to be hashed) and then applies
+`migrations/002_multi_user.sql`:
 
 ```bash
 python migrate_multi_user.py --dry-run     # print the statements, change nothing
@@ -103,6 +104,23 @@ It creates the tables and columns accounts need, then hands everything already
 logged to one owner account built from `APP_USERNAME` / `APP_PASSWORD` — so you
 carry on logging in with the credentials you already use, and your history is
 where you left it. Anyone else registers at `/signup`. Re-running it is a no-op.
+
+Without a Python environment against that database — a Supabase or Neon SQL
+console, say — paste `migrations/002_multi_user.sql` in as it stands. It takes
+the single account already in `users` as the owner. When there is none yet, or
+more than one, name the owner first, in the same session, and hash the password
+with the application's own hasher (the login form rejects anything else):
+
+```bash
+python -c "import auth; print(auth.hash_password('YOUR-PASSWORD'))"
+```
+
+```sql
+SELECT set_config('gym_tracker.owner_username',      'sohaib', false);
+SELECT set_config('gym_tracker.owner_password_hash', 'pbkdf2_sha256$600000$...', false);
+SELECT set_config('gym_tracker.owner_timezone',      'Asia/Karachi', false);  -- optional
+-- then the contents of migrations/002_multi_user.sql
+```
 
 **Supabase:** enable RLS on every table. The app connects as the table owner so
 it bypasses RLS, but Supabase auto-exposes a REST API over the `public` schema to

--- a/migrate_multi_user.py
+++ b/migrate_multi_user.py
@@ -11,9 +11,13 @@ that the owner logs in with the same credentials as before, and anyone else can
 register their own account at /signup.
 
 The statements themselves live in migrations/002_multi_user.sql, which is the
-single source of truth for the shape of the change; this script only supplies
-the owner id, runs each statement in its own transaction, and skips the ones
-already applied so a re-run is a no-op.
+single source of truth for the shape of the change and is idempotent on its
+own; this script only creates the owner account, names it to the migration,
+and runs each statement in its own transaction. A re-run is a no-op.
+
+That file can also be pasted straight into psql or a SQL console - see its
+header - which is why the owner is named through a setting rather than
+substituted into the SQL here.
 """
 
 from __future__ import annotations
@@ -33,32 +37,49 @@ import pipeline  # noqa: E402
 
 MIGRATION = Path(__file__).resolve().parent / "migrations" / "002_multi_user.sql"
 
-_ADD_CONSTRAINT = re.compile(
-    r"ALTER TABLE\s+(?P<table>\w+)\s+ADD CONSTRAINT\s+(?P<name>\w+)", re.IGNORECASE
-)
+# The migration reads the owner's username from this setting, set for the
+# transaction the statement that needs it runs in.
+OWNER_SETTING = "gym_tracker.owner_username"
+
+# $$ ... $$ or $tag$ ... $tag$, which is what a PL/pgSQL block in the migration
+# is wrapped in.
+_DOLLAR_QUOTE = re.compile(r"\$\w*\$")
 
 
 def statements(sql: str) -> list[str]:
-    """Split the migration into executable statements, comments removed."""
+    """Split the migration into executable statements, comments removed.
+
+    A semicolon inside a dollar-quoted body belongs to the PL/pgSQL block it is
+    written in, not to the migration, so splitting has to skip over those
+    bodies whole - otherwise a DO block arrives at the server in pieces.
+    """
     without_comments = "\n".join(
         line for line in sql.splitlines() if not line.lstrip().startswith("--")
     )
-    return [part.strip() for part in without_comments.split(";") if part.strip()]
 
+    parts: list[str] = []
+    start = position = 0
+    tag: str | None = None
+    while position < len(without_comments):
+        if tag is None:
+            opening = _DOLLAR_QUOTE.match(without_comments, position)
+            if opening:
+                tag = opening.group(0)
+                position = opening.end()
+            elif without_comments[position] == ";":
+                parts.append(without_comments[start:position])
+                position += 1
+                start = position
+            else:
+                position += 1
+        elif without_comments.startswith(tag, position):
+            position += len(tag)
+            tag = None
+        else:
+            position += 1
+    parts.append(without_comments[start:])
 
-def constraint_exists(conn, table: str, name: str) -> bool:
-    return bool(
-        conn.execute(
-            text(
-                """
-                SELECT 1 FROM pg_constraint c
-                JOIN pg_class t ON t.oid = c.conrelid
-                WHERE t.relname = :table AND c.conname = :name
-                """
-            ),
-            {"table": table, "name": name},
-        ).scalar()
-    )
+    return [part.strip() for part in parts if part.strip()]
 
 
 def table_exists(conn, table: str) -> bool:
@@ -129,31 +150,24 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     owner = None
-    applied = skipped = 0
     for part in parts:
-        match = _ADD_CONSTRAINT.search(part)
-        if match:
-            with engine.connect() as conn:
-                if constraint_exists(conn, match["table"], match["name"]):
-                    skipped += 1
-                    continue
-
-        # The owner is created the moment a statement first needs its id, which
-        # is the backfill. It cannot be created any earlier: the CREATE TABLE
-        # that gives it somewhere to live is one of the statements above it.
-        if ":owner_id" in part and owner is None:
+        # The owner is created the moment a statement first asks who it is,
+        # which is the backfill. It cannot be created any earlier: the CREATE
+        # TABLE that gives it somewhere to live is one of the statements above.
+        names_owner = OWNER_SETTING in part
+        if names_owner and owner is None:
             owner = ensure_owner(engine, username, password)
 
         # One transaction per statement: a step that has already been applied
-        # must not roll back the ones before it.
+        # must not roll back the ones before it. The setting is transaction
+        # local, so it is set inside the same one the statement runs in.
         with engine.begin() as conn:
-            conn.execute(text(part), {"owner_id": owner.user_id if owner else None})
-        applied += 1
-
-    if owner is None:
-        # Every backfill statement was a no-op, which means a previous run
-        # already did them. Find the account so the summary can still report.
-        owner = ensure_owner(engine, username, password)
+            if names_owner:
+                conn.execute(
+                    text("SELECT set_config(:name, :value, true)"),
+                    {"name": OWNER_SETTING, "value": owner.username},
+                )
+            conn.execute(text(part))
 
     with engine.connect() as conn:
         counts = {
@@ -164,7 +178,7 @@ def main(argv: list[str] | None = None) -> int:
             for table in ("exercises", "workout_logs", "bodyweight_logs", "weekly_reports")
         }
 
-    print(f"\nApplied {applied} statement(s), skipped {skipped} already in place.")
+    print(f"\nRan {len(parts)} statement(s) from {MIGRATION.name}.")
     print(f"Owned by {owner.username!r}:")
     for table, count in counts.items():
         print(f"  {table:<16} {count}")

--- a/migrations/002_multi_user.sql
+++ b/migrations/002_multi_user.sql
@@ -73,7 +73,7 @@ ALTER TABLE weekly_reports  ADD COLUMN IF NOT EXISTS user_id INTEGER;
 -- A database whose rows all have an owner already needs none of this and asks
 -- for nothing, which is what keeps the second run quiet.
 
-DO $owner$
+DO $$
 DECLARE
     typed_name    text    := trim(coalesce(current_setting('gym_tracker.owner_username', true), ''));
     wanted        text    := lower(typed_name);
@@ -115,11 +115,13 @@ BEGIN
         END IF;
     END IF;
 
-    SELECT EXISTS (SELECT 1 FROM exercises       WHERE user_id IS NULL)
-        OR EXISTS (SELECT 1 FROM workout_logs    WHERE user_id IS NULL)
-        OR EXISTS (SELECT 1 FROM bodyweight_logs WHERE user_id IS NULL)
-        OR EXISTS (SELECT 1 FROM weekly_reports  WHERE user_id IS NULL)
-      INTO unowned;
+    -- An assignment, not SELECT ... INTO: the INTO form reads as a plain-SQL
+    -- CREATE TABLE AS to anything that sees this line outside the block, which
+    -- is exactly what a tool that mis-splits the file does to it.
+    unowned :=  EXISTS (SELECT 1 FROM exercises       WHERE user_id IS NULL)
+             OR EXISTS (SELECT 1 FROM workout_logs    WHERE user_id IS NULL)
+             OR EXISTS (SELECT 1 FROM bodyweight_logs WHERE user_id IS NULL)
+             OR EXISTS (SELECT 1 FROM weekly_reports  WHERE user_id IS NULL);
 
     IF NOT unowned THEN
         -- Either a re-run, or a database with nothing in it yet. Nothing to
@@ -150,7 +152,7 @@ BEGIN
 
     RAISE NOTICE 'Rows without an owner now belong to user_id %.', owner_id;
 END
-$owner$;
+$$;
 
 -- --- 4. Lock it down ------------------------------------------------------
 -- A no-op on a column that is already NOT NULL, so this survives a re-run.
@@ -164,7 +166,7 @@ ALTER TABLE weekly_reports  ALTER COLUMN user_id SET NOT NULL;
 -- Postgres has no ADD CONSTRAINT IF NOT EXISTS, so each one is added only when
 -- the catalogue says it is missing.
 
-DO $fks$
+DO $$
 DECLARE
     target text;
 BEGIN
@@ -182,7 +184,7 @@ BEGIN
         END IF;
     END LOOP;
 END
-$fks$;
+$$;
 
 -- --- 6. Uniqueness becomes per-user ---------------------------------------
 -- An exercise name is unique within an account, not across the deployment;
@@ -198,7 +200,7 @@ ALTER TABLE weekly_reports DROP CONSTRAINT IF EXISTS weekly_reports_week_start_d
 DROP INDEX IF EXISTS exercises_name_key;
 DROP INDEX IF EXISTS weekly_reports_week_start_date_key;
 
-DO $uniques$
+DO $$
 BEGIN
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -216,7 +218,7 @@ BEGIN
             ADD CONSTRAINT weekly_reports_user_week_unique UNIQUE (user_id, week_start_date);
     END IF;
 END
-$uniques$;
+$$;
 
 -- --- 7. Indexes, now user-first -------------------------------------------
 

--- a/migrations/002_multi_user.sql
+++ b/migrations/002_multi_user.sql
@@ -1,13 +1,29 @@
 -- 002: accounts, and one owner for everything already logged.
 --
 -- Turns the single-user database into a multi-user one. Every existing row is
--- assigned to one owner account, which the runner creates from APP_USERNAME /
--- APP_PASSWORD (or --username/--password) before this file's backfill step.
+-- assigned to one owner account, and from then on the application filters
+-- everything by the logged-in user.
 --
--- Do not run this file by hand unless you have already inserted that owner row
--- and know its user_id: the statements below reference :owner_id. Run
--- `python migrate_multi_user.py` instead, which creates the owner (password
--- hashing needs Python), runs these statements in order, and is safe to re-run.
+-- Two ways to run it, both safe to re-run - every step checks before it acts:
+--
+--   1. python migrate_multi_user.py
+--      Creates the owner from APP_USERNAME / APP_PASSWORD (or
+--      --username/--password) and then runs this file.
+--
+--   2. By hand, in psql or a SQL console (Supabase, Neon, ...)
+--      Paste this file as it stands. The owner is the single account already
+--      in `users`; with none there yet, or more than one, say who it is first
+--      in the same session, and generate the hash with the application's own
+--      hasher so the password you pick actually works at the login form:
+--
+--          python -c "import auth; print(auth.hash_password('YOUR-PASSWORD'))"
+--
+--          SELECT set_config('gym_tracker.owner_username',      'sohaib', false);
+--          SELECT set_config('gym_tracker.owner_password_hash', 'pbkdf2_sha256$600000$...', false);
+--          SELECT set_config('gym_tracker.owner_timezone',      'Asia/Karachi', false);  -- optional
+--
+--      The hash is only read when that account does not exist yet; an account
+--      that is already there is never touched.
 --
 -- Ordering matters. Columns go on as nullable, are backfilled, and only then
 -- become NOT NULL - the other way round would fail on the first existing row.
@@ -45,16 +61,99 @@ ALTER TABLE workout_logs    ADD COLUMN IF NOT EXISTS user_id INTEGER;
 ALTER TABLE bodyweight_logs ADD COLUMN IF NOT EXISTS user_id INTEGER;
 ALTER TABLE weekly_reports  ADD COLUMN IF NOT EXISTS user_id INTEGER;
 
--- --- 3. Backfill ----------------------------------------------------------
+-- --- 3. The owner, and the backfill ---------------------------------------
 -- Everything that exists today was logged by one person, so it all goes to the
 -- owner. Only NULLs are touched, which is what makes a re-run a no-op.
+--
+-- The owner id cannot be written into this file as a literal - it is not known
+-- until the account exists - so it is resolved here instead: the account named
+-- by gym_tracker.owner_username, or the only account in `users` when nothing
+-- was named. Anything ambiguous stops the migration rather than guessing, and
+-- since this all happens inside one statement, nothing below it has run yet.
+-- A database whose rows all have an owner already needs none of this and asks
+-- for nothing, which is what keeps the second run quiet.
 
-UPDATE exercises       SET user_id = :owner_id WHERE user_id IS NULL;
-UPDATE workout_logs    SET user_id = :owner_id WHERE user_id IS NULL;
-UPDATE bodyweight_logs SET user_id = :owner_id WHERE user_id IS NULL;
-UPDATE weekly_reports  SET user_id = :owner_id WHERE user_id IS NULL;
+DO $owner$
+DECLARE
+    typed_name    text    := trim(coalesce(current_setting('gym_tracker.owner_username', true), ''));
+    wanted        text    := lower(typed_name);
+    supplied_hash text    := trim(coalesce(current_setting('gym_tracker.owner_password_hash', true), ''));
+    zone          text    := nullif(trim(coalesce(current_setting('gym_tracker.owner_timezone', true), '')), '');
+    owner_id      integer;
+    account_count integer;
+    unowned       boolean;
+BEGIN
+    IF wanted <> '' THEN
+        SELECT user_id INTO owner_id FROM users WHERE username = wanted;
+
+        IF owner_id IS NULL THEN
+            -- Named an account that is not there yet: create it, but only with
+            -- a hash the login form will accept. auth.py stores
+            -- `pbkdf2_sha256$<iterations>$<salt>$<hash>` and rejects anything
+            -- else, so a plaintext password pasted in here would lock the
+            -- owner out of their own data.
+            IF supplied_hash = '' THEN
+                RAISE EXCEPTION 'No account named "%", and no password hash to create one with.', wanted
+                    USING HINT = 'Set gym_tracker.owner_password_hash to the output of '
+                                 '`python -c "import auth; print(auth.hash_password(''YOUR-PASSWORD''))"`, '
+                                 'or run python migrate_multi_user.py instead.';
+            END IF;
+            IF supplied_hash NOT LIKE 'pbkdf2\_sha256$%$%$%' THEN
+                RAISE EXCEPTION 'gym_tracker.owner_password_hash is not a hash this application can verify.'
+                    USING HINT = 'It must look like pbkdf2_sha256$600000$<salt>$<hash> - see auth.hash_password.';
+            END IF;
+            IF length(wanted) < 3 OR length(wanted) > 32
+               OR wanted !~ '^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$' THEN
+                RAISE EXCEPTION 'Username "%" is not one the login form accepts.', typed_name
+                    USING HINT = '3-32 characters, lowercase letters, digits, dot, dash or underscore.';
+            END IF;
+
+            INSERT INTO users (username, display_name, password_hash, timezone)
+            VALUES (wanted, typed_name, supplied_hash, zone)
+            RETURNING user_id INTO owner_id;
+            RAISE NOTICE 'Created owner account "%" (user_id %).', wanted, owner_id;
+        END IF;
+    END IF;
+
+    SELECT EXISTS (SELECT 1 FROM exercises       WHERE user_id IS NULL)
+        OR EXISTS (SELECT 1 FROM workout_logs    WHERE user_id IS NULL)
+        OR EXISTS (SELECT 1 FROM bodyweight_logs WHERE user_id IS NULL)
+        OR EXISTS (SELECT 1 FROM weekly_reports  WHERE user_id IS NULL)
+      INTO unowned;
+
+    IF NOT unowned THEN
+        -- Either a re-run, or a database with nothing in it yet. Nothing to
+        -- hand over, so an owner is not needed and none is demanded.
+        RAISE NOTICE 'Every row already has an owner; nothing to backfill.';
+        RETURN;
+    END IF;
+
+    IF owner_id IS NULL THEN
+        SELECT count(*) INTO account_count FROM users;
+
+        IF account_count = 1 THEN
+            SELECT user_id INTO owner_id FROM users;
+        ELSIF account_count = 0 THEN
+            RAISE EXCEPTION 'There is no account for the existing training data to belong to.'
+                USING HINT = 'Run python migrate_multi_user.py, or set gym_tracker.owner_username '
+                             'and gym_tracker.owner_password_hash and re-run - see the header of this file.';
+        ELSE
+            RAISE EXCEPTION 'This database has % accounts, so which one owns the existing data is ambiguous.', account_count
+                USING HINT = 'Name it: SELECT set_config(''gym_tracker.owner_username'', ''<username>'', false); then re-run.';
+        END IF;
+    END IF;
+
+    UPDATE exercises       SET user_id = owner_id WHERE user_id IS NULL;
+    UPDATE workout_logs    SET user_id = owner_id WHERE user_id IS NULL;
+    UPDATE bodyweight_logs SET user_id = owner_id WHERE user_id IS NULL;
+    UPDATE weekly_reports  SET user_id = owner_id WHERE user_id IS NULL;
+
+    RAISE NOTICE 'Rows without an owner now belong to user_id %.', owner_id;
+END
+$owner$;
 
 -- --- 4. Lock it down ------------------------------------------------------
+-- A no-op on a column that is already NOT NULL, so this survives a re-run.
 
 ALTER TABLE exercises       ALTER COLUMN user_id SET NOT NULL;
 ALTER TABLE workout_logs    ALTER COLUMN user_id SET NOT NULL;
@@ -62,21 +161,28 @@ ALTER TABLE bodyweight_logs ALTER COLUMN user_id SET NOT NULL;
 ALTER TABLE weekly_reports  ALTER COLUMN user_id SET NOT NULL;
 
 -- --- 5. Foreign keys ------------------------------------------------------
--- Named so the runner can check for them before adding; Postgres has no
--- ADD CONSTRAINT IF NOT EXISTS.
+-- Postgres has no ADD CONSTRAINT IF NOT EXISTS, so each one is added only when
+-- the catalogue says it is missing.
 
-ALTER TABLE exercises
-    ADD CONSTRAINT exercises_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
-ALTER TABLE workout_logs
-    ADD CONSTRAINT workout_logs_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
-ALTER TABLE bodyweight_logs
-    ADD CONSTRAINT bodyweight_logs_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
-ALTER TABLE weekly_reports
-    ADD CONSTRAINT weekly_reports_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE;
+DO $fks$
+DECLARE
+    target text;
+BEGIN
+    FOREACH target IN ARRAY ARRAY['exercises', 'workout_logs', 'bodyweight_logs', 'weekly_reports']
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = target::regclass AND conname = target || '_user_id_fkey'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ADD CONSTRAINT %I FOREIGN KEY (user_id) '
+                'REFERENCES users (user_id) ON DELETE CASCADE',
+                target, target || '_user_id_fkey'
+            );
+        END IF;
+    END LOOP;
+END
+$fks$;
 
 -- --- 6. Uniqueness becomes per-user ---------------------------------------
 -- An exercise name is unique within an account, not across the deployment;
@@ -84,12 +190,33 @@ ALTER TABLE weekly_reports
 -- global constraints is the step that lets a second person log a "Bench Press".
 
 ALTER TABLE exercises DROP CONSTRAINT IF EXISTS exercises_name_key;
-ALTER TABLE exercises
-    ADD CONSTRAINT exercises_user_name_unique UNIQUE (user_id, name);
-
 ALTER TABLE weekly_reports DROP CONSTRAINT IF EXISTS weekly_reports_week_start_date_key;
-ALTER TABLE weekly_reports
-    ADD CONSTRAINT weekly_reports_user_week_unique UNIQUE (user_id, week_start_date);
+
+-- Same names again in case an older database enforced them with a bare unique
+-- index rather than a constraint. Dropping the constraint above already took
+-- its index with it, so these are no-ops in the ordinary case.
+DROP INDEX IF EXISTS exercises_name_key;
+DROP INDEX IF EXISTS weekly_reports_week_start_date_key;
+
+DO $uniques$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'exercises'::regclass AND conname = 'exercises_user_name_unique'
+    ) THEN
+        ALTER TABLE exercises
+            ADD CONSTRAINT exercises_user_name_unique UNIQUE (user_id, name);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'weekly_reports'::regclass AND conname = 'weekly_reports_user_week_unique'
+    ) THEN
+        ALTER TABLE weekly_reports
+            ADD CONSTRAINT weekly_reports_user_week_unique UNIQUE (user_id, week_start_date);
+    END IF;
+END
+$uniques$;
 
 -- --- 7. Indexes, now user-first -------------------------------------------
 

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -10,6 +10,7 @@ each fragment reaches the server as nonsense.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -58,9 +59,9 @@ class TestTheMigrationFile:
 
     def test_every_block_is_closed(self):
         for part in migrate_multi_user.statements(MIGRATION_SQL):
-            if part.startswith("DO $"):
-                tag = part[3 : part.index("$", 3) + 1]
-                assert part.endswith(tag), f"unterminated block: {part[:80]}"
+            opening = re.match(r"DO (\$\w*\$)", part)
+            if opening:
+                assert part.endswith(opening.group(1)), f"unterminated: {part[:80]}"
 
     def test_the_owner_is_named_through_the_setting_the_runner_sets(self):
         naming = [

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -1,0 +1,72 @@
+"""The migration has to survive both ways of running it.
+
+`migrations/002_multi_user.sql` is pasted into a SQL console as often as it is
+run through `migrate_multi_user.py`, so it carries no bind parameters - a
+`:owner_id` in the file is a syntax error the moment psql or the Supabase
+editor sees it. These tests hold that line, and hold the statement splitter to
+keeping a PL/pgSQL block whole: split one on the semicolons inside its body and
+each fragment reaches the server as nonsense.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import migrate_multi_user  # noqa: E402
+
+MIGRATION_SQL = migrate_multi_user.MIGRATION.read_text(encoding="utf-8")
+
+
+class TestSplittingStatements:
+    def test_plain_statements_split_on_the_semicolon(self):
+        parts = migrate_multi_user.statements("SELECT 1; SELECT 2;")
+        assert parts == ["SELECT 1", "SELECT 2"]
+
+    def test_comment_lines_are_dropped(self):
+        parts = migrate_multi_user.statements("-- a note\nSELECT 1;\n    -- indented\n")
+        assert parts == ["SELECT 1"]
+
+    def test_a_block_stays_whole_despite_its_semicolons(self):
+        parts = migrate_multi_user.statements(
+            "SELECT 1;\n"
+            "DO $b$ BEGIN RAISE NOTICE 'one'; RAISE NOTICE 'two'; END $b$;\n"
+            "SELECT 2;"
+        )
+        assert len(parts) == 3
+        assert parts[1].startswith("DO $b$") and parts[1].endswith("$b$")
+        assert "RAISE NOTICE 'two'" in parts[1]
+
+    def test_an_untagged_block_stays_whole_too(self):
+        parts = migrate_multi_user.statements("DO $$ BEGIN PERFORM 1; END $$;")
+        assert len(parts) == 1
+
+    def test_a_trailing_statement_without_its_semicolon_still_counts(self):
+        assert migrate_multi_user.statements("SELECT 1") == ["SELECT 1"]
+
+
+class TestTheMigrationFile:
+    def test_no_statement_carries_a_bind_parameter(self):
+        # What broke the paste into the SQL console: `SET user_id = :owner_id`
+        # is a syntax error to everything except a driver that fills it in.
+        for part in migrate_multi_user.statements(MIGRATION_SQL):
+            assert not text(part)._bindparams, f"bind parameter in: {part[:80]}"
+
+    def test_every_block_is_closed(self):
+        for part in migrate_multi_user.statements(MIGRATION_SQL):
+            if part.startswith("DO $"):
+                tag = part[3 : part.index("$", 3) + 1]
+                assert part.endswith(tag), f"unterminated block: {part[:80]}"
+
+    def test_the_owner_is_named_through_the_setting_the_runner_sets(self):
+        naming = [
+            part
+            for part in migrate_multi_user.statements(MIGRATION_SQL)
+            if migrate_multi_user.OWNER_SETTING in part
+        ]
+        assert len(naming) == 1, "exactly one statement should ask who the owner is"
+        assert naming[0].startswith("DO $")


### PR DESCRIPTION
## Summary
Refactored the multi-user migration to be fully idempotent and executable directly in SQL consoles (Supabase, Neon, etc.) without requiring the Python runner script. The migration now handles owner account creation and identification entirely within SQL using PL/pgSQL blocks and PostgreSQL settings.

## Key Changes

- **Idempotent SQL blocks**: Wrapped owner creation, foreign key additions, and unique constraint creation in `DO` blocks that check for existence before acting, making re-runs safe and silent
- **Owner identification via settings**: Replaced bind parameters (`:owner_id`) with PostgreSQL `set_config()` calls, allowing the migration to be pasted directly into SQL consoles without a driver
- **Smart owner resolution**: The migration now automatically determines the owner by:
  - Using a named account if `gym_tracker.owner_username` is set
  - Creating a new account if username and password hash are provided
  - Falling back to the single existing account if none is named
  - Raising clear errors when ambiguous (multiple accounts, no data owner)
- **Enhanced statement splitter**: Updated `migrate_multi_user.py` to properly handle dollar-quoted PL/pgSQL blocks, preventing them from being split on internal semicolons
- **Comprehensive documentation**: Added detailed header comments and README instructions for both execution paths (Python script and direct SQL console)
- **Test coverage**: Added `test_migration_runner.py` to verify no bind parameters exist in the migration file and that PL/pgSQL blocks remain intact after splitting

## Implementation Details

- The migration file is now the single source of truth; the Python script only creates the owner account and sets the naming configuration
- All constraint and index operations use `IF NOT EXISTS` patterns or check the PostgreSQL catalog before acting
- Password hashes are validated to match the application's `pbkdf2_sha256` format before account creation
- Username validation enforces the same rules as the login form (3-32 chars, lowercase alphanumeric + dot/dash/underscore)
- Each statement runs in its own transaction to prevent cascading rollbacks
- The migration gracefully handles re-runs by detecting when all rows already have owners and skipping unnecessary work

https://claude.ai/code/session_01KxK3Fx5KchUMQ9qcT6z24P